### PR TITLE
`ogma-cli`: Update README to demonstrate robotics. Refs #172.

### DIFF
--- a/ogma-cli/CHANGELOG.md
+++ b/ogma-cli/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Provide ability to customize template in cfs command (#157).
 * Provide ability to customize template in ros command (#162).
 * Introduce new standalone command (#170).
+* Update README to demonstrate robotics (#172).
 
 ## [1.4.1] - 2024-09-21
 

--- a/ogma-cli/README.md
+++ b/ogma-cli/README.md
@@ -27,6 +27,12 @@ verification framework that generates hard real-time C99 code.
   <i>Integration of monitors into larger applications (e.g., simulators).</i>
 </p>
 
+<p align="center">
+  <img src="https://raw.githubusercontent.com/nasa/ogma/gh-pages/images/ros.gif" alt="Monitoring within ROS simulation video">
+  <br />
+  <i>Integration of monitors into robotics applications.</i>
+</p>
+
 ## Table of Contents
 
 - [Installation](#installation)


### PR DESCRIPTION
Update README to include a video of an Ogma-generated monitor running in ROS, demonstrated via Gazebo, as prescribed in the solution proposed for #172.