### PR TITLE
`ogma-cli`: Provide ability to preprocess properties via external command. Refs #197.

### DIFF
--- a/ogma-cli/CHANGELOG.md
+++ b/ogma-cli/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Revision history for ogma-cli
 
-## [1.X.Y] - 2025-01-10
+## [1.X.Y] - 2025-01-14
 
 * Update contribution guidelines (#161).
 * Provide ability to customize template in fprime command (#185).
@@ -8,6 +8,7 @@
 * Add repository information to cabal package (#148).
 * Add version bounds to all dependencies (#119).
 * Introduce new diagram command (#194).
+* Provide ability to preprocess properties via external command (#197).
 
 ## [1.5.0] - 2024-11-21
 

--- a/ogma-cli/src/CLI/CommandStandalone.hs
+++ b/ogma-cli/src/CLI/CommandStandalone.hs
@@ -65,6 +65,7 @@ data CommandOpts = CommandOpts
   , standalonePropFormat  :: String
   , standaloneTypes       :: [String]
   , standaloneTarget      :: String
+  , standalonePropVia     :: Maybe String
   }
 
 -- | Transform an input specification into a Copilot specification.
@@ -79,6 +80,7 @@ command c = standalone (standaloneFileName c) internalCommandOpts
       , Command.Standalone.standalonePropFormat  = standalonePropFormat c
       , Command.Standalone.standaloneTypeMapping = types
       , Command.Standalone.standaloneFilename    = standaloneTarget c
+      , Command.Standalone.standalonePropVia     = standalonePropVia c
       }
 
     types :: [(String, String)]
@@ -150,6 +152,13 @@ commandOptsParser = CommandOpts
         <> showDefault
         <> value "monitor"
         )
+  <*> optional
+        ( strOption
+            (  long "parse-prop-via"
+            <> metavar "COMMAND"
+            <> help strStandalonePropViaDesc
+            )
+        )
 
 -- | Target dir flag description.
 strStandaloneTargetDirDesc :: String
@@ -179,6 +188,11 @@ strStandaloneMapTypeDesc = "Map a type to another type"
 strStandaloneTargetDesc :: String
 strStandaloneTargetDesc =
   "Filename prefix for monitoring files in target language"
+
+-- | External command to pre-process individual properties.
+strStandalonePropViaDesc :: String
+strStandalonePropViaDesc =
+  "Command to pre-process individual properties"
 
 -- * Error codes
 

--- a/ogma-core/CHANGELOG.md
+++ b/ogma-core/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Revision history for ogma-core
 
-## [1.X.Y] - 2025-01-10
+## [1.X.Y] - 2025-01-14
 
 * Replace queueSize with QUEUE_SIZE in FPP file (#186).
 * Use template expansion system to generate F' monitoring component (#185).
@@ -8,6 +8,7 @@
 * Add repository information to cabal package (#148).
 * Add version bounds to all dependencies (#119).
 * Add command to transform state diagrams into monitors (#194).
+* Extend standalone command to use external process to parse properties (#197).
 
 ## [1.5.0] - 2024-11-21
 

--- a/ogma-core/ogma-core.cabal
+++ b/ogma-core/ogma-core.cabal
@@ -127,6 +127,7 @@ library
     , graphviz                >= 2999.20  && < 2999.21
     , megaparsec              >= 8.0.0    && < 9.10
     , mtl                     >= 2.2.2    && < 2.4
+    , process                 >= 1.6      && < 1.7
     , text                    >= 1.2.3.1  && < 2.1
 
     , ogma-extra              >= 1.5.0 && < 1.6

--- a/ogma-core/src/Command/ROSApp.hs
+++ b/ogma-core/src/Command/ROSApp.hs
@@ -45,8 +45,8 @@ module Command.ROSApp
 
 -- External imports
 import qualified Control.Exception    as E
-import           Control.Monad.Except (ExceptT, liftEither, liftIO, runExceptT,
-                                       throwError)
+import           Control.Monad.Except (ExceptT(..), liftEither, liftIO,
+                                       runExceptT, throwError)
 import           Data.Aeson           (eitherDecode, object, (.=))
 import           Data.List            (find, intersperse)
 import           Data.Maybe           (fromMaybe)
@@ -176,12 +176,15 @@ parseOptionalFRETCS Nothing   = return Nothing
 parseOptionalFRETCS (Just fp) = do
   -- Throws an exception if the file cannot be read.
   content <- liftIO $ B.safeReadFile fp
-  let fretCS :: Either String (Spec String)
-      fretCS = parseJSONSpec return fretFormat =<< eitherDecode =<< content
 
-  case fretCS of
-    Left e   -> throwError $ cannotOpenFRETFile fp e
-    Right cs -> return $ Just cs
+  fretCS <- case eitherDecode =<< content of
+              Left e  -> ExceptT $ return $ Left $ cannotOpenFRETFile fp e
+              Right v -> ExceptT $ do
+                           p <- parseJSONSpec (return . return) fretFormat v
+                           case p of
+                             Left e  -> return $ Left $ cannotOpenFRETFile fp e
+                             Right r -> return $ Right r
+  return $ Just fretCS
 
 -- | Process a variable selection file, if available, and return the variable
 -- names.

--- a/ogma-core/tests/Main.hs
+++ b/ogma-core/tests/Main.hs
@@ -110,6 +110,7 @@ testFretComponentSpec2Copilot file success = do
                  , standaloneFilename    = "fret"
                  , standaloneTargetDir   = targetDir
                  , standaloneTemplateDir = Nothing
+                 , standalonePropVia     = Nothing
                  }
     result <- standalone file opts
 
@@ -145,6 +146,7 @@ testFretReqsDBCoCoSpec2Copilot file success = do
                  , standaloneFilename    = "fret"
                  , standaloneTargetDir   = targetDir
                  , standaloneTemplateDir = Nothing
+                 , standalonePropVia     = Nothing
                  }
     result <- standalone file opts
 

--- a/ogma-language-jsonspec/CHANGELOG.md
+++ b/ogma-language-jsonspec/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Revision history for ogma-language-jsonspec
 
-## [1.X.Y] - 2024-12-24
+## [1.X.Y] - 2025-01-14
 
 * Add repository information to cabal package (#148).
 * Add version bounds to all dependencies (#119).
+* Extend JSON spec parser to use an IO action to parse properties (#197).
 
 ## [1.5.0] - 2024-11-21
 

--- a/ogma-language-jsonspec/ogma-language-jsonspec.cabal
+++ b/ogma-language-jsonspec/ogma-language-jsonspec.cabal
@@ -74,6 +74,7 @@ library
     , jsonpath               >= 0.3      && < 0.4
     , text                   >= 1.2.3.1  && < 2.1
     , megaparsec             >= 8.0.0    && < 9.10
+    , mtl                    >= 2.2.2    && < 2.4
     , bytestring             >= 0.10.8.2 && < 0.13
 
     , ogma-spec              >= 1.5.0 && < 1.6


### PR DESCRIPTION
Extend Ogma with the ability to preprocess properties by using a user-provided tool, as prescribed in the solution proposed for #197.