### PR TITLE
Prevent modifications by people outside the project. Refs #74.

### DIFF
--- a/ogma-cli/CHANGELOG.md
+++ b/ogma-cli/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [1.X.Y] - 2023-03-21
 
 * Introduce new F' (FPrime) backend (#77).
+* Mark package as uncurated (#74).
 
 ## [1.0.7] - 2023-01-21
 * Version bump 1.0.7 (#69).

--- a/ogma-cli/ogma-cli.cabal
+++ b/ogma-cli/ogma-cli.cabal
@@ -109,6 +109,13 @@ description:         Ogma is a tool to facilitate the integration of safe runtim
                      .
                      - <https://shemesh.larc.nasa.gov/people/cam/publications/FMAS2020_3.pdf "From Requirements to Autonomous Flight">, Dutle et al. 2020.
 
+-- Ogma packages should be uncurated so that only the official maintainers make
+-- changes.
+--
+-- Because this is a NASA project, we want to make sure that users obtain
+-- exactly what we publish, unmodified by anyone external to our project.
+x-curation: uncurated
+
 executable ogma
 
   main-is:

--- a/ogma-core/CHANGELOG.md
+++ b/ogma-core/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Support inequality operator in SMV and CoCoSpec (#71).
 * Introduce new F' (FPrime) backend (#77).
+* Mark package as uncurated (#74).
 
 ## [1.0.7] - 2023-01-21
 * Version bump 1.0.7 (#69).

--- a/ogma-core/ogma-core.cabal
+++ b/ogma-core/ogma-core.cabal
@@ -66,6 +66,14 @@ data-files:          templates/copilot-cfs/CMakeLists.txt
                      templates/fprime/CMakeLists.txt
                      templates/fprime/Dockerfile
                      templates/fprime/instance-copilot
+
+-- Ogma packages should be uncurated so that only the official maintainers make
+-- changes.
+--
+-- Because this is a NASA project, we want to make sure that users obtain
+-- exactly what we publish, unmodified by anyone external to our project.
+x-curation: uncurated
+
 library
 
   exposed-modules:

--- a/ogma-extra/CHANGELOG.md
+++ b/ogma-extra/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Revision history for ogma-extra
 
+## [1.X.Y] - 2023-03-21
+
+* Mark package as uncurated (#74).
+
 ## [1.0.7] - 2023-01-21
 * Version bump 1.0.7 (#69).
 

--- a/ogma-extra/ogma-extra.cabal
+++ b/ogma-extra/ogma-extra.cabal
@@ -52,6 +52,13 @@ description:         Ogma is a tool to facilitate the integration of safe runtim
                      and modules that are used in several ogma packages and their
                      testing facilities.
 
+-- Ogma packages should be uncurated so that only the official maintainers make
+-- changes.
+--
+-- Because this is a NASA project, we want to make sure that users obtain
+-- exactly what we publish, unmodified by anyone external to our project.
+x-curation: uncurated
+
 library
 
   exposed-modules:

--- a/ogma-language-c/CHANGELOG.md
+++ b/ogma-language-c/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Revision history for ogma-language-c
 
+## [1.X.Y] - 2023-03-21
+
+* Mark package as uncurated (#74).
+
 ## [1.0.7] - 2023-01-21
 * Version bump 1.0.7 (#69).
 * Specify upper bound constraint for Cabal. Refs #69.

--- a/ogma-language-c/ogma-language-c.cabal
+++ b/ogma-language-c/ogma-language-c.cabal
@@ -54,6 +54,13 @@ description:         Ogma is a tool to facilitate the integration of safe runtim
                      .
                      This library contains a frontend to read C header files.
 
+-- Ogma packages should be uncurated so that only the official maintainers make
+-- changes.
+--
+-- Because this is a NASA project, we want to make sure that users obtain
+-- exactly what we publish, unmodified by anyone external to our project.
+x-curation: uncurated
+
 custom-setup
   setup-depends:
       base    >= 4.11.0.0 && < 5

--- a/ogma-language-cocospec/CHANGELOG.md
+++ b/ogma-language-cocospec/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Revision history for ogma-language-cocospec
 
-## [1.X.Y] - 2023-02-01
+## [1.X.Y] - 2023-03-21
 
 * Support inequality operator (#71).
+* Mark package as uncurated (#74).
 
 ## [1.0.7] - 2023-01-21
 * Version bump 1.0.7 (#69).

--- a/ogma-language-cocospec/ogma-language-cocospec.cabal
+++ b/ogma-language-cocospec/ogma-language-cocospec.cabal
@@ -55,6 +55,13 @@ description:         Ogma is a tool to facilitate the integration of safe runtim
                      This library contains a frontend to read CoCoSpec Boolean expressions, used by
                      the tool FRET to capture requirement specifications.
 
+-- Ogma packages should be uncurated so that only the official maintainers make
+-- changes.
+--
+-- Because this is a NASA project, we want to make sure that users obtain
+-- exactly what we publish, unmodified by anyone external to our project.
+x-curation: uncurated
+
 custom-setup
   setup-depends:
       base    >= 4.11.0.0 && < 5

--- a/ogma-language-copilot/CHANGELOG.md
+++ b/ogma-language-copilot/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Revision history for ogma-language-copilot
 
+## [1.X.Y] - 2023-03-21
+
+* Mark package as uncurated (#74).
+
 ## [1.0.7] - 2023-01-21
 * Version bump 1.0.7 (#69).
 

--- a/ogma-language-copilot/ogma-language-copilot.cabal
+++ b/ogma-language-copilot/ogma-language-copilot.cabal
@@ -51,6 +51,13 @@ description:         Ogma is a tool to facilitate the integration of safe runtim
                      This library contains a frontend to read Copilot monitors, a definition of Copilot
                      structs, and a backend to generate and pretty print Copilot code.
 
+-- Ogma packages should be uncurated so that only the official maintainers make
+-- changes.
+--
+-- Because this is a NASA project, we want to make sure that users obtain
+-- exactly what we publish, unmodified by anyone external to our project.
+x-curation: uncurated
+
 library
 
   exposed-modules:

--- a/ogma-language-fret-cs/CHANGELOG.md
+++ b/ogma-language-fret-cs/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Revision history for ogma-language-fret-cs
 
+## [1.X.Y] - 2023-03-21
+
+* Mark package as uncurated (#74).
+
 ## [1.0.7] - 2023-01-21
 * Version bump 1.0.7 (#69).
 

--- a/ogma-language-fret-cs/ogma-language-fret-cs.cabal
+++ b/ogma-language-fret-cs/ogma-language-fret-cs.cabal
@@ -52,6 +52,13 @@ description:         Ogma is a tool to facilitate the integration of safe runtim
                      .
                      This library contains a frontend to read FRET Component Specifications.
 
+-- Ogma packages should be uncurated so that only the official maintainers make
+-- changes.
+--
+-- Because this is a NASA project, we want to make sure that users obtain
+-- exactly what we publish, unmodified by anyone external to our project.
+x-curation: uncurated
+
 library
 
   exposed-modules:

--- a/ogma-language-fret-reqs/CHANGELOG.md
+++ b/ogma-language-fret-reqs/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Revision history for ogma-language-fret-reqs
 
+## [1.X.Y] - 2023-03-21
+
+* Mark package as uncurated (#74).
+
 ## [1.0.7] - 2023-01-21
 * Version bump 1.0.7 (#69).
 

--- a/ogma-language-fret-reqs/ogma-language-fret-reqs.cabal
+++ b/ogma-language-fret-reqs/ogma-language-fret-reqs.cabal
@@ -52,6 +52,13 @@ description:         Ogma is a tool to facilitate the integration of safe runtim
                      .
                      This library contains a frontend to read FRET Component Requirement Databases.
 
+-- Ogma packages should be uncurated so that only the official maintainers make
+-- changes.
+--
+-- Because this is a NASA project, we want to make sure that users obtain
+-- exactly what we publish, unmodified by anyone external to our project.
+x-curation: uncurated
+
 library
 
   exposed-modules:

--- a/ogma-language-smv/CHANGELOG.md
+++ b/ogma-language-smv/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Revision history for ogma-language-smv
 
-## [1.X.Y] - 2023-02-01
+## [1.X.Y] - 2023-03-21
 
 * Support inequality operator (#71).
+* Mark package as uncurated (#74).
 
 ## [1.0.7] - 2023-01-21
 * Version bump 1.0.7 (#69).

--- a/ogma-language-smv/ogma-language-smv.cabal
+++ b/ogma-language-smv/ogma-language-smv.cabal
@@ -55,6 +55,13 @@ description:         Ogma is a tool to facilitate the integration of safe runtim
                      This library contains a frontend to read SMV Boolean expressions, used by
                      the tool FRET to capture requirement specifications.
 
+-- Ogma packages should be uncurated so that only the official maintainers make
+-- changes.
+--
+-- Because this is a NASA project, we want to make sure that users obtain
+-- exactly what we publish, unmodified by anyone external to our project.
+x-curation: uncurated
+
 custom-setup
   setup-depends:
       base    >= 4.11.0.0 && < 5


### PR DESCRIPTION
Mark packages as uncurated to prevent modifications to packages published on hackage, by people outside of the development team (e.g., Hackage maintainers), as prescribed in the solution proposed for #74.