### PR TITLE
Add version bounds to all dependencies in cabal packages. Refs #119.

### DIFF
--- a/ogma-cli/CHANGELOG.md
+++ b/ogma-cli/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Provide ability to customize template in fprime command (#185).
 * Provide ability to customize template in standalone command (#189).
 * Add repository information to cabal package (#148).
+* Add version bounds to all dependencies (#119).
 
 ## [1.5.0] - 2024-11-21
 

--- a/ogma-cli/ogma-cli.cabal
+++ b/ogma-cli/ogma-cli.cabal
@@ -139,7 +139,7 @@ executable ogma
 
   build-depends:
       base                 >= 4.11.0.0 && < 5
-    , optparse-applicative
+    , optparse-applicative >= 0.14     && < 0.19
     , ogma-core            >= 1.5.0 && < 1.6
 
   hs-source-dirs:
@@ -160,11 +160,11 @@ test-suite test-ogma
 
   build-depends:
       base                 >= 4.11.0.0 && < 5
-    , HUnit
-    , process
-    , test-framework
-    , test-framework-hunit
-    , unix
+    , HUnit                >= 1.2.0.0  && < 1.7
+    , process              >= 1.6      && < 1.7
+    , test-framework       >= 0.8.2    && < 0.9
+    , test-framework-hunit >= 0.2.0    && < 0.4
+    , unix                 >= 2.7.2.2  && < 2.9
 
   hs-source-dirs:
     tests

--- a/ogma-core/CHANGELOG.md
+++ b/ogma-core/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Use template expansion system to generate F' monitoring component (#185).
 * Use template expansion system to generate standalone Copilot monitor (#189).
 * Add repository information to cabal package (#148).
+* Add version bounds to all dependencies (#119).
 
 ## [1.5.0] - 2024-11-21
 

--- a/ogma-core/ogma-core.cabal
+++ b/ogma-core/ogma-core.cabal
@@ -119,9 +119,9 @@ library
   build-depends:
       base                    >= 4.11.0.0 && < 5
     , aeson                   >= 2.0.0.0  && < 2.2
-    , bytestring
-    , filepath
-    , mtl
+    , bytestring              >= 0.10.8.2 && < 0.13
+    , filepath                >= 1.4.2    && < 1.6
+    , mtl                     >= 2.2.2    && < 2.4
     , text                    >= 1.2.3.1  && < 2.1
 
     , ogma-extra              >= 1.5.0 && < 1.6
@@ -149,13 +149,13 @@ test-suite unit-tests
     Main.hs
 
   build-depends:
-      base
-    , directory
-    , HUnit
-    , QuickCheck
-    , test-framework
-    , test-framework-hunit
-    , test-framework-quickcheck2
+      base                       >= 4.11.0.0 && < 5
+    , directory                  >= 1.3.1.5  && < 1.4
+    , HUnit                      >= 1.2.0.0  && < 1.7
+    , QuickCheck                 >= 2.8.2    && < 2.16
+    , test-framework             >= 0.8.2    && < 0.9
+    , test-framework-hunit       >= 0.2.0    && < 0.4
+    , test-framework-quickcheck2 >= 0.3.0.4  && < 0.4
 
     , ogma-core
 

--- a/ogma-extra/CHANGELOG.md
+++ b/ogma-extra/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Deprecate unnecessary functions (#185).
 * Add repository information to cabal package (#148).
+* Add version bounds to all dependencies (#119).
 
 ## [1.5.0] - 2024-11-21
 

--- a/ogma-extra/ogma-extra.cabal
+++ b/ogma-extra/ogma-extra.cabal
@@ -76,10 +76,10 @@ library
   build-depends:
       base        >= 4.11.0.0 && < 5
     , aeson       >= 2.0.0.0  && < 2.2
-    , bytestring
-    , Cabal
-    , directory
-    , filepath
+    , bytestring  >= 0.10.8.2 && < 0.13
+    , Cabal       >= 2.2.0.0  && < 3.9
+    , directory   >= 1.3.1.5  && < 1.4
+    , filepath    >= 1.4.2    && < 1.6
     , microstache >= 1.0      && < 1.1
     , text        >= 1.2.3.1  && < 2.1
 
@@ -100,10 +100,10 @@ test-suite unit-tests
     Main.hs
 
   build-depends:
-      base
-    , QuickCheck
-    , test-framework
-    , test-framework-quickcheck2
+      base                       >= 4.11.0.0 && < 5
+    , QuickCheck                 >= 2.8.2    && < 2.16
+    , test-framework             >= 0.8.2    && < 0.9
+    , test-framework-quickcheck2 >= 0.3.0.4  && < 0.4
 
     , ogma-extra
 

--- a/ogma-language-c/CHANGELOG.md
+++ b/ogma-language-c/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [1.X.Y] - 2024-12-24
 
 * Add repository information to cabal package (#148).
+* Add version bounds to all dependencies (#119).
 
 ## [1.5.0] - 2024-11-21
 

--- a/ogma-language-c/ogma-language-c.cabal
+++ b/ogma-language-c/ogma-language-c.cabal
@@ -71,8 +71,8 @@ custom-setup
   setup-depends:
       base    >= 4.11.0.0 && < 5
     , Cabal   >= 2.0 && < 3.9
-    , process
-    , BNFC    >= 2.9.1
+    , process >= 1.6      && < 1.7
+    , BNFC    >= 2.9.1    && < 2.10
 
 library
 
@@ -91,7 +91,7 @@ library
 
   build-depends:
       base  >= 4.11.0.0 && < 5
-    , array >= 0.5.2.0
+    , array >= 0.5.2.0  && < 0.6
 
   hs-source-dirs:
     src
@@ -108,9 +108,9 @@ test-suite unit-tests
 
   build-depends:
       base                       >= 4.11.0.0 && < 5
-    , QuickCheck
-    , test-framework
-    , test-framework-quickcheck2
+    , QuickCheck                 >= 2.8.2    && < 2.16
+    , test-framework             >= 0.8.2    && < 0.9
+    , test-framework-quickcheck2 >= 0.3.0.4  && < 0.4
 
     , ogma-language-c
 

--- a/ogma-language-cocospec/CHANGELOG.md
+++ b/ogma-language-cocospec/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [1.X.Y] - 2024-12-24
 
 * Add repository information to cabal package (#148).
+* Add version bounds to all dependencies (#119).
 
 ## [1.5.0] - 2024-11-21
 

--- a/ogma-language-cocospec/ogma-language-cocospec.cabal
+++ b/ogma-language-cocospec/ogma-language-cocospec.cabal
@@ -72,8 +72,8 @@ custom-setup
   setup-depends:
       base    >= 4.11.0.0 && < 5
     , Cabal   >= 2.0 && < 3.9
-    , process
-    , BNFC    >= 2.9.1
+    , process >= 1.6      && < 1.7
+    , BNFC    >= 2.9.1    && < 2.10
 
 library
 
@@ -92,7 +92,7 @@ library
 
   build-depends:
       base  >= 4.11.0.0 && < 5
-    , array >= 0.5.2.0
+    , array >= 0.5.2.0  && < 0.6
 
   hs-source-dirs:
     src
@@ -109,9 +109,9 @@ test-suite unit-tests
 
   build-depends:
       base                       >= 4.11.0.0 && < 5
-    , QuickCheck
-    , test-framework
-    , test-framework-quickcheck2
+    , QuickCheck                 >= 2.8.2    && < 2.16
+    , test-framework             >= 0.8.2    && < 0.9
+    , test-framework-quickcheck2 >= 0.3.0.4  && < 0.4
 
     , ogma-language-cocospec
 

--- a/ogma-language-jsonspec/CHANGELOG.md
+++ b/ogma-language-jsonspec/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [1.X.Y] - 2024-12-24
 
 * Add repository information to cabal package (#148).
+* Add version bounds to all dependencies (#119).
 
 ## [1.5.0] - 2024-11-21
 

--- a/ogma-language-jsonspec/ogma-language-jsonspec.cabal
+++ b/ogma-language-jsonspec/ogma-language-jsonspec.cabal
@@ -72,9 +72,9 @@ library
       base                   >= 4.11.0.0 && < 5
     , aeson                  >= 2.0.0.0  && < 2.2
     , jsonpath               >= 0.3      && < 0.4
-    , text
-    , megaparsec
-    , bytestring
+    , text                   >= 1.2.3.1  && < 2.1
+    , megaparsec             >= 8.0.0    && < 9.10
+    , bytestring             >= 0.10.8.2 && < 0.13
 
     , ogma-spec              >= 1.5.0 && < 1.6
 

--- a/ogma-language-smv/CHANGELOG.md
+++ b/ogma-language-smv/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [1.X.Y] - 2024-12-24
 
 * Add repository information to cabal package (#148).
+* Add version bounds to all dependencies (#119).
 
 ## [1.5.0] - 2024-11-21
 

--- a/ogma-language-smv/ogma-language-smv.cabal
+++ b/ogma-language-smv/ogma-language-smv.cabal
@@ -72,8 +72,8 @@ custom-setup
   setup-depends:
       base    >= 4.11.0.0 && < 5
     , Cabal   >= 2.0 && < 3.9
-    , process
-    , BNFC    >= 2.9.1
+    , process >= 1.6      && < 1.7
+    , BNFC    >= 2.9.1    && < 2.10
 
 library
 
@@ -93,7 +93,7 @@ library
 
   build-depends:
       base  >= 4.11.0.0 && < 5
-    , array >= 0.5.2.0
+    , array >= 0.5.2.0  && < 0.6
 
   hs-source-dirs:
     src
@@ -110,9 +110,9 @@ test-suite unit-tests
 
   build-depends:
       base                       >= 4.11.0.0 && < 5
-    , QuickCheck
-    , test-framework
-    , test-framework-quickcheck2
+    , QuickCheck                 >= 2.8.2    && < 2.16
+    , test-framework             >= 0.8.2    && < 0.9
+    , test-framework-quickcheck2 >= 0.3.0.4  && < 0.4
 
     , ogma-language-smv
 


### PR DESCRIPTION
Add version bounds to all dependencies in the cabal packages, as prescribed in the solution proposed for #119 .

The version bounds are chosen so that Ogma can be installed with GHC 8.4.4, the lowest version supported based on the existing constraints on `base`, and GHC 9.4.8, the highest version supported (based on constraints to other packages, as well as the specifics of the current implementation).