### PR TITLE
`ogma-core`: Enable using user-provided file as format definition spec. Refs #200.

### DIFF
--- a/ogma-core/CHANGELOG.md
+++ b/ogma-core/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Revision history for ogma-core
 
-## [1.X.Y] - 2025-01-14
+## [1.X.Y] - 2025-01-19
 
 * Replace queueSize with QUEUE_SIZE in FPP file (#186).
 * Use template expansion system to generate F' monitoring component (#185).
@@ -9,6 +9,7 @@
 * Add version bounds to all dependencies (#119).
 * Add command to transform state diagrams into monitors (#194).
 * Extend standalone command to use external process to parse properties (#197).
+* Enable using user-provided file as format definition spec (#200).
 
 ## [1.5.0] - 2024-11-21
 

--- a/ogma-core/ogma-core.cabal
+++ b/ogma-core/ogma-core.cabal
@@ -123,6 +123,7 @@ library
     , aeson                   >= 2.0.0.0  && < 2.2
     , bytestring              >= 0.10.8.2 && < 0.13
     , containers              >= 0.5      && < 0.8
+    , directory               >= 1.3.1.5  && < 1.4
     , filepath                >= 1.4.2    && < 1.6
     , graphviz                >= 2999.20  && < 2999.21
     , megaparsec              >= 8.0.0    && < 9.10


### PR DESCRIPTION
Modify `ogma-core`'s standalone backend to treat the format name as a local file name when applicable, as prescribed in the solution proposed for #200.