### PR TITLE
`ogma-core`: Adjust handler names in ROS, FPrime app generators to match Copilot backend. Refs #130.

### DIFF
--- a/ogma-core/CHANGELOG.md
+++ b/ogma-core/CHANGELOG.md
@@ -1,11 +1,12 @@
 # Revision history for ogma-core
 
-## [1.X.Y] - 2024-03-13
+## [1.X.Y] - 2024-03-14
 
 * Fix missing stream name substitution (#120).
 * Use generalized JSON parser for DB Spec (#122).
 * Fix translation of equivalence boolean operator from SMV (#126).
 * Sanitize handler names (#127).
+* Use same handler name in FPrime/ROS and Copilot (#130).
 
 ## [1.2.0] - 2024-01-21
 

--- a/ogma-core/src/Command/FPrimeApp.hs
+++ b/ogma-core/src/Command/FPrimeApp.hs
@@ -246,7 +246,7 @@ fretCSExtractHandlers (Just cs) = map handlerNameF
                                 $ map requirementName
                                 $ requirements cs
   where
-    handlerNameF = ("handlerprop" ++) . sanitizeUCIdentifier
+    handlerNameF = ("handler" ++) . sanitizeUCIdentifier
 
 -- | Return the variable information needed to generate declarations
 -- and subscriptions for a given variable name and variable database.

--- a/ogma-core/src/Command/ROSApp.hs
+++ b/ogma-core/src/Command/ROSApp.hs
@@ -250,7 +250,7 @@ fretCSExtractHandlers (Just cs) = map handlerNameF
                                 $ map requirementName
                                 $ requirements cs
   where
-    handlerNameF = ("handlerprop" ++) . sanitizeUCIdentifier
+    handlerNameF = ("handler" ++) . sanitizeUCIdentifier
 
 -- | Return the variable information needed to generate declarations
 -- and subscriptions for a given variable name and variable database.


### PR DESCRIPTION
Adjust the names of the expected handlers in the ROS and FPrime application generators to match what the Copilot backend is using, as prescribed in the solution proposed for #130.