### PR TITLE
`ogma-cli`: Add version bounds to `base`. Refs #180.

### DIFF
--- a/ogma-cli/CHANGELOG.md
+++ b/ogma-cli/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Introduce new standalone command (#170).
 * Update README to demonstrate robotics (#172).
 * Remove unused resources (#174).
+* Add version bounds to base (#180).
 
 ## [1.4.1] - 2024-09-21
 

--- a/ogma-cli/ogma-cli.cabal
+++ b/ogma-cli/ogma-cli.cabal
@@ -153,7 +153,7 @@ test-suite test-ogma
     Main.hs
 
   build-depends:
-      base
+      base                 >= 4.11.0.0 && < 5
     , HUnit
     , process
     , test-framework


### PR DESCRIPTION
Add version bounds to base in all components in the cabal package description of `ogma-cli`, as prescribed in the solution proposed for #180.