### PR TITLE
`ogma-core`: Fix translation of equivalence boolean operator from SMV. Refs #126.

### DIFF
--- a/ogma-core/CHANGELOG.md
+++ b/ogma-core/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Revision history for ogma-core
 
-## [1.X.Y] - 2024-01-24
+## [1.X.Y] - 2024-03-03
 
 * Fix missing stream name substitution (#120).
 * Use generalized JSON parser for DB Spec (#122).
+* Fix translation of equivalence boolean operator from SMV (#126).
 
 ## [1.2.0] - 2024-01-21
 

--- a/ogma-core/src/Language/Trans/SMV2Copilot.hs
+++ b/ogma-core/src/Language/Trans/SMV2Copilot.hs
@@ -83,7 +83,7 @@ boolSpec2Copilot b = case b of
                               ++ ")"
 
   BoolSpecEquivs spec1 spec2 -> "(" ++ boolSpec2Copilot spec1
-                             ++ " " ++ "<==>"
+                             ++ " " ++ "=="
                              ++ " " ++ boolSpec2Copilot spec2
                              ++ ")"
 


### PR DESCRIPTION
Replace the translation of the equivalence operator from SMV to be `(==)` in Copilot, as prescribed in the solution proposed for #126.