### PR TITLE
Support floating point numbers in SMV expressions. Refs #58.

### DIFF
--- a/ogma-core/CHANGELOG.md
+++ b/ogma-core/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Revision history for ogma-core
 
-## [1.0.X] - 2022-09-01
+## [1.0.X] - 2022-09-21
 
 * Bump version bounds of Aeson (#55).
+* Support floating point numbers in SMV expressions (#58).
 
 ## [1.0.4] - 2022-07-21
 

--- a/ogma-core/src/Language/Trans/SMV2Copilot.hs
+++ b/ogma-core/src/Language/Trans/SMV2Copilot.hs
@@ -106,7 +106,8 @@ const2Copilot BoolConstLAST  = "last"
 -- | Return the Copilot representation of a numeric expression.
 numExpr2Copilot :: NumExpr -> String
 numExpr2Copilot (NumId i)        = ident2Copilot i
-numExpr2Copilot (NumConst i)     = show i
+numExpr2Copilot (NumConstI i)    = show i
+numExpr2Copilot (NumConstD i)    = show i
 numExpr2Copilot (NumAdd x op y)  = "("
                                    ++ numExpr2Copilot x
                                    ++ additiveOp2Copilot op
@@ -209,6 +210,7 @@ boolSpecNames b = case b of
 numExprNames :: NumExpr -> [String]
 numExprNames numExpr = case numExpr of
   NumId (Ident i)         -> [i]
-  NumConst _c             -> []
+  NumConstI _c            -> []
+  NumConstD _c            -> []
   NumAdd expr1 _op expr2  -> numExprNames expr1 ++ numExprNames expr2
   NumMult expr1 _op expr2 -> numExprNames expr1 ++ numExprNames expr2

--- a/ogma-language-fret-cs/CHANGELOG.md
+++ b/ogma-language-fret-cs/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Revision history for ogma-language-fret-cs
 
-## [1.0.X] - 2022-09-01
+## [1.0.X] - 2022-09-21
 
 * Bump version bounds of Aeson; adjust code to work with Aeson 2 (#55).
+* Support floating point numbers in SMV expressions (#58).
 
 ## [1.0.4] - 2022-07-21
 

--- a/ogma-language-fret-cs/src/Language/FRETComponentSpec/AST.hs
+++ b/ogma-language-fret-cs/src/Language/FRETComponentSpec/AST.hs
@@ -221,7 +221,8 @@ applySubstitution sub file =
     mapNumExprIdent f numExpr =
       case numExpr of
         SMV.NumId (SMV.Ident i)    -> SMV.NumId (SMV.Ident (f i))
-        SMV.NumConst c             -> SMV.NumConst c
+        SMV.NumConstI c            -> SMV.NumConstI c
+        SMV.NumConstD c            -> SMV.NumConstD c
         SMV.NumAdd expr1 op expr2  -> SMV.NumAdd
                                             (mapNumExprIdent f expr1)
                                             op

--- a/ogma-language-smv/CHANGELOG.md
+++ b/ogma-language-smv/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Revision history for ogma-language-smv
 
+## [1.0.X] - 2022-09-21
+* Support floating point numbers in SMV expressions (#58).
+
 ## [1.0.4] - 2022-07-21
 
 * Version bump 1.0.4 (#53).

--- a/ogma-language-smv/grammar/SMV.cf
+++ b/ogma-language-smv/grammar/SMV.cf
@@ -62,10 +62,11 @@ _ . BoolSpec2 ::= BoolSpec3 ;
 _ . BoolSpec1 ::= BoolSpec2 ;
 _ . BoolSpec  ::= BoolSpec1 ;
 
-NumId    . NumExpr2 ::= Ident ;
-NumConst . NumExpr2 ::= Integer ;
-NumAdd   . NumExpr1 ::= NumExpr1 AdditiveOp NumExpr2;
-NumMult  . NumExpr  ::= NumExpr MultOp NumExpr1;
+NumId     . NumExpr2 ::= Ident ;
+NumConstI . NumExpr2 ::= Integer ;
+NumConstD . NumExpr2 ::= Double;
+NumAdd    . NumExpr1 ::= NumExpr1 AdditiveOp NumExpr2;
+NumMult   . NumExpr  ::= NumExpr MultOp NumExpr1;
 
 _ . NumExpr2 ::= "(" NumExpr ")" ;
 _ . NumExpr1 ::= NumExpr2 ;


### PR DESCRIPTION
Support floating point numbers in SMV expressions, as prescribed in the solution proposed for #58.