### PR TITLE
Enable CI on Travis with detailed logs. Refs #47.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,40 @@
+language: haskell
+
+ghc:
+  - "8.8.4"
+
+env:
+  - PATH=${HOME}/.cabal/bin:${PATH}
+
+before_install:
+  - travis_retry sudo apt-get update
+
+install:
+  - travis_retry cabal install alex happy
+  - travis_retry cabal install --enable-tests --only-dependencies ogma-**/
+
+script:
+  # We want to document the build process, and  get detailed information if
+  # there is a problem (or if all goes well). We therefore execute the
+  # installation with -j1.
+  #
+  # Some tests need the ogma executable to be in the path, which won't happen
+  # until installation completes successfully (which only happens after tests
+  # if running tests is enabled). We therefore need to run the installation
+  # twice: once without --run-tests, and again with --run-tests.
+  #
+  # We still --enable-tests in the first compilation to make sure that the
+  # dependencies do not change and cabal does not change the installation plan
+  # (which would mean we'd be running the tests with a version of ogma compiled
+  # with different dependencies).
+  - cabal install --enable-tests -j1 ogma-**/
+  - cabal install --run-tests -j1 ogma-**/
+
+after_script:
+
+branches:
+    only:
+          - master
+          - /^develop.*$/
+          - /^hotfix.*$/
+          - /^release.*$/

--- a/ogma-cli/CHANGELOG.md
+++ b/ogma-cli/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Revision history for ogma-cli
 
-## [Upcoming] - 2022-05-17
+## [Upcoming] - 2022-05-21
 
+* Enable CI (#47).
 * Conformance with style guide (partial) (#45).
 
 ## [1.0.2] - 2022-03-21


### PR DESCRIPTION
This PR includes a Travis script that builds Ogma, producing detailed logs, and running the rests. We pick GHC 8.8 as the version to build with, because it's not too modern or too old.