### PR TITLE
`ogma-cli`: Allow customizing the F' component template. Refs #185.

### DIFF
--- a/ogma-cli/CHANGELOG.md
+++ b/ogma-cli/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Revision history for ogma-cli
 
-## [1.X.Y] - 2024-11-23
+## [1.X.Y] - 2024-11-26
 
 * Update contribution guidelines (#161).
+* Provide ability to customize template in fprime command (#185).
 
 ## [1.5.0] - 2024-11-21
 

--- a/ogma-cli/README.md
+++ b/ogma-cli/README.md
@@ -401,6 +401,7 @@ F' components are generated using the Ogma command `fprime`, which receives
 five main arguments:
 - `--app-target-dir DIR`: location where the F' application files must be
   stored.
+- `--app-template-dir DIR`: directory holding F' component source template.
 - `--variable-file FILENAME`: a file containing a list of variables that must
 be made available to the monitor.
 - `--variable-db FILENAME`: a file containing a database of known variables,
@@ -463,6 +464,67 @@ FPrime component should restrict to monitoring. They are listed one per line:
 $ cat handlers
 handlerpropREQ_001
 ```
+
+### Template Customization
+
+By default, Ogma uses a pre-defined template to generate the F' monitoring
+component. It's possible to customize the output by providing a directory with
+a set of files with an F' component template, which Ogma will use instead.
+
+To choose this feature, one must call Ogma's `fprime` command with the argument
+`--app-template-dir DIR`, where `DIR` is the path to a directory containing an
+F' component specification template. For example, assuming that the directory
+`my_template` contains a custom F' component template, one can execute:
+
+```
+$ ogma fprime --app-template-dir my_template/ --handlers filename --variable-file variables --variable-db fprime-variable-db --app-target-dir fprime_demo
+```
+
+Ogma will copy the files in that directory to the target path, filling in
+several holes with specific information. For the component interface, the
+variables are:
+
+- {{{ifaceTypePorts}}}: Contain the type declarations for the types used by the
+  ports.
+
+- {{{ifaceInputPorts}}}: Contains the declarations of the `async input` port,
+  to provide information needed by the monitors.
+
+- {{{ifaceViolationEvents}}}: Contains the output port declarations, used to
+  emit property violations.
+
+For the monitor's header file, the variables are:
+
+- {{{hdrHandlers}}}: Contains the declarations of operations to execute when
+  new information is received in an input port, prior to re-evaluating the
+  monitors.
+
+For the monitor's implementation, the variables are:
+
+- {{{implInputs}}}: Contains the declarations of the variables with inputs
+  needed by the monitor.
+
+- {{{implMonitorResults}}}: Contains the declarations of boolean variables,
+  each holding the result of the evaluation of one of the monitors.
+
+- {{{implInputHandlers}}}: Contains the implementations of operations to
+  execute when new information is received in an input port, prior to
+  re-evaluating the monitors.
+
+- {{{implTriggerResultReset}}}: Contains instructions that reset the status of
+  the monitors.
+
+- {{{implTriggerChecks}}}: Contains instructions that check whether any monitor
+  has resulted in a violation and, if so, sends an event via the corresponding
+  port.
+
+- {{{implTriggers}}}: Contains the implementations of the functions that set
+  the result of a monitor evaluation to true when the Copilot implementation
+  finds a violation.
+
+We understand that this level of customization may be insufficient for your
+application. If that is the case, feel free to reach out to our team to discuss
+how we could make the template expansion system more versatile.
 
 ### Current limitations
 

--- a/ogma-cli/src/CLI/CommandFPrimeApp.hs
+++ b/ogma-cli/src/CLI/CommandFPrimeApp.hs
@@ -56,11 +56,12 @@ import Command.FPrimeApp ( ErrorCode, fprimeApp )
 
 -- | Options needed to generate the FPrime component.
 data CommandOpts = CommandOpts
-  { fprimeAppTarget   :: String
-  , fprimeAppFRETFile :: Maybe String
-  , fprimeAppVarNames :: Maybe String
-  , fprimeAppVarDB    :: Maybe String
-  , fprimeAppHandlers :: Maybe String
+  { fprimeAppTarget      :: String
+  , fprimeAppTemplateDir :: Maybe String
+  , fprimeAppFRETFile    :: Maybe String
+  , fprimeAppVarNames    :: Maybe String
+  , fprimeAppVarDB       :: Maybe String
+  , fprimeAppHandlers    :: Maybe String
   }
 
 -- | Create <https://github.com/nasa/fprime FPrime> component that subscribe
@@ -72,6 +73,7 @@ command :: CommandOpts -> IO (Result ErrorCode)
 command c =
   fprimeApp
     (fprimeAppTarget c)
+    (fprimeAppTemplateDir c)
     (fprimeAppFRETFile c)
     (fprimeAppVarNames c)
     (fprimeAppVarDB c)
@@ -93,6 +95,13 @@ commandOptsParser = CommandOpts
         <> showDefault
         <> value "fprime"
         <> help strFPrimeAppDirArgDesc
+        )
+  <*> optional
+        ( strOption
+            (  long "app-template-dir"
+            <> metavar "DIR"
+            <> help strFPrimeAppTemplateDirArgDesc
+            )
         )
   <*> optional
         ( strOption
@@ -126,6 +135,11 @@ commandOptsParser = CommandOpts
 -- | Argument target directory to FPrime component generation command
 strFPrimeAppDirArgDesc :: String
 strFPrimeAppDirArgDesc = "Target directory"
+
+-- | Argument template directory to FPrime component generation command
+strFPrimeAppTemplateDirArgDesc :: String
+strFPrimeAppTemplateDirArgDesc =
+  "Directory holding F' component source template"
 
 -- | Argument FRET CS to FPrime component generation command
 strFPrimeAppFRETFileNameArgDesc :: String

--- a/ogma-core/CHANGELOG.md
+++ b/ogma-core/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [1.X.Y] - 2024-12-04
 
 * Replace queueSize with QUEUE_SIZE in FPP file (#186).
+* Use template expansion system to generate F' monitoring component (#185).
 
 ## [1.5.0] - 2024-11-21
 

--- a/ogma-core/ogma-core.cabal
+++ b/ogma-core/ogma-core.cabal
@@ -66,6 +66,9 @@ data-files:          templates/copilot-cfs/CMakeLists.txt
                      templates/ros/copilot/src/copilot_monitor.cpp
                      templates/ros/copilot/package.xml
                      templates/fprime/CMakeLists.txt
+                     templates/fprime/Copilot.cpp
+                     templates/fprime/Copilot.fpp
+                     templates/fprime/Copilot.hpp
                      templates/fprime/Dockerfile
                      templates/fprime/instance-copilot
                      data/formats/fcs_smv

--- a/ogma-core/src/Command/FPrimeApp.hs
+++ b/ogma-core/src/Command/FPrimeApp.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE OverloadedStrings #-}
 -- Copyright 2022 United States Government as represented by the Administrator
 -- of the National Aeronautics and Space Administration. All Rights Reserved.
 --
@@ -42,16 +43,17 @@ module Command.FPrimeApp
 import qualified Control.Exception    as E
 import           Control.Monad.Except ( ExceptT, liftEither, liftIO, runExceptT,
                                         throwError )
-import           Data.Aeson           ( eitherDecode )
+import           Data.Aeson           ( eitherDecode, object, (.=) )
 import           Data.Char            ( toUpper )
 import           Data.List            ( find, intercalate, nub, sort )
 import           Data.Maybe           ( fromMaybe )
+import           Data.Text.Lazy       ( pack )
 import           System.FilePath      ( (</>) )
 
 -- External imports: auxiliary
 import Data.ByteString.Extra  as B ( safeReadFile )
 import Data.String.Extra      ( sanitizeLCIdentifier, sanitizeUCIdentifier )
-import System.Directory.Extra ( copyDirectoryRecursive )
+import System.Directory.Extra ( copyTemplate )
 
 -- External imports: ogma
 import Data.OgmaSpec            (Spec, externalVariableName, externalVariables,
@@ -112,9 +114,6 @@ fprimeApp' targetDir varNames varDB monitors =
     dataDir <- getDataDir
     let templateDir = dataDir </> "templates" </> "fprime"
 
-    -- Expand template
-    copyDirectoryRecursive templateDir targetDir
-
     let f n o@(oVars) =
           case variableMap varDB n of
             Nothing   -> o
@@ -123,29 +122,32 @@ fprimeApp' targetDir varNames varDB monitors =
     -- This is a Data.List.unzip4
     let vars = foldr f [] varNames
 
-    let fprimeFileName =
-          targetDir </> "Copilot.fpp"
-        fprimeFileContents =
-          unlines $
-            componentInterface vars monitors
+        -- Copilot.fpp
+        (ifaceTypePorts, ifaceInputPorts, ifaceViolationEvents) =
+          componentInterface vars monitors
 
-    writeFile fprimeFileName fprimeFileContents
+        -- Copilot.hpp
+        hdrHandlers = componentHeader vars monitors
 
-    let fprimeFileName =
-          targetDir </> "Copilot.hpp"
-        fprimeFileContents =
-          unlines $
-            componentHeader vars monitors
+        -- Copilot.cpp
+        (implInputs,             implMonitorResults, implInputHandlers,
+         implTriggerResultReset, implTriggerChecks,  implTriggers) =
+          componentImpl vars monitors
 
-    writeFile fprimeFileName fprimeFileContents
+        subst = object $
+                  [ "ifaceTypePorts"         .= pack ifaceTypePorts
+                  , "ifaceInputPorts"        .= pack ifaceInputPorts
+                  , "ifaceViolationEvents"   .= pack ifaceViolationEvents
+                  , "hdrHandlers"            .= pack hdrHandlers
+                  , "implInputs"             .= pack implInputs
+                  , "implMonitorResults"     .= pack implMonitorResults
+                  , "implInputHandlers"      .= pack implInputHandlers
+                  , "implTriggerResultReset" .= pack implTriggerResultReset
+                  , "implTriggerChecks"      .= pack implTriggerChecks
+                  , "implTriggers"           .= pack implTriggers
+                  ]
 
-    let fprimeFileName =
-          targetDir </> "Copilot.cpp"
-        fprimeFileContents =
-          unlines $
-            componentImpl vars monitors
-
-    writeFile fprimeFileName fprimeFileContents
+    copyTemplate templateDir subst targetDir
 
     return $ Right ()
 
@@ -280,93 +282,19 @@ data VarDecl = VarDecl
 -- | Return the contents of the FPrime component interface (.fpp) specification.
 componentInterface :: [VarDecl]
                    -> [String]     -- Monitors
-                   -> [String]
+                   -> (String, String, String)
 componentInterface variables monitors =
-    [ "module Ref {"
-    , ""
-    ]
-    ++ typePorts ++
-    [ ""
-    , "  @ Monitoring component"
-    , "  queued component Copilot {"
-    , ""
-    , "    # ----------------------------------------------------------------------"
-    , "    # General ports"
-    , "    # ----------------------------------------------------------------------"
-    , ""
-    ]
-    ++ inputPorts ++
-    [ ""
-    , "    # ----------------------------------------------------------------------"
-    , "    # Special ports"
-    , "    # ----------------------------------------------------------------------"
-    , ""
-    , "    @ Command receive"
-    , "    command recv port cmdIn"
-    , ""
-    , "    @ Command registration"
-    , "    command reg port cmdRegOut"
-    , ""
-    , "    @ Command response"
-    , "    command resp port cmdResponseOut"
-    , ""
-    , "    @ Event"
-    , "    event port eventOut"
-    , ""
-    , "    @ Parameter get"
-    , "    param get port prmGetOut"
-    , ""
-    , "    @ Parameter set"
-    , "    param set port prmSetOut"
-    , ""
-    , "    @ Telemetry"
-    , "    telemetry port tlmOut"
-    , ""
-    , "    @ Text event"
-    , "    text event port textEventOut"
-    , ""
-    , "    @ Time get"
-    , "    time get port timeGetOut"
-    , ""
-    , "    # ----------------------------------------------------------------------"
-    , "    # Parameters"
-    , "    # ----------------------------------------------------------------------"
-    , ""
-    , "    # This section intentionally left blank"
-    , ""
-    , "    # ----------------------------------------------------------------------"
-    , "    # Events"
-    , "    # ----------------------------------------------------------------------"
-    , ""
-    ]
-    ++ violationEvents ++
-    [ ""
-    , "    # ----------------------------------------------------------------------"
-    , "    # Commands"
-    , "    # ----------------------------------------------------------------------"
-    , ""
-    , "    sync command CHECK_MONITORS()"
-    , ""
-    , "    # ----------------------------------------------------------------------"
-    , "    # Telemetry"
-    , "    # ----------------------------------------------------------------------"
-    , ""
-    , "    # This section intentionally left blank"
-    , ""
-    , "  }"
-    , ""
-    , "}"
-    ]
+    (typePorts, inputPorts, violationEvents)
   where
 
-    typePorts = nub $ sort $ map toTypePort variables
+    typePorts = unlines' $ nub $ sort $ map toTypePort variables
     toTypePort varDecl = "    port "
                        ++ fprimeVarDeclType varDecl
                        ++ "Value(value: "
                        ++ fprimeVarDeclType varDecl
                        ++ ")"
 
-    inputPorts = map toInputPortDecl variables
+    inputPorts = unlines' $ map toInputPortDecl variables
     toInputPortDecl varDecl = "    async input port "
                             ++ varDeclName varDecl
                             ++ "In : " ++ fprimeVarDeclType varDecl
@@ -385,7 +313,8 @@ componentInterface variables monitors =
       "double"   -> "F64"
       def        -> def
 
-    violationEvents = intercalate [""]
+    violationEvents = unlines'
+                    $ intercalate [""]
                     $ map violationEvent monitors
     violationEvent monitor =
         [ "    @ " ++ monitor ++ " violation"
@@ -401,78 +330,11 @@ componentInterface variables monitors =
 -- | Return the contents of the FPrime component header file.
 componentHeader :: [VarDecl]
                 -> [String]     -- Monitors
-                -> [String]
-componentHeader variables _monitors =
-    [ "// ======================================================================"
-    , "// \\title  Copilot.hpp"
-    , "// \\author root"
-    , "// \\brief  hpp file for Copilot component implementation class"
-    , "// ======================================================================"
-    , ""
-    , "#ifndef Copilot_HPP"
-    , "#define Copilot_HPP"
-    , ""
-    , "#include \"Ref/Copilot/CopilotComponentAc.hpp\""
-    , ""
-    , "namespace Ref {"
-    , ""
-    , "  class Copilot :"
-    , "    public CopilotComponentBase"
-    , "  {"
-    , ""
-    , "    public:"
-    , ""
-    , "      // ----------------------------------------------------------------------"
-    , "      // Construction, initialization, and destruction"
-    , "      // ----------------------------------------------------------------------"
-    , ""
-    , "      //! Construct object Copilot"
-    , "      //!"
-    , "      Copilot("
-    , "          const char *const compName /*!< The component name*/"
-    , "      );"
-    , ""
-    , "      //! Initialize object Copilot"
-    , "      //!"
-    , "      void init("
-    , "          const NATIVE_INT_TYPE queueDepth, /*!< The queue depth*/"
-    , "          const NATIVE_INT_TYPE instance = 0 /*!< The instance number*/"
-    , "      );"
-    , ""
-    , "      //! Destroy object Copilot"
-    , "      //!"
-    , "      ~Copilot();"
-    , ""
-    , "    PRIVATE:"
-    , ""
-    , "      // ----------------------------------------------------------------------"
-    , "      // Handler implementations for user-defined typed input ports"
-    , "      // ----------------------------------------------------------------------"
-    , ""
-    ]
-    ++ handlers ++
-    [ ""
-    , "    PRIVATE:"
-    , ""
-    , "      // ----------------------------------------------------------------------"
-    , "      // Command handler implementations"
-    , "      // ----------------------------------------------------------------------"
-    , ""
-    , "      //! Implementation for CHECK_MONITORS command handler"
-    , "      //! "
-    , "      void CHECK_MONITORS_cmdHandler("
-    , "          const FwOpcodeType opCode, /*!< The opcode*/"
-    , "          const U32 cmdSeq /*!< The command sequence number*/"
-    , "      );"
-    , ""
-    , "    };"
-    , ""
-    , "} // end namespace Ref"
-    , ""
-    , "#endif"
-    ]
+                -> String
+componentHeader variables _monitors = handlers
   where
-    handlers = intercalate [""]
+    handlers = unlines'
+             $ intercalate [""]
              $ map toInputHandler variables
     toInputHandler nm =
         [ "      //! Handler implementation for " ++ varDeclName nm ++ "In"
@@ -489,103 +351,29 @@ componentHeader variables _monitors =
 -- | Return the contents of the main FPrime component.
 componentImpl :: [VarDecl]
               -> [String]     -- Monitors
-              -> [String]
+              -> (String, String, String, String, String, String)
 componentImpl variables monitors =
-    [ "// ======================================================================"
-    , "// \\title  Copilot.cpp"
-    , "// \\author Ogma"
-    , "// \\brief  cpp file for Copilot component implementation class"
-    , "// ======================================================================"
-    , ""
-    , ""
-    , "#include <Ref/Copilot/Copilot.hpp>"
-    , "#include \"Fw/Types/BasicTypes.hpp\""
-    , ""
-    , "#ifdef __cplusplus"
-    , "extern \"C\" {"
-    , "#endif"
-    , ""
-    , "#include \"copilot.h\""
-    , "#include \"copilot_types.h\""
-    , ""
-    , "#ifdef __cplusplus"
-    , "}"
-    , "#endif"
-    , ""
-    ]
-    ++ inputs
-    ++ monitorResults ++
-    [ ""
-    , "namespace Ref {"
-    , ""
-    , "  // ----------------------------------------------------------------------"
-    , "  // Construction, initialization, and destruction"
-    , "  // ----------------------------------------------------------------------"
-    , ""
-    , "  Copilot ::"
-    , "    Copilot("
-    , "        const char *const compName"
-    , "    ) : CopilotComponentBase(compName)"
-    , "  {"
-    , ""
-    , "  }"
-    , ""
-    , "  void Copilot ::"
-    , "    init("
-    , "        const NATIVE_INT_TYPE queueDepth,"
-    , "        const NATIVE_INT_TYPE instance"
-    , "    )"
-    , "  {"
-    , "    CopilotComponentBase::init(queueDepth, instance);"
-    , "  }"
-    , ""
-    , "  Copilot ::"
-    , "    ~Copilot()"
-    , "  {"
-    , ""
-    , "  }"
-    , ""
-    , "  // ----------------------------------------------------------------------"
-    , "  // Handler implementations for user-defined typed input ports"
-    , "  // ----------------------------------------------------------------------"
-    , ""
-    ]
-    ++ inputHandlers ++
-    [ ""
-    , "  // ----------------------------------------------------------------------"
-    , "  // Command handler implementations"
-    , "  // ----------------------------------------------------------------------"
-    , ""
-    , "  void Copilot ::"
-    , "    CHECK_MONITORS_cmdHandler("
-    , "        const FwOpcodeType opCode,"
-    , "        const U32 cmdSeq"
-    , "    )"
-    , "  {"
-    ]
-    ++ triggerResultReset ++
-    [ "    step();"
-    , "    this->cmdResponse_out(opCode,cmdSeq,Fw::CmdResponse::OK);"
-    ]
-    ++ triggerChecks ++
-    [ "  }"
-    , ""
-    , "} // end namespace Ref"
-    , ""
-    ]
-    ++ triggers
+    ( inputs
+    , monitorResults
+    , inputHandlers
+    , triggerResultReset
+    , triggerChecks
+    , triggers
+    )
 
   where
 
-    inputs = variablesS
+    inputs = unlines' variablesS
 
-    monitorResults = intercalate [""]
+    monitorResults = unlines'
+                   $ intercalate [""]
                    $ map monitorResult monitors
     monitorResult monitor =
         [ "bool " ++ monitor ++ "_result;"
         ]
 
-    inputHandlers = intercalate [""]
+    inputHandlers = unlines'
+                  $ intercalate [""]
                   $ map toInputHandler variables
     toInputHandler nm =
         [ "  void Copilot :: "
@@ -601,13 +389,15 @@ componentImpl variables monitors =
         portTy = varDeclType nm
         ty     = varDeclType nm
 
-    triggerResultReset = intercalate [""]
+    triggerResultReset = unlines'
+                       $ intercalate [""]
                        $ map monitorResultReset monitors
     monitorResultReset monitor =
         [ "    " ++ monitor ++ "_result = false;"
         ]
 
-    triggerChecks = intercalate [""]
+    triggerChecks = unlines'
+                  $ intercalate [""]
                   $ map triggerCheck monitors
     triggerCheck monitor =
         [ "    if (" ++ monitor ++ "_result) {"
@@ -617,8 +407,9 @@ componentImpl variables monitors =
       where
         ucMonitor = map toUpper monitor
 
-    triggers :: [String]
-    triggers = intercalate [""]
+    triggers :: String
+    triggers = unlines'
+             $ intercalate [""]
              $ map triggerImpl monitors
     triggerImpl monitor =
         [ "void " ++ monitor ++ "() {"
@@ -753,3 +544,11 @@ fretFormat = JSONFormat
   , specRequirementDesc = Just ".fretish"
   , specRequirementExpr = ".ptLTL"
   }
+
+-- * Auxliary functions
+
+-- | Create a string from a list of strings, inserting new line characters
+-- between them. Unlike 'Prelude.unlines', this function does not insert
+-- an end of line character at the end of the last string.
+unlines' :: [String] -> String
+unlines' = intercalate "\n"

--- a/ogma-core/templates/fprime/Copilot.cpp
+++ b/ogma-core/templates/fprime/Copilot.cpp
@@ -1,0 +1,78 @@
+// ======================================================================
+// \title  Copilot.cpp
+// \author Ogma
+// \brief  cpp file for Copilot component implementation class
+// ======================================================================
+
+
+#include <Ref/Copilot/Copilot.hpp>
+#include "Fw/Types/BasicTypes.hpp"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "copilot.h"
+#include "copilot_types.h"
+
+#ifdef __cplusplus
+}
+#endif
+
+{{{implInputs}}}
+{{{implMonitorResults}}}
+
+namespace Ref {
+
+  // ----------------------------------------------------------------------
+  // Construction, initialization, and destruction
+  // ----------------------------------------------------------------------
+
+  Copilot ::
+    Copilot(
+        const char *const compName
+    ) : CopilotComponentBase(compName)
+  {
+
+  }
+
+  void Copilot ::
+    init(
+        const NATIVE_INT_TYPE queueDepth,
+        const NATIVE_INT_TYPE instance
+    )
+  {
+    CopilotComponentBase::init(queueDepth, instance);
+  }
+
+  Copilot ::
+    ~Copilot()
+  {
+
+  }
+
+  // ----------------------------------------------------------------------
+  // Handler implementations for user-defined typed input ports
+  // ----------------------------------------------------------------------
+
+{{{implInputHandlers}}}
+
+  // ----------------------------------------------------------------------
+  // Command handler implementations
+  // ----------------------------------------------------------------------
+
+  void Copilot ::
+    CHECK_MONITORS_cmdHandler(
+        const FwOpcodeType opCode,
+        const U32 cmdSeq
+    )
+  {
+{{{implTriggerResultReset}}}
+    step();
+    this->cmdResponse_out(opCode,cmdSeq,Fw::CmdResponse::OK);
+{{{implTriggerChecks}}}
+  }
+
+} // end namespace Ref
+
+{{{implTriggers}}}

--- a/ogma-core/templates/fprime/Copilot.fpp
+++ b/ogma-core/templates/fprime/Copilot.fpp
@@ -1,0 +1,71 @@
+module Ref {
+
+{{{ifaceTypePorts}}}
+
+  @ Monitoring component
+  queued component Copilot {
+
+    # ----------------------------------------------------------------------
+    # General ports
+    # ----------------------------------------------------------------------
+
+{{{ifaceInputPorts}}}
+
+    # ----------------------------------------------------------------------
+    # Special ports
+    # ----------------------------------------------------------------------
+
+    @ Command receive
+    command recv port cmdIn
+
+    @ Command registration
+    command reg port cmdRegOut
+
+    @ Command response
+    command resp port cmdResponseOut
+
+    @ Event
+    event port eventOut
+
+    @ Parameter get
+    param get port prmGetOut
+
+    @ Parameter set
+    param set port prmSetOut
+
+    @ Telemetry
+    telemetry port tlmOut
+
+    @ Text event
+    text event port textEventOut
+
+    @ Time get
+    time get port timeGetOut
+
+    # ----------------------------------------------------------------------
+    # Parameters
+    # ----------------------------------------------------------------------
+
+    # This section intentionally left blank
+
+    # ----------------------------------------------------------------------
+    # Events
+    # ----------------------------------------------------------------------
+
+{{{ifaceViolationEvents}}}
+
+    # ----------------------------------------------------------------------
+    # Commands
+    # ----------------------------------------------------------------------
+
+    sync command CHECK_MONITORS()
+
+    # ----------------------------------------------------------------------
+    # Telemetry
+    # ----------------------------------------------------------------------
+
+    # This section intentionally left blank
+
+  }
+
+}

--- a/ogma-core/templates/fprime/Copilot.hpp
+++ b/ogma-core/templates/fprime/Copilot.hpp
@@ -1,0 +1,66 @@
+// ======================================================================
+// \title  Copilot.hpp
+// \author root
+// \brief  hpp file for Copilot component implementation class
+// ======================================================================
+
+#ifndef Copilot_HPP
+#define Copilot_HPP
+
+#include "Ref/Copilot/CopilotComponentAc.hpp"
+
+namespace Ref {
+
+  class Copilot :
+    public CopilotComponentBase
+  {
+
+    public:
+
+      // ----------------------------------------------------------------------
+      // Construction, initialization, and destruction
+      // ----------------------------------------------------------------------
+
+      //! Construct object Copilot
+      //!
+      Copilot(
+          const char *const compName /*!< The component name*/
+      );
+
+      //! Initialize object Copilot
+      //!
+      void init(
+          const NATIVE_INT_TYPE queueDepth, /*!< The queue depth*/
+          const NATIVE_INT_TYPE instance = 0 /*!< The instance number*/
+      );
+
+      //! Destroy object Copilot
+      //!
+      ~Copilot();
+
+    PRIVATE:
+
+      // ----------------------------------------------------------------------
+      // Handler implementations for user-defined typed input ports
+      // ----------------------------------------------------------------------
+
+{{{hdrHandlers}}}
+
+    PRIVATE:
+
+      // ----------------------------------------------------------------------
+      // Command handler implementations
+      // ----------------------------------------------------------------------
+
+      //! Implementation for CHECK_MONITORS command handler
+      //! 
+      void CHECK_MONITORS_cmdHandler(
+          const FwOpcodeType opCode, /*!< The opcode*/
+          const U32 cmdSeq /*!< The command sequence number*/
+      );
+
+    };
+
+} // end namespace Ref
+
+#endif

--- a/ogma-extra/CHANGELOG.md
+++ b/ogma-extra/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Revision history for ogma-extra
 
+## [1.X.Y] - 2024-12-05
+
+* Deprecate unnecessary functions (#185).
+
 ## [1.5.0] - 2024-11-21
 
 * Version bump 1.5.0 (#178).

--- a/ogma-extra/src/System/Directory/Extra.hs
+++ b/ogma-extra/src/System/Directory/Extra.hs
@@ -56,6 +56,7 @@ import           Text.Microstache          ( compileMustacheFile,
                                              compileMustacheText,
                                              renderMustache )
 
+{-# DEPRECATED copyDirectoryRecursive "This function is deprecated in ogma-extra-1.6.0." #-}
 -- | Copy all files from one directory to another.
 copyDirectoryRecursive :: FilePath  -- ^ Source directory
                        -> FilePath  -- ^ Target directory
@@ -74,6 +75,7 @@ copyDirectoryRecursive sourceDir targetDir =
     -- Copy all the files, replacing the top directory.
     mapM_ (copyFile' . sourceAndDest) files
 
+{-# DEPRECATED copyFile' "This function is deprecated in ogma-extra-1.6.0." #-}
 -- | Copy file origin to dest, creating the target directory if it does not
 -- exist.
 copyFile' :: (FilePath, FilePath) -> IO ()


### PR DESCRIPTION
Adjust `ogma-cli` and `ogma-core` to allow customizing the F' monitoring component by using custom-provided templates, as prescribed in the solution proposed for #185 .