### PR TITLE
`ogma-core`: Fix missing stream name substitution. Refs #120.

### DIFF
--- a/ogma-core/CHANGELOG.md
+++ b/ogma-core/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Revision history for ogma-core
 
+## [1.X.Y] - 2024-01-23
+
+* Fix missing stream name substitution (#120).
+
 ## [1.2.0] - 2024-01-21
 
 * Version bump 1.2.0 (#117).

--- a/ogma-core/src/Language/Trans/Spec2Copilot.hs
+++ b/ogma-core/src/Language/Trans/Spec2Copilot.hs
@@ -214,7 +214,7 @@ spec2Copilot specName typeMaps exprTransform showExpr spec =
                        ++ propName ++ ") " ++ "[]"
           where
             handlerName = "handler" ++ requirementName r
-            propName    = requirementName r
+            propName    = safeMap nameSubstitutions (requirementName r)
 
     -- Main program that compiles specification to C in two files (code and
     -- header).


### PR DESCRIPTION
Use the same name substitution when generating `trigger` calls in `Spec2Copilot`, as prescribed in the solution proposed for #120.