### PR TITLE
Add `src/.keep` files to `extra-source-files` in cabal files. Refs #65.

### DIFF
--- a/ogma-language-c/CHANGELOG.md
+++ b/ogma-language-c/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Revision history for ogma-language-c
 
-## [1.0.X] - 2022-11-18
+## [1.0.X] - 2022-11-21
 
 * Update license in cabal file to OtherLicense (#62).
+* Add empty file to keep directory structure in distributable package (#65).
 
 ## [1.0.5] - 2022-09-21
 

--- a/ogma-language-c/ogma-language-c.cabal
+++ b/ogma-language-c/ogma-language-c.cabal
@@ -41,6 +41,7 @@ maintainer:          ivan.perezdominguez@nasa.gov
 category:            Aerospace
 extra-source-files:  CHANGELOG.md
                      grammar/C.cf
+                     src/.keep
                      tests/reduced_geofence_msgs.h
                      tests/reduced_geofence_msgs_bad.h
 

--- a/ogma-language-cocospec/CHANGELOG.md
+++ b/ogma-language-cocospec/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Revision history for ogma-language-cocospec
 
-## [1.0.X] - 2022-11-18
+## [1.0.X] - 2022-11-21
 
 * Update license in cabal file to OtherLicense (#62).
+* Add empty file to keep directory structure in distributable package (#65).
 
 ## [1.0.5] - 2022-09-21
 

--- a/ogma-language-cocospec/ogma-language-cocospec.cabal
+++ b/ogma-language-cocospec/ogma-language-cocospec.cabal
@@ -41,6 +41,7 @@ maintainer:          ivan.perezdominguez@nasa.gov
 category:            Aerospace
 extra-source-files:  CHANGELOG.md
                      grammar/CoCoSpec.cf
+                     src/.keep
                      tests/cocospec_good
                      tests/cocospec_bad
 

--- a/ogma-language-smv/CHANGELOG.md
+++ b/ogma-language-smv/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Revision history for ogma-language-smv
 
-## [1.0.X] - 2022-11-18
+## [1.0.X] - 2022-11-21
 
 * Update license in cabal file to OtherLicense (#62).
+* Add empty file to keep directory structure in distributable package (#65).
 
 ## [1.0.5] - 2022-09-21
 

--- a/ogma-language-smv/ogma-language-smv.cabal
+++ b/ogma-language-smv/ogma-language-smv.cabal
@@ -41,6 +41,7 @@ maintainer:          ivan.perezdominguez@nasa.gov
 category:            Aerospace
 extra-source-files:  CHANGELOG.md
                      grammar/SMV.cf
+                     src/.keep
                      tests/smv_good
                      tests/smv_bad
 


### PR DESCRIPTION
Update `extra-source-files` in the cabal files of language libraries composed of auto-generated files only to include the `src` directory, so that the packages can be accepted in hackage, as prescribed in the solution proposed for #65 .