### PR TITLE
`ogma-core`: Replace mentions of the Sample App. Refs #105.

### DIFF
--- a/ogma-core/CHANGELOG.md
+++ b/ogma-core/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [1.X.Y] - 2023-11-21
 
 * Remove trailing spaces from cFS app template (#108).
+* Replace all mentions of the Sample App (#105).
 
 ## [1.0.11] - 2023-09-21
 

--- a/ogma-core/src/Command/CFSApp.hs
+++ b/ogma-core/src/Command/CFSApp.hs
@@ -209,7 +209,7 @@ fileContents variables msgIds msgNames msgDatas = cfsFileContents
       , "** File: copilot_cfs.c"
       , "**"
       , "** Purpose:"
-      , "**   This file contains the source code for the Sample App."
+      , "**   This file contains the source code for the Copilot App."
       , "**"
       , "*********************************************************************/"
       , ""

--- a/ogma-core/templates/copilot-cfs/CMakeLists.txt
+++ b/ogma-core/templates/copilot-cfs/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 2.6.4)
-project(CFE_SAMPLE_APP C)
+project(CFE_COPILOT_APP C)
 
 include_directories(../../Modules/Core/Interfaces)
 include_directories(../Icarouslib/fsw/platform_inc)

--- a/ogma-core/templates/copilot-cfs/fsw/mission_inc/copilot_cfs_perfids.h
+++ b/ogma-core/templates/copilot-cfs/fsw/mission_inc/copilot_cfs_perfids.h
@@ -3,7 +3,7 @@
 **   $Id: copilot_cfs_perfids.h  $
 **
 ** Purpose:
-**  Define Sample App Performance IDs
+**  Define Copilot App Performance IDs
 **
 ** Notes:
 **

--- a/ogma-core/templates/copilot-cfs/fsw/platform_inc/copilot_cfs_msgids.h
+++ b/ogma-core/templates/copilot-cfs/fsw/platform_inc/copilot_cfs_msgids.h
@@ -3,7 +3,7 @@
 **   $Id: copilot_cfs_msgids.h  $
 **
 ** Purpose:
-**  Define Sample App  Message IDs
+**  Define Copilot App  Message IDs
 **
 ** Notes:
 **

--- a/ogma-core/templates/copilot-cfs/fsw/src/copilot_cfs.c
+++ b/ogma-core/templates/copilot-cfs/fsw/src/copilot_cfs.c
@@ -2,7 +2,7 @@
 ** File: copilot_cfs.c
 **
 ** Purpose:
-**   This file contains the source code for the Sample App.
+**   This file contains the source code for the Copilot App.
 **
 *******************************************************************************/
 

--- a/ogma-core/templates/copilot-cfs/fsw/src/copilot_cfs_version.h
+++ b/ogma-core/templates/copilot-cfs/fsw/src/copilot_cfs_version.h
@@ -3,7 +3,7 @@
 **   $Id: copilot_app_version.h  $
 **
 ** Purpose:
-**  The Sample Application header file containing version number
+**  The Copilot Application header file containing version number
 **
 ** Notes:
 **


### PR DESCRIPTION
Replace all mentions of the Sample App in the code and the template with mentions of the Copilot app, as prescribed in the solution proposed for #105.