### PR TITLE
Adapt Ogma to work with GHC 9.2. Refs #55.

### DIFF
--- a/ogma-cli/CHANGELOG.md
+++ b/ogma-cli/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Revision history for ogma-cli
 
+## [1.0.X] - 2022-09-01
+
+* Update README to reflect that GHC 9.2 is supported (#55).
+
 ## [1.0.4] - 2022-07-21
 
 * Version bump 1.0.4 (#53).

--- a/ogma-cli/README.md
+++ b/ogma-cli/README.md
@@ -54,7 +54,7 @@ verification framework that generates hard real-time C99 code.
 
 To install Ogma from source, users must have the tools GHC and cabal-install.
 At this time, we recommend GHC 8.6 and a version of cabal-install between 2.4
-and 3.2. (Ogma has been tested with GHC versions up to 8.10 and cabal-install
+and 3.2. (Ogma has been tested with GHC versions up to 9.2 and cabal-install
 versions up to 3.6, although the installation steps may vary slightly depending
 on the version of cabal-install being used.)
 

--- a/ogma-core/CHANGELOG.md
+++ b/ogma-core/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Revision history for ogma-core
 
+## [1.0.X] - 2022-09-01
+
+* Bump version bounds of Aeson (#55).
+
 ## [1.0.4] - 2022-07-21
 
 * Version bump 1.0.4 (#53).

--- a/ogma-core/ogma-core.cabal
+++ b/ogma-core/ogma-core.cabal
@@ -89,7 +89,7 @@ library
 
   build-depends:
       base                    >= 4.11.0.0 && < 5
-    , aeson                   < 2
+    , aeson                   >= 2.0.0.0  && < 2.2
     , filepath
     , IfElse
 

--- a/ogma-language-fret-cs/CHANGELOG.md
+++ b/ogma-language-fret-cs/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Revision history for ogma-language-fret-cs
 
+## [1.0.X] - 2022-09-01
+
+* Bump version bounds of Aeson; adjust code to work with Aeson 2 (#55).
+
 ## [1.0.4] - 2022-07-21
 
 * Version bump 1.0.4 (#53).

--- a/ogma-language-fret-cs/ogma-language-fret-cs.cabal
+++ b/ogma-language-fret-cs/ogma-language-fret-cs.cabal
@@ -60,8 +60,6 @@ library
   build-depends:
       base                   >= 4.11.0.0 && < 5
     , aeson                  >= 2.0.0.0  && < 2.2
-    , text
-    , unordered-containers
 
     , ogma-language-cocospec >= 1.0.0 && < 1.1
     , ogma-language-smv      >= 1.0.0 && < 1.1

--- a/ogma-language-fret-cs/ogma-language-fret-cs.cabal
+++ b/ogma-language-fret-cs/ogma-language-fret-cs.cabal
@@ -59,7 +59,7 @@ library
 
   build-depends:
       base                   >= 4.11.0.0 && < 5
-    , aeson                  < 2
+    , aeson                  >= 2.0.0.0  && < 2.2
     , text
     , unordered-containers
 
@@ -85,7 +85,7 @@ test-suite unit-tests
   build-depends:
       base                       >= 4.11.0.0 && < 5
 
-    , aeson                      < 2
+    , aeson                      >= 2.0.0.0  && < 2.2
     , QuickCheck
     , test-framework
     , test-framework-quickcheck2

--- a/ogma-language-fret-cs/src/Language/FRETComponentSpec/AST.hs
+++ b/ogma-language-fret-cs/src/Language/FRETComponentSpec/AST.hs
@@ -41,8 +41,8 @@ module Language.FRETComponentSpec.AST where
 -- External imports
 import           Data.Aeson          ( FromJSON (..), Value (Object), (.:) )
 import           Data.Aeson.Types    ( prependFailure, typeMismatch )
-import qualified Data.HashMap.Strict as M
-import qualified Data.Text           as T
+import           Data.Aeson.Key      ( toString )
+import qualified Data.Aeson.KeyMap   as M
 
 -- Internal imports
 import qualified Language.CoCoSpec.AbsCoCoSpec as CoCoSpec
@@ -65,7 +65,7 @@ data FRETComponentSpec = FRETComponentSpec
 instance FromJSON FRETComponentSpec where
   parseJSON (Object v)
       | (specName, Object specValues) <- head (M.toList v)
-      = FRETComponentSpec (T.unpack specName)
+      = FRETComponentSpec (toString specName)
       <$> specValues .: "Internal_variables"
       <*> specValues .: "Other_variables"
       <*> specValues .: "Requirements"

--- a/ogma-language-fret-reqs/CHANGELOG.md
+++ b/ogma-language-fret-reqs/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Revision history for ogma-language-fret-reqs
 
+## [1.0.X] - 2022-09-01
+
+* Bump version bounds of Aeson (#55).
+
 ## [1.0.4] - 2022-07-21
 
 * Version bump 1.0.4 (#53).

--- a/ogma-language-fret-reqs/ogma-language-fret-reqs.cabal
+++ b/ogma-language-fret-reqs/ogma-language-fret-reqs.cabal
@@ -59,7 +59,7 @@ library
 
   build-depends:
       base                   >= 4.11.0.0 && < 5
-    , aeson                  < 2
+    , aeson                  >= 2.0.0.0  && < 2.2
     , text
 
     , ogma-language-cocospec >= 1.0.0 && < 1.1
@@ -84,7 +84,7 @@ test-suite unit-tests
   build-depends:
       base                       >= 4.11.0.0 && < 5
 
-    , aeson                      < 2
+    , aeson                      >= 2.0.0.0  && < 2.2
     , QuickCheck
     , test-framework
     , test-framework-quickcheck2


### PR DESCRIPTION
Adapt the cabal files and the code to work with GHC 9.2, as prescribed in the solution proposed for #55.