### PR TITLE
`ogma-core`: Fix incorrect path when using Space ROS humble-2024.10.0. Refs #158.

### DIFF
--- a/ogma-core/CHANGELOG.md
+++ b/ogma-core/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Revision history for ogma-core
 
+## [1.X.Y] - 2024-11-13
+
+* Fix incorrect path when using Space ROS humble-2024.10.0 (#158).
+
 ## [1.4.1] - 2024-09-21
 
 * Version bump 1.4.1 (#155).

--- a/ogma-core/templates/ros/Dockerfile
+++ b/ogma-core/templates/ros/Dockerfile
@@ -1,4 +1,4 @@
-FROM osrf/space-ros:latest
+FROM osrf/space-ros:humble-2024.10.0
 
 ARG USER=spaceros-user
 ARG PACKAGE_PATH=/home/${USER}/monitors
@@ -12,5 +12,5 @@ USER ${USER}
 
 SHELL ["/bin/bash", "-c"]
 WORKDIR ${PACKAGE_PATH}
-RUN source ${ROS_PATH}/install/setup.bash && \
+RUN source /opt/spaceros/install/setup.bash && \
     colcon build


### PR DESCRIPTION
Fix incorrect path to `setup.bash` in latest Space ROS and fix Space ROS version to `humble-2024.10.0`, as prescribed in the solution proposed for #158.