### PR TITLE
`ogma-core`: Remove dependency on `IfElse`. Refs #150.

### DIFF
--- a/ogma-core/CHANGELOG.md
+++ b/ogma-core/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Revision history for ogma-core
 
+## [1.4.X] - 2024-09-21
+
+* Remove dependency on IfElse (#150).
+
 ## [1.4.0] - 2024-05-21
 
 * Version bump 1.4.0 (#145).

--- a/ogma-core/ogma-core.cabal
+++ b/ogma-core/ogma-core.cabal
@@ -107,7 +107,6 @@ library
     , aeson                   >= 2.0.0.0  && < 2.2
     , bytestring
     , filepath
-    , IfElse
     , mtl
 
     , ogma-extra              >= 1.4.0 && < 1.5

--- a/ogma-core/src/Command/FRETComponentSpec2Copilot.hs
+++ b/ogma-core/src/Command/FRETComponentSpec2Copilot.hs
@@ -41,9 +41,9 @@ module Command.FRETComponentSpec2Copilot
   where
 
 -- External imports
-import Control.Monad.IfElse ( awhen )
 import Data.Aeson           ( eitherDecode, decode )
 import Data.ByteString.Lazy (fromStrict)
+import Data.Foldable        (for_)
 
 -- External imports: auxiliary
 import Data.ByteString.Extra as B ( safeReadFile )
@@ -91,7 +91,7 @@ fretComponentSpec2Copilot fp options = do
   let (mOutput, result) =
         fretComponentSpec2CopilotResult options fp copilot
 
-  awhen mOutput putStrLn
+  for_ mOutput putStrLn
   return result
 
 -- | Print the contents of a Copilot module that implements the Past-time TL

--- a/ogma-core/src/Command/FRETReqsDB2Copilot.hs
+++ b/ogma-core/src/Command/FRETReqsDB2Copilot.hs
@@ -39,9 +39,9 @@ module Command.FRETReqsDB2Copilot
   where
 
 -- External imports
-import Control.Monad.IfElse ( awhen )
-import Data.Aeson           ( eitherDecode )
-import Data.List            ( nub, (\\) )
+import Data.Aeson    (eitherDecode)
+import Data.Foldable (for_)
+import Data.List     (nub, (\\))
 
 -- External imports: auxiliary
 import Data.ByteString.Extra as B ( safeReadFile )
@@ -88,7 +88,7 @@ fretReqsDB2Copilot fp options = do
   let (mOutput, result) =
         fretReqsDB2CopilotResult options fp copilot
 
-  awhen mOutput putStrLn
+  for_ mOutput putStrLn
   return result
 
 -- | Print the contents of a Copilot module that implements the Past-time TL


### PR DESCRIPTION
Replace uses of definitions from `IfElse` with other functions from `base`, as prescribed in the solution proposed for #150.