### PR TITLE
`ogma-core`: Fix comment in generated Copilot spec. Refs #164.

### DIFF
--- a/ogma-core/CHANGELOG.md
+++ b/ogma-core/CHANGELOG.md
@@ -1,10 +1,11 @@
 # Revision history for ogma-core
 
-## [1.X.Y] - 2024-11-20
+## [1.X.Y] - 2024-11-21
 
 * Fix incorrect path when using Space ROS humble-2024.10.0 (#158).
 * Use template expansion system to generate cFS monitoring application (#157).
 * Use template expansion system to generate ROS monitoring application (#162).
+* Fix comment in generated Copilot spec (#164).
 
 ## [1.4.1] - 2024-09-21
 

--- a/ogma-core/src/Language/Trans/Spec2Copilot.hs
+++ b/ogma-core/src/Language/Trans/Spec2Copilot.hs
@@ -197,9 +197,9 @@ spec2Copilot specName typeMaps exprTransform showExpr spec =
     -- Main specification
     copilotSpec :: [String]
     copilotSpec = [ ""
-                  , "-- | Complete specification. Calls the C function void "
-                    ++ " handler(); when"
-                  , "-- the property is violated."
+                  , "-- | Complete specification. Calls C handler functions"
+                    ++ " when"
+                  , "-- properties are violated."
                   , "spec :: Spec"
                   , "spec = do"
                   ]


### PR DESCRIPTION
Fix comment in generated Copilot spec, as prescribed in the solution proposed for #164.