### PR TITLE
`ogma-cli`:  Constrain version of dependency in CI jobs. Refs #151.

### DIFF
--- a/.github/workflows/repo-ghc-8.6-cabal-2.4-ros.yml
+++ b/.github/workflows/repo-ghc-8.6-cabal-2.4-ros.yml
@@ -43,7 +43,7 @@ jobs:
 
     - name: Install ogma
       run: |
-        cabal v1-install copilot ogma-**/ --constraint="copilot >= 3.19.1"
+        cabal v1-install copilot ogma-**/ --constraint="copilot >= 3.19.1" --constraint="aeson >= 2.0.3.0"
 
     - name: Generate ROS app
       run: |

--- a/.github/workflows/repo-ghc-8.6-cabal-2.4.yml
+++ b/.github/workflows/repo-ghc-8.6-cabal-2.4.yml
@@ -53,11 +53,10 @@ jobs:
         # the dependencies do not change and cabal does not change the
         # installation plan (which would mean we'd be running the tests with a
         # version of ogma compiled with different dependencies).
-        cabal v1-install ogma-**/ --enable-tests
-
+        cabal v1-install ogma-**/ --enable-tests --constraint="aeson >= 2.0.3.0"
     - name: Test all packages
       run: |
         # We want to document the build process, and get detailed information
         # if there is a problem (or if all goes well). We therefore execute the
         # installation with -j1.
-        cabal v1-install ogma-**/ --enable-tests --run-tests -j1
+        cabal v1-install ogma-**/ --enable-tests --run-tests -j1 --constraint="aeson >= 2.0.3.0"

--- a/ogma-cli/CHANGELOG.md
+++ b/ogma-cli/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Revision history for ogma-cli
 
+## [1.4.X] - 2024-09-21
+
+* Constrain version of dependency in CI jobs (#151).
+
 ## [1.4.0] - 2024-05-21
 
 * Version bump 1.4.0 (#145).


### PR DESCRIPTION
Constrain the version of `aeson` to be greater than 2.0.2.0 in the CI jobs, as prescribed in the solution proposed for #151.