### PR TITLE
`copilot-core`: Sanitize handler names. Refs #127.

### DIFF
--- a/ogma-core/CHANGELOG.md
+++ b/ogma-core/CHANGELOG.md
@@ -1,10 +1,11 @@
 # Revision history for ogma-core
 
-## [1.X.Y] - 2024-03-03
+## [1.X.Y] - 2024-03-13
 
 * Fix missing stream name substitution (#120).
 * Use generalized JSON parser for DB Spec (#122).
 * Fix translation of equivalence boolean operator from SMV (#126).
+* Sanitize handler names (#127).
 
 ## [1.2.0] - 2024-01-21
 

--- a/ogma-core/src/Language/Trans/Spec2Copilot.hs
+++ b/ogma-core/src/Language/Trans/Spec2Copilot.hs
@@ -213,7 +213,7 @@ spec2Copilot specName typeMaps exprTransform showExpr spec =
         reqTrigger r = "  trigger " ++ show handlerName ++ " (not "
                        ++ propName ++ ") " ++ "[]"
           where
-            handlerName = "handler" ++ requirementName r
+            handlerName = "handler" ++ sanitizeUCIdentifier (requirementName r)
             propName    = safeMap nameSubstitutions (requirementName r)
 
     -- Main program that compiles specification to C in two files (code and


### PR DESCRIPTION
Sanitize handler names used in the generated Copilot specs, as prescribed in the solution proposed for #127.