### PR TITLE
`ogma-core`: Add missing notPreviousNot to generated spec. Refs #168.

### DIFF
--- a/ogma-core/CHANGELOG.md
+++ b/ogma-core/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Use template expansion system to generate cFS monitoring application (#157).
 * Use template expansion system to generate ROS monitoring application (#162).
 * Fix comment in generated Copilot spec (#164).
+* Add missing notPreviousNot to generated spec (#168).
 
 ## [1.4.1] - 2024-09-21
 

--- a/ogma-core/src/Language/Trans/Spec2Copilot.hs
+++ b/ogma-core/src/Language/Trans/Spec2Copilot.hs
@@ -67,6 +67,7 @@ spec2Copilot specName typeMaps exprTransform showExpr spec =
       , ftp
       , pre
       , tpre
+      , notPreviousNot
       , copilotSpec
       , main'
       ]
@@ -193,6 +194,13 @@ spec2Copilot specName typeMaps exprTransform showExpr spec =
            , "tpre :: Stream Bool -> Stream Bool"
            , "tpre = ([True] ++)"
            ]
+
+    -- Auxiliary streams: notPreviousNot
+    notPreviousNot :: [String]
+    notPreviousNot = [ ""
+                     , "notPreviousNot :: Stream Bool -> Stream Bool"
+                     , "notPreviousNot = not . PTLTL.previous . not"
+                     ]
 
     -- Main specification
     copilotSpec :: [String]


### PR DESCRIPTION
Modify Copilot spec generator to include a definition for `notPreviousNot`, as prescribed in the solution proposed for #168.