### PR TITLE
Support MTL operators with number ranges in SMV.

### DIFF
--- a/ogma-core/CHANGELOG.md
+++ b/ogma-core/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Revision history for ogma-core
 
+## [1.X.Y] - 2023-07-21
+
+* Support MTL operators with number ranges in SMV (#101).
+
 ## [1.0.10] - 2023-07-21
 
 * Version bump 1.0.10 (#98).

--- a/ogma-core/src/Language/Trans/FRETReqsDB2Copilot.hs
+++ b/ogma-core/src/Language/Trans/FRETReqsDB2Copilot.hs
@@ -112,6 +112,7 @@ fret2CopilotModule' prefs smvSpec cocoSpec = unlines $ concat sections
       , "import           Copilot.Library.PTLTL     (since, previous,"
         ++ " alwaysBeen)"
       , "import qualified Copilot.Library.PTLTL     as PTLTL"
+      , "import qualified Copilot.Library.MTL       as MTL"
       , "import           Language.Copilot          (reify)"
       , "import Prelude                   hiding ((&&), (||), (++), (<=), (>=),"
         ++ " (<), (>), (==), (/=), not)"

--- a/ogma-core/src/Language/Trans/SMV2Copilot.hs
+++ b/ogma-core/src/Language/Trans/SMV2Copilot.hs
@@ -142,6 +142,7 @@ ordOp2Copilot OrdOpGE = ">="
 opOne2Copilot :: OpOne -> String
 opOne2Copilot (Op1Alone x)    = opOneAlone2Copilot x
 opOne2Copilot (Op1MTL x op v) = opOneMTL2Copilot x op v
+opOne2Copilot (Op1MTLRange op mn mx) = opOneMTLRange2Copilot op mn mx
 
 -- | Return the Copilot representation of a unary logical non-MTL FRET
 -- operator.
@@ -160,6 +161,15 @@ opOneMTL2Copilot :: Op1Name -> OrdOp -> Number -> String
 opOneMTL2Copilot operator _comparison number =
   opOneMTL2Copilot' operator ++ " " ++ show (0 :: Int)
                              ++ " " ++ number2Copilot number
+                             ++ " " ++ "clock" ++ " "
+                             ++ show (1 :: Int)
+
+-- | Return the Copilot representation of a unary logical MTL FRET operator
+-- that uses an explicit range.
+opOneMTLRange2Copilot :: Op1Name -> Number -> Number -> String
+opOneMTLRange2Copilot operator mn mx =
+  opOneMTL2Copilot' operator ++ " " ++ number2Copilot mn
+                             ++ " " ++ number2Copilot mx
                              ++ " " ++ "clock" ++ " "
                              ++ show (1 :: Int)
 

--- a/ogma-language-smv/CHANGELOG.md
+++ b/ogma-language-smv/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Revision history for ogma-language-smv
 
+## [1.X.Y] - 2023-07-21
+
+* Support MTL operators with number ranges (#101).
+
 ## [1.0.10] - 2023-07-21
 
 * Version bump 1.0.10 (#98).

--- a/ogma-language-smv/grammar/SMV.cf
+++ b/ogma-language-smv/grammar/SMV.cf
@@ -83,8 +83,9 @@ BoolConstFalse. BoolConst ::= "FALSE";
 BoolConstFTP.   BoolConst ::= "FTP";
 BoolConstLAST.  BoolConst ::= "LAST";
 
-Op1Alone . OpOne ::= Op1Name;
-Op1MTL.    OpOne ::= Op1Name "[" OrdOp Number "]";
+Op1Alone .   OpOne ::= Op1Name;
+Op1MTL.      OpOne ::= Op1Name "[" OrdOp Number "]";
+Op1MTLRange. OpOne ::= Op1Name "[" Number "," Number "]";
 
 NumberInt . Number ::= Integer;
 _ . Number ::= "<b>" Number "</b>";


### PR DESCRIPTION
Support MTL operators with number ranges in SMV parser, and add the necessary translation to `ogma-core`, as prescribed in the solution proposed for #101.