### PR TITLE
Update licenses in cabal files to `OtherLicense`. Refs #62.

### DIFF
--- a/ogma-cli/CHANGELOG.md
+++ b/ogma-cli/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Revision history for ogma-cli
 
+## [1.0.X] - 2022-11-18
+
+* Update license in cabal file to OtherLicense (#62).
+
 ## [1.0.5] - 2022-09-21
 
 * Version bump 1.0.5 (#60).

--- a/ogma-cli/ogma-cli.cabal
+++ b/ogma-cli/ogma-cli.cabal
@@ -34,7 +34,7 @@ build-type:          Simple
 name:                ogma-cli
 version:             1.0.5
 homepage:            http://nasa.gov
-license:             AllRightsReserved
+license:             OtherLicense
 license-file:        LICENSE.pdf
 author:              Ivan Perez, Alwyn Goodloe
 maintainer:          ivan.perezdominguez@nasa.gov

--- a/ogma-core/CHANGELOG.md
+++ b/ogma-core/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Revision history for ogma-core
 
+## [1.0.X] - 2022-11-18
+
+* Update license in cabal file to OtherLicense (#62).
+
 ## [1.0.5] - 2022-09-21
 
 * Version bump 1.0.5 (#60).

--- a/ogma-core/ogma-core.cabal
+++ b/ogma-core/ogma-core.cabal
@@ -34,7 +34,7 @@ build-type:          Simple
 name:                ogma-core
 version:             1.0.5
 homepage:            http://nasa.gov
-license:             AllRightsReserved
+license:             OtherLicense
 license-file:        LICENSE.pdf
 author:              Ivan Perez, Alwyn Goodloe
 maintainer:          ivan.perezdominguez@nasa.gov

--- a/ogma-extra/CHANGELOG.md
+++ b/ogma-extra/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Revision history for ogma-extra
 
+## [1.0.X] - 2022-11-18
+
+* Update license in cabal file to OtherLicense (#62).
+
 ## [1.0.5] - 2022-09-21
 
 * Version bump 1.0.5 (#60).

--- a/ogma-extra/ogma-extra.cabal
+++ b/ogma-extra/ogma-extra.cabal
@@ -34,7 +34,7 @@ build-type:          Simple
 name:                ogma-extra
 version:             1.0.5
 homepage:            http://nasa.gov
-license:             AllRightsReserved
+license:             OtherLicense
 license-file:        LICENSE.pdf
 author:              Ivan Perez, Alwyn Goodloe
 maintainer:          ivan.perezdominguez@nasa.gov

--- a/ogma-language-c/CHANGELOG.md
+++ b/ogma-language-c/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Revision history for ogma-language-c
 
+## [1.0.X] - 2022-11-18
+
+* Update license in cabal file to OtherLicense (#62).
+
 ## [1.0.5] - 2022-09-21
 
 * Version bump 1.0.5 (#60).

--- a/ogma-language-c/ogma-language-c.cabal
+++ b/ogma-language-c/ogma-language-c.cabal
@@ -34,7 +34,7 @@ build-type:          Custom
 name:                ogma-language-c
 version:             1.0.5
 homepage:            http://nasa.gov
-license:             AllRightsReserved
+license:             OtherLicense
 license-file:        LICENSE.pdf
 author:              Ivan Perez, Alwyn Goodloe
 maintainer:          ivan.perezdominguez@nasa.gov

--- a/ogma-language-cocospec/CHANGELOG.md
+++ b/ogma-language-cocospec/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Revision history for ogma-language-cocospec
 
+## [1.0.X] - 2022-11-18
+
+* Update license in cabal file to OtherLicense (#62).
+
 ## [1.0.5] - 2022-09-21
 
 * Version bump 1.0.5 (#60).

--- a/ogma-language-cocospec/ogma-language-cocospec.cabal
+++ b/ogma-language-cocospec/ogma-language-cocospec.cabal
@@ -34,7 +34,7 @@ build-type:          Custom
 name:                ogma-language-cocospec
 version:             1.0.5
 homepage:            http://nasa.gov
-license:             AllRightsReserved
+license:             OtherLicense
 license-file:        LICENSE.pdf
 author:              Ivan Perez, Alwyn Goodloe
 maintainer:          ivan.perezdominguez@nasa.gov

--- a/ogma-language-copilot/CHANGELOG.md
+++ b/ogma-language-copilot/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Revision history for ogma-language-copilot
 
+## [1.0.X] - 2022-11-18
+
+* Update license in cabal file to OtherLicense (#62).
+
 ## [1.0.5] - 2022-09-21
 
 * Version bump 1.0.5 (#60).

--- a/ogma-language-copilot/ogma-language-copilot.cabal
+++ b/ogma-language-copilot/ogma-language-copilot.cabal
@@ -34,7 +34,7 @@ build-type:          Simple
 name:                ogma-language-copilot
 version:             1.0.5
 homepage:            http://nasa.gov
-license:             AllRightsReserved
+license:             OtherLicense
 license-file:        LICENSE.pdf
 author:              Ivan Perez, Alwyn Goodloe
 maintainer:          ivan.perezdominguez@nasa.gov

--- a/ogma-language-fret-cs/CHANGELOG.md
+++ b/ogma-language-fret-cs/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Revision history for ogma-language-fret-cs
 
+## [1.0.X] - 2022-11-18
+
+* Update license in cabal file to OtherLicense (#62).
+
 ## [1.0.5] - 2022-09-21
 
 * Version bump 1.0.5 (#60).

--- a/ogma-language-fret-cs/ogma-language-fret-cs.cabal
+++ b/ogma-language-fret-cs/ogma-language-fret-cs.cabal
@@ -34,7 +34,7 @@ build-type:          Simple
 name:                ogma-language-fret-cs
 version:             1.0.5
 homepage:            http://nasa.gov
-license:             AllRightsReserved
+license:             OtherLicense
 license-file:        LICENSE.pdf
 author:              Ivan Perez, Alwyn Goodloe
 maintainer:          ivan.perezdominguez@nasa.gov

--- a/ogma-language-fret-reqs/CHANGELOG.md
+++ b/ogma-language-fret-reqs/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Revision history for ogma-language-fret-reqs
 
+## [1.0.X] - 2022-11-18
+
+* Update license in cabal file to OtherLicense (#62).
+
 ## [1.0.5] - 2022-09-21
 
 * Version bump 1.0.5 (#60).

--- a/ogma-language-fret-reqs/ogma-language-fret-reqs.cabal
+++ b/ogma-language-fret-reqs/ogma-language-fret-reqs.cabal
@@ -34,7 +34,7 @@ build-type:          Simple
 name:                ogma-language-fret-reqs
 version:             1.0.5
 homepage:            http://nasa.gov
-license:             AllRightsReserved
+license:             OtherLicense
 license-file:        LICENSE.pdf
 author:              Ivan Perez, Alwyn Goodloe
 maintainer:          ivan.perezdominguez@nasa.gov

--- a/ogma-language-smv/CHANGELOG.md
+++ b/ogma-language-smv/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Revision history for ogma-language-smv
 
+## [1.0.X] - 2022-11-18
+
+* Update license in cabal file to OtherLicense (#62).
+
 ## [1.0.5] - 2022-09-21
 
 * Version bump 1.0.5 (#60).

--- a/ogma-language-smv/ogma-language-smv.cabal
+++ b/ogma-language-smv/ogma-language-smv.cabal
@@ -34,7 +34,7 @@ build-type:          Custom
 name:                ogma-language-smv
 version:             1.0.5
 homepage:            http://nasa.gov
-license:             AllRightsReserved
+license:             OtherLicense
 license-file:        LICENSE.pdf
 author:              Ivan Perez, Alwyn Goodloe
 maintainer:          ivan.perezdominguez@nasa.gov


### PR DESCRIPTION
Updates all the licenses in the cabal files to `OtherLicense`, so that the packages can be accepted in hackage, as prescribed in the solution proposed for #62.