### PR TITLE
`ogma-cli`: Allow customizing the ROS application template. Refs #162.

### DIFF
--- a/ogma-cli/CHANGELOG.md
+++ b/ogma-cli/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Revision history for ogma-cli
 
-## [1.X.Y] - 2024-11-11
+## [1.X.Y] - 2024-11-20
 
 * Provide ability to customize template in cfs command (#157).
+* Provide ability to customize template in ros command (#162).
 
 ## [1.4.1] - 2024-09-21
 

--- a/ogma-cli/src/CLI/CommandROSApp.hs
+++ b/ogma-cli/src/CLI/CommandROSApp.hs
@@ -56,11 +56,12 @@ import Command.ROSApp ( ErrorCode, rosApp )
 
 -- | Options needed to generate the ROS application.
 data CommandOpts = CommandOpts
-  { rosAppTarget   :: String
-  , rosAppFRETFile :: Maybe String
-  , rosAppVarNames :: Maybe String
-  , rosAppVarDB    :: Maybe String
-  , rosAppHandlers :: Maybe String
+  { rosAppTarget      :: String
+  , rosAppTemplateDir :: Maybe String
+  , rosAppFRETFile    :: Maybe String
+  , rosAppVarNames    :: Maybe String
+  , rosAppVarDB       :: Maybe String
+  , rosAppHandlers    :: Maybe String
   }
 
 -- | Create <https://www.ros.org/ Robot Operating System> (ROS) applications
@@ -72,6 +73,7 @@ command :: CommandOpts -> IO (Result ErrorCode)
 command c =
   rosApp
     (rosAppTarget c)
+    (rosAppTemplateDir c)
     (rosAppFRETFile c)
     (rosAppVarNames c)
     (rosAppVarDB c)
@@ -93,6 +95,13 @@ commandOptsParser = CommandOpts
         <> showDefault
         <> value "ros"
         <> help strROSAppDirArgDesc
+        )
+  <*> optional
+        ( strOption
+            (  long "app-template-dir"
+            <> metavar "DIR"
+            <> help strROSAppTemplateDirArgDesc
+            )
         )
   <*> optional
         ( strOption
@@ -126,6 +135,11 @@ commandOptsParser = CommandOpts
 -- | Argument target directory to ROS app generation command
 strROSAppDirArgDesc :: String
 strROSAppDirArgDesc = "Target directory"
+
+-- | Argument template directory to ROS app generation command
+strROSAppTemplateDirArgDesc :: String
+strROSAppTemplateDirArgDesc =
+  "Directory holding ROS application source template"
 
 -- | Argument FRET CS to ROS app generation command
 strROSAppFRETFileNameArgDesc :: String

--- a/ogma-core/CHANGELOG.md
+++ b/ogma-core/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Revision history for ogma-core
 
-## [1.X.Y] - 2024-11-13
+## [1.X.Y] - 2024-11-20
 
 * Fix incorrect path when using Space ROS humble-2024.10.0 (#158).
 * Use template expansion system to generate cFS monitoring application (#157).
+* Use template expansion system to generate ROS monitoring application (#162).
 
 ## [1.4.1] - 2024-09-21
 

--- a/ogma-core/ogma-core.cabal
+++ b/ogma-core/ogma-core.cabal
@@ -106,10 +106,7 @@ library
       base                    >= 4.11.0.0 && < 5
     , aeson                   >= 2.0.0.0  && < 2.2
     , bytestring
-    , Cabal                   >= 2.4      && < 3.10
-    , directory               >= 1.3.1.0  && < 1.4
     , filepath
-    , microstache             >= 1.0      && < 1.1
     , mtl
     , text                    >= 1.2.3.1  && < 2.1
 

--- a/ogma-core/ogma-core.cabal
+++ b/ogma-core/ogma-core.cabal
@@ -62,7 +62,8 @@ data-files:          templates/copilot-cfs/CMakeLists.txt
                      templates/copilot-cfs/fsw/src/copilot_cfs_events.h
                      templates/ros/Dockerfile
                      templates/ros/copilot/CMakeLists.txt
-                     templates/ros/copilot/src/.keep
+                     templates/ros/copilot/src/copilot_logger.cpp
+                     templates/ros/copilot/src/copilot_monitor.cpp
                      templates/ros/copilot/package.xml
                      templates/fprime/CMakeLists.txt
                      templates/fprime/Dockerfile

--- a/ogma-core/templates/ros/copilot/src/copilot_logger.cpp
+++ b/ogma-core/templates/ros/copilot/src/copilot_logger.cpp
@@ -1,0 +1,27 @@
+#include <functional>
+#include <memory>
+
+#include "rclcpp/rclcpp.hpp"
+
+#include "std_msgs/msg/empty.hpp"
+using std::placeholders::_1;
+
+class CopilotLogger : public rclcpp::Node {
+  public:
+    CopilotLogger() : Node("copilotlogger") {
+{{{logMsgSubscriptionS}}}
+    }
+
+  private:
+{{{logMsgCallbacks}}}
+{{{logMsgSubscriptionDeclrs}}}
+};
+
+int main(int argc, char* argv[]) {
+  rclcpp::init(argc, argv);
+  rclcpp::spin(std::make_shared<CopilotLogger>());
+  rclcpp::shutdown();
+  return 0;
+}
+
+

--- a/ogma-core/templates/ros/copilot/src/copilot_monitor.cpp
+++ b/ogma-core/templates/ros/copilot/src/copilot_monitor.cpp
@@ -1,0 +1,52 @@
+#include <functional>
+#include <memory>
+
+#include "rclcpp/rclcpp.hpp"
+
+#include "std_msgs/msg/bool.hpp"
+#include "std_msgs/msg/empty.hpp"
+#include "std_msgs/msg/u_int8.hpp"
+#include "std_msgs/msg/u_int16.hpp"
+#include "std_msgs/msg/u_int32.hpp"
+#include "std_msgs/msg/u_int64.hpp"
+#include "std_msgs/msg/int8.hpp"
+#include "std_msgs/msg/int16.hpp"
+#include "std_msgs/msg/int32.hpp"
+#include "std_msgs/msg/int64.hpp"
+#include "std_msgs/msg/float32.hpp"
+#include "std_msgs/msg/float64.hpp"
+#include <cstdint>
+#include "monitor.h"
+#include "monitor.c"
+
+using std::placeholders::_1;
+
+{{{variablesS}}}
+class CopilotRV : public rclcpp::Node {
+  public:
+    CopilotRV() : Node("copilotrv") {
+{{{msgSubscriptionS}}}
+{{{msgPublisherS}}}
+    }
+
+{{{msgHandlerInClassS}}}
+    // Needed so we can report messages to the log.
+    static CopilotRV& getInstance() {
+      static CopilotRV instance;
+      return instance;
+    }
+
+  private:
+{{{msgCallbacks}}}
+{{{msgSubscriptionDeclrs}}}
+{{{msgPublisherDeclrs}}}
+};
+
+{{{msgHandlerGlobalS}}}
+int main(int argc, char* argv[]) {
+  rclcpp::init(argc, argv);
+  rclcpp::spin(std::make_shared<CopilotRV>());
+  rclcpp::shutdown();
+  return 0;
+}
+

--- a/ogma-extra/CHANGELOG.md
+++ b/ogma-extra/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Revision history for ogma-extra
 
+## [1.X.Y] - 2024-11-20
+
+* Introduce template expansion functionality (#162).
+
 ## [1.4.1] - 2024-09-21
 
 * Version bump 1.4.1 (#155).

--- a/ogma-extra/ogma-extra.cabal
+++ b/ogma-extra/ogma-extra.cabal
@@ -68,11 +68,14 @@ library
     System.Directory.Extra
 
   build-depends:
-      base       >= 4.11.0.0 && < 5
+      base        >= 4.11.0.0 && < 5
+    , aeson       >= 2.0.0.0  && < 2.2
     , bytestring
     , Cabal
     , directory
     , filepath
+    , microstache >= 1.0      && < 1.1
+    , text        >= 1.2.3.1  && < 2.1
 
   hs-source-dirs:
     src


### PR DESCRIPTION
Adjust `ogma-cli` and `ogma-core` to allow customizing the ROS application by using custom-provided templates, as prescribed in the solution proposed for #162.