### PR TITLE
`ogma-cli`: Document cabal update step in README. Refs #100.

### DIFF
--- a/ogma-cli/CHANGELOG.md
+++ b/ogma-cli/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Revision history for ogma-cli
 
+## [1.X.Y] - 2023-11-21
+
+* Document cabal update step in README (#100).
+
 ## [1.0.11] - 2023-09-21
 
 * Version bump 1.0.11 (#103).

--- a/ogma-cli/README.md
+++ b/ogma-cli/README.md
@@ -86,6 +86,7 @@ Once GHC and cabal are installed, the simplest way to install Ogma is with:
 $ git clone https://github.com/nasa/ogma.git
 $ cd ogma
 $ export PATH="$HOME/.cabal/bin/:$PATH"
+$ cabal v1-update
 $ cabal v1-install alex happy
 $ cabal v1-install BNFC copilot
 $ cabal v1-install ogma-*/


### PR DESCRIPTION
Modify the installation instructions in README.md to include the cabal update step, as prescribed in the solution proposed for #100.