### PR TITLE
`ogma-core`: Map `float` and `double` to the same types in C++. Refs #138.

### DIFF
--- a/ogma-cli/CHANGELOG.md
+++ b/ogma-cli/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Revision history for ogma-cli
 
-## [1.X.X] - 2024-05-20
+## [1.X.X] - 2024-05-21
 
 * Introduce CI test job (#139).
 * Introduce test job for ROS package generation (#136).
+* Add a float and a double input variable to ROS example (#138).
 
 ## [1.3.0] - 2024-03-21
 

--- a/ogma-cli/examples/ros-copilot/ROS.hs
+++ b/ogma-cli/examples/ros-copilot/ROS.hs
@@ -1,13 +1,21 @@
 import Copilot.Compile.C99
 import Copilot.Language
 import Language.Copilot    (reify)
-import Prelude             hiding (not, (>=))
+import Prelude             hiding (not, (&&), (>=))
 
 inputSignal :: Stream Int64
 inputSignal = extern "input_signal" Nothing
 
+inputSignalFloat :: Stream Float
+inputSignalFloat = extern "input_signal_float" Nothing
+
+inputSignalDouble :: Stream Double
+inputSignalDouble = extern "input_signal_double" Nothing
+
 propTestCopilot :: Stream Bool
 propTestCopilot = inputSignal >= 5
+               && inputSignalFloat >= 5
+               && inputSignalDouble >= 5
 
 spec :: Spec
 spec = do

--- a/ogma-cli/examples/ros-copilot/variables
+++ b/ogma-cli/examples/ros-copilot/variables
@@ -1,1 +1,3 @@
 input_signal
+input_signal_float
+input_signal_double

--- a/ogma-cli/examples/ros-copilot/vars-db
+++ b/ogma-cli/examples/ros-copilot/vars-db
@@ -1,1 +1,3 @@
 ("input_signal","int64_t","/demo/topic","int64_t")
+("input_signal_float","float","/demo/topicf","float")
+("input_signal_double","double","/demo/topicd","double")

--- a/ogma-core/CHANGELOG.md
+++ b/ogma-core/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Revision history for ogma-core
 
-## [1.X.X] - 2024-05-20
+## [1.X.X] - 2024-05-21
 
 * Make ros command generate dockerfile (#136).
+* Map float and double to the same types in C++ (#138).
 
 ## [1.3.0] - 2024-03-21
 

--- a/ogma-core/src/Command/ROSApp.hs
+++ b/ogma-core/src/Command/ROSApp.hs
@@ -403,8 +403,8 @@ rosMonitorContents varNames variables msgIds msgNames msgDatas monitors =
           "int16_t"  -> "std::int16_t"
           "int32_t"  -> "std::int32_t"
           "int64_t"  -> "std::int64_t"
-          "float"    -> "std::float32"
-          "double"   -> "std::float64"
+          "float"    -> "float"
+          "double"   -> "double"
           def        -> def
 
     msgSubscriptionS     = unlines


### PR DESCRIPTION
Modify the ROS backend to map the input types `float` and `double` to the same types in the generated C++ ROS nodes, as prescribed in the solution proposed for #138.