### PR TITLE
Support inequality operator in TL formulas in SMV and CoCoSpec. Refs #71.

### DIFF
--- a/ogma-core/CHANGELOG.md
+++ b/ogma-core/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Revision history for ogma-core
 
+## [1.X.Y] - 2023-02-01
+
+* Support inequality operator in SMV and CoCoSpec (#71).
+
 ## [1.0.7] - 2023-01-21
 * Version bump 1.0.7 (#69).
 * Introduce new ROS2 backend (#56).

--- a/ogma-core/src/Language/Trans/CoCoSpec2Copilot.hs
+++ b/ogma-core/src/Language/Trans/CoCoSpec2Copilot.hs
@@ -113,6 +113,7 @@ numOpTwoIn2Copilot NumOp2Mult  = "*"
 -- operator.
 opTwoNum2Copilot :: BoolNumOp -> String
 opTwoNum2Copilot BoolNumOp2Eq = "=="
+opTwoNum2Copilot BoolNumOp2Ne = "/="
 opTwoNum2Copilot BoolNumOp2Le = "<="
 opTwoNum2Copilot BoolNumOp2Lt = "<"
 opTwoNum2Copilot BoolNumOp2Gt = ">="

--- a/ogma-core/src/Language/Trans/FRETComponentSpec2Copilot.hs
+++ b/ogma-core/src/Language/Trans/FRETComponentSpec2Copilot.hs
@@ -107,7 +107,7 @@ fretComponentSpec2Copilot' prefs fretComponentSpec =
       , "import qualified Copilot.Library.MTL       as MTL"
       , "import           Language.Copilot          (reify)"
       , "import           Prelude                   hiding ((&&), (||), (++),"
-        ++ " (<=), (>=), (<), (>), (==), not)"
+        ++ " (<=), (>=), (<), (>), (==), (/=), not)"
       , ""
       ]
 

--- a/ogma-core/src/Language/Trans/FRETReqsDB2Copilot.hs
+++ b/ogma-core/src/Language/Trans/FRETReqsDB2Copilot.hs
@@ -111,7 +111,7 @@ fret2CopilotModule' prefs smvSpec cocoSpec = unlines $ concat sections
       , "import qualified Copilot.Library.PTLTL     as PTLTL"
       , "import           Language.Copilot          (reify)"
       , "import Prelude                   hiding ((&&), (||), (++), (<=), (>=),"
-        ++ " (<), (>), (==), not)"
+        ++ " (<), (>), (==), (/=), not)"
       , ""
       ]
 

--- a/ogma-core/src/Language/Trans/SMV2Copilot.hs
+++ b/ogma-core/src/Language/Trans/SMV2Copilot.hs
@@ -134,6 +134,7 @@ ordOp2Copilot :: OrdOp -> String
 ordOp2Copilot OrdOpLT = "<"
 ordOp2Copilot OrdOpLE = "<="
 ordOp2Copilot OrdOpEQ = "=="
+ordOp2Copilot OrdOpNE = "/="
 ordOp2Copilot OrdOpGT = ">"
 ordOp2Copilot OrdOpGE = ">="
 

--- a/ogma-language-cocospec/CHANGELOG.md
+++ b/ogma-language-cocospec/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Revision history for ogma-language-cocospec
 
+## [1.X.Y] - 2023-02-01
+
+* Support inequality operator (#71).
+
 ## [1.0.7] - 2023-01-21
 * Version bump 1.0.7 (#69).
 * Specify upper bound constraint for Cabal. Refs #69.

--- a/ogma-language-cocospec/grammar/CoCoSpec.cf
+++ b/ogma-language-cocospec/grammar/CoCoSpec.cf
@@ -81,6 +81,7 @@ NumOp2Minus. NumOp2In ::= "-" ;
 NumOp2Mult . NumOp2In ::= "*" ;
 
 BoolNumOp2Eq . BoolNumOp ::= "=" ;
+BoolNumOp2Ne . BoolNumOp ::= "<>" ;
 BoolNumOp2Le . BoolNumOp ::= "<=" ;
 BoolNumOp2Lt . BoolNumOp ::= "<" ;
 BoolNumOp2Gt . BoolNumOp ::= ">" ;

--- a/ogma-language-smv/CHANGELOG.md
+++ b/ogma-language-smv/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Revision history for ogma-language-smv
 
+## [1.X.Y] - 2023-02-01
+
+* Support inequality operator (#71).
+
 ## [1.0.7] - 2023-01-21
 * Version bump 1.0.7 (#69).
 * Specify upper bound constraint for Cabal. Refs #69.

--- a/ogma-language-smv/grammar/SMV.cf
+++ b/ogma-language-smv/grammar/SMV.cf
@@ -93,6 +93,7 @@ _ . Number ::= "<i>" Number "</i>";
 OrdOpLT . OrdOp ::= "<";
 OrdOpLE . OrdOp ::= "<=";
 OrdOpEQ . OrdOp ::= "=";
+OrdOpNE . OrdOp ::= "!=";
 OrdOpGT . OrdOp ::= ">";
 OrdOpGE . OrdOp ::= ">=";
 


### PR DESCRIPTION
Add the inequality operator in the grammars of SMV and CoCoSpec, and add the appropriate translation in `ogma-core`, as prescribed in the solution proposed for #71.