### PR TITLE
`ogma-core`: Remove trailing spaces from cFS app template. Refs #108.

### DIFF
--- a/ogma-core/CHANGELOG.md
+++ b/ogma-core/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Revision history for ogma-core
 
+## [1.X.Y] - 2023-11-21
+
+* Remove trailing spaces from cFS app template (#108).
+
 ## [1.0.11] - 2023-09-21
 
 * Version bump 1.0.11 (#103).

--- a/ogma-core/templates/copilot-cfs/fsw/for_build/Makefile
+++ b/ogma-core/templates/copilot-cfs/fsw/for_build/Makefile
@@ -1,10 +1,10 @@
 ###############################################################################
-# File: CFS Application Makefile 
+# File: CFS Application Makefile
 #
 # $Id: Makefile 1.8 2009/07/09 12:25:54EDT rmcgraw Exp  $
 #
 # $Log: Makefile  $
-# Revision 1.8 2009/07/09 12:25:54EDT rmcgraw 
+# Revision 1.8 2009/07/09 12:25:54EDT rmcgraw
 # DCR8291:1 Changed CFE_MISSION_INC to CFS_MISSION_INC and added log
 #
 ###############################################################################
@@ -13,9 +13,9 @@
 #
 APPTARGET = copilot_cfs
 
-# 
+#
 # Entry Point for task
-# 
+#
 ENTRY_PT = COPILOT_CFSMain
 
 #
@@ -33,7 +33,7 @@ SOURCES = $(OBJS:.o=.c)
 ##
 ## Specify extra C Flags needed to build this subsystem
 ##
-LOCAL_COPTS = 
+LOCAL_COPTS =
 
 
 ##
@@ -49,22 +49,22 @@ EXEDIR=../exe
 ## entry like the following:
 ##  -R../tst_lib/tst_lib.elf
 ##
-SHARED_LIB_LINK = 
+SHARED_LIB_LINK =
 
 ########################################################################
-# Should not have to change below this line, except for customized 
+# Should not have to change below this line, except for customized
 # Mission and cFE directory structures
 ########################################################################
 
 #
-# Set build type to CFE_APP. This allows us to 
+# Set build type to CFE_APP. This allows us to
 # define different compiler flags for the cFE Core and Apps.
-# 
+#
 BUILD_TYPE = CFE_APP
 
-## 
+##
 ## Include all necessary cFE make rules
-## Any of these can be copied to a local file and 
+## Any of these can be copied to a local file and
 ## changed if needed.
 ##
 ##
@@ -98,13 +98,13 @@ INCLUDE_PATH = \
 -I../inc
 
 ##
-## Define the VPATH make variable. 
+## Define the VPATH make variable.
 ## This can be modified to include source from another directory.
 ## If there is no corresponding app in the cfs-apps directory, then this can be discarded, or
-## if the mission chooses to put the src in another directory such as "src", then that can be 
+## if the mission chooses to put the src in another directory such as "src", then that can be
 ## added here as well.
 ##
-VPATH = $(CFS_APP_SRC)/$(APPTARGET)/fsw/src 
+VPATH = $(CFS_APP_SRC)/$(APPTARGET)/fsw/src
 
 ##
 ## Include the common make rules for building a cFE Application

--- a/ogma-core/templates/copilot-cfs/fsw/mission_inc/copilot_cfs_perfids.h
+++ b/ogma-core/templates/copilot-cfs/fsw/mission_inc/copilot_cfs_perfids.h
@@ -2,7 +2,7 @@
 ** File:
 **   $Id: copilot_cfs_perfids.h  $
 **
-** Purpose: 
+** Purpose:
 **  Define Sample App Performance IDs
 **
 ** Notes:
@@ -12,7 +12,7 @@
 #define _copilot_cfs_perfids_h_
 
 
-#define COPILOT_CFS_PERF_ID              91 
+#define COPILOT_CFS_PERF_ID              91
 
 #endif /* _copilot_cfs_perfids_h_ */
 

--- a/ogma-core/templates/copilot-cfs/fsw/platform_inc/copilot_cfs_msgids.h
+++ b/ogma-core/templates/copilot-cfs/fsw/platform_inc/copilot_cfs_msgids.h
@@ -2,7 +2,7 @@
 ** File:
 **   $Id: copilot_cfs_msgids.h  $
 **
-** Purpose: 
+** Purpose:
 **  Define Sample App  Message IDs
 **
 ** Notes:

--- a/ogma-core/templates/copilot-cfs/fsw/src/copilot_cfs.c
+++ b/ogma-core/templates/copilot-cfs/fsw/src/copilot_cfs.c
@@ -60,7 +60,7 @@ void COPILOT_AppMain( void )
 
         /* Pend on receipt of command packet -- timeout set to 500 millisecs */
         status = CFE_SB_RcvMsg(&COPILOTMsgPtr, COPILOT_CommandPipe, 500);
-        
+
         CFE_ES_PerfLogEntry(COPILOT_CFS_PERF_ID);
 
         if (status == CFE_SUCCESS)
@@ -88,7 +88,7 @@ void COPILOT_AppInit(void)
 
     /*
     ** Register the events
-    */ 
+    */
     CFE_EVS_Register(COPILOT_EventFilters,
                      sizeof(COPILOT_EventFilters)/sizeof(CFE_EVS_BinFilter_t),
                      CFE_EVS_BINARY_FILTER);
@@ -103,10 +103,10 @@ void COPILOT_AppInit(void)
     CFE_EVS_SendEvent (COPILOT_STARTUP_INF_EID, CFE_EVS_INFORMATION,
                "COPILOT App Initialized. Version %d.%d.%d.%d",
                 COPILOT_CFS_MAJOR_VERSION,
-                COPILOT_CFS_MINOR_VERSION, 
-                COPILOT_CFS_REVISION, 
+                COPILOT_CFS_MINOR_VERSION,
+                COPILOT_CFS_REVISION,
                 COPILOT_CFS_MISSION_REV);
-				
+
 } /* End of COPILOT_AppInit() */
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * **/
@@ -147,7 +147,7 @@ void COPILOT_ProcessIcarousPosition(void)
     position_t* msg;
     msg = (position_t*) COPILOTMsgPtr;
     my_position = *msg;
-    
+
     // Run all copilot monitors.
     step();
 }

--- a/ogma-core/templates/copilot-cfs/fsw/src/copilot_cfs_events.h
+++ b/ogma-core/templates/copilot-cfs/fsw/src/copilot_cfs_events.h
@@ -1,8 +1,8 @@
 /************************************************************************
 ** File:
-**    copilot_app_events.h 
+**    copilot_app_events.h
 **
-** Purpose: 
+** Purpose:
 **  Define COPILOT App Events IDs
 **
 ** Notes:
@@ -14,11 +14,11 @@
 
 
 #define COPILOT_RESERVED_EID                0
-#define COPILOT_STARTUP_INF_EID             1 
+#define COPILOT_STARTUP_INF_EID             1
 #define COPILOT_COMMAND_ERR_EID             2
 #define COPILOT_COMMANDCPVIOL_INF_EID       3
-#define COPILOT_INVALID_MSGID_ERR_EID       4 
-#define COPILOT_LEN_ERR_EID                 5 
+#define COPILOT_INVALID_MSGID_ERR_EID       4
+#define COPILOT_LEN_ERR_EID                 5
 
 #endif /* _copilot_app_events_h_ */
 

--- a/ogma-core/templates/copilot-cfs/fsw/src/copilot_cfs_msg.h
+++ b/ogma-core/templates/copilot-cfs/fsw/src/copilot_cfs_msg.h
@@ -1,8 +1,8 @@
 /*******************************************************************************
 ** File:
-**   copilot_cfs_msg.h 
+**   copilot_cfs_msg.h
 **
-** Purpose: 
+** Purpose:
 **  Define COPILOT App  Messages and info
 **
 ** Notes:
@@ -26,7 +26,7 @@ typedef struct
 /*
 ** Type definition (COPILOT App housekeeping)
 */
-typedef struct 
+typedef struct
 {
     uint8              TlmHeader[CFE_SB_TLM_HDR_SIZE];
     uint8              copilot_command_error_count;

--- a/ogma-core/templates/copilot-cfs/fsw/src/copilot_cfs_version.h
+++ b/ogma-core/templates/copilot-cfs/fsw/src/copilot_cfs_version.h
@@ -2,7 +2,7 @@
 ** File:
 **   $Id: copilot_app_version.h  $
 **
-** Purpose: 
+** Purpose:
 **  The Sample Application header file containing version number
 **
 ** Notes:
@@ -16,7 +16,7 @@
 #define COPILOT_CFS_MINOR_VERSION    0
 #define COPILOT_CFS_REVISION         0
 #define COPILOT_CFS_MISSION_REV      0
-      
+
 #endif /* _copilot_app_version_h_ */
 
 /************************/


### PR DESCRIPTION
Remove trailing spaces from the cFS application template, as prescribed in the solution proposed for #108.