### PR TITLE
`ogma-cli`: Replace all occurrences of ROS2 with ROS 2. Refs #83.

### DIFF
--- a/ogma-cli/CHANGELOG.md
+++ b/ogma-cli/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Revision history for ogma-cli
 
+## [1.X.Y] - 2023-03-23
+
+* Rename ROS2 to ROS 2 (#83).
+
 ## [1.0.8] - 2023-03-21
 
 * Version bump 1.0.8 (#81).

--- a/ogma-cli/README.md
+++ b/ogma-cli/README.md
@@ -117,7 +117,7 @@ Available commands:
                            Specification
   fret-reqs-db             Generate a Copilot file from a FRET Requirements
                            Database
-  ros                      Generate a ROS2 monitoring package
+  ros                      Generate a ROS 2 monitoring package
 ```
 
 ## Language transformations: FRET

--- a/ogma-cli/ogma-cli.cabal
+++ b/ogma-cli/ogma-cli.cabal
@@ -67,7 +67,7 @@ description:         Ogma is a tool to facilitate the integration of safe runtim
                        to a Copilot monitor.
                      .
                      - Generating
-                       <https://ros.org Robot Operating System (ROS2)>
+                       <https://ros.org Robot Operating System (ROS 2)>
                        applications that use Copilot for monitoring data
                        received from different topics.
                      .
@@ -91,7 +91,7 @@ description:         Ogma is a tool to facilitate the integration of safe runtim
                      >                           Specification
                      >  fret-reqs-db             Generate a Copilot file from a FRET Requirements
                      >                           Database
-                     >  ros                      Generate a ROS2 monitoring application
+                     >  ros                      Generate a ROS 2 monitoring application
                      .
                      For further information, see:
                      .
@@ -103,7 +103,7 @@ description:         Ogma is a tool to facilitate the integration of safe runtim
                      .
                      - <https://cfs.gsfc.nasa.gov/ The NASA Core Flight System web page>.
                      .
-                     - <https://ros.org/ The Robot Operating System (ROS2) web page>.
+                     - <https://ros.org/ The Robot Operating System (ROS 2) web page>.
                      .
                      - <https://ntrs.nasa.gov/citations/20200003164 "Copilot 3">, Perez, Dedden and Goodloe. 2020.
                      .

--- a/ogma-cli/src/CLI/CommandROSApp.hs
+++ b/ogma-cli/src/CLI/CommandROSApp.hs
@@ -81,7 +81,7 @@ command c =
 
 -- | ROS command description
 commandDesc :: String
-commandDesc = "Generate a ROS2 monitoring package"
+commandDesc = "Generate a ROS 2 monitoring package"
 
 -- | Subparser for the @ros@ command, used to generate a Robot Operating System
 -- application connected to Copilot monitors.


### PR DESCRIPTION
Replace all occurrences of ROS2 with ROS 2 in the code, package descriptions and documentation, as prescribed in the solution proposed for #83.