### PR TITLE
`ogma-cli`: Add all auxiliary test files to distributable Cabal package. Refs #216.

### DIFF
--- a/ogma-cli/CHANGELOG.md
+++ b/ogma-cli/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Revision history for ogma-cli
 
+## [1.X.Y] - 2025-01-25
+
+* Add all auxiliary test files to distributable Cabal package (#216).
+
 ## [1.6.0] - 2025-01-21
 
 * Version bump 1.6.0 (#208).

--- a/ogma-cli/ogma-cli.cabal
+++ b/ogma-cli/ogma-cli.cabal
@@ -114,6 +114,11 @@ description:         Ogma is a tool to facilitate the integration of safe runtim
                      .
                      - "<https://shemesh.larc.nasa.gov/people/cam/publications/FMAS2020_3.pdf From Requirements to Autonomous Flight>", Dutle et al. 2020.
 
+extra-source-files:  tests/fcs-example1.json
+                     tests/fdb-example1.json
+                     tests/reduced_geofence_msgs.h
+                     tests/reduced_geofence_msgs_bad.h
+
 -- Ogma packages should be uncurated so that only the official maintainers make
 -- changes.
 --

--- a/ogma-cli/tests/Main.hs
+++ b/ogma-cli/tests/Main.hs
@@ -48,7 +48,7 @@ tests =
   , testCase "cli-cmd-standalone-fail" (runErrorCode ["standalone", "--incorrect-argument"] False)
     -- Should fail due to arguments being incorrect
 
-  , testCase "cli-cmd-standalone-fcs" (parseStandaloneFCS "examples/fcs-2.json" True)
+  , testCase "cli-cmd-standalone-fcs" (parseStandaloneFCS "tests/fcs-example1.json" True)
     -- Should pass
 
   , testCase "cli-cmd-standalone-file-not-found" (parseStandaloneFCS "tests/file-invalid.json" False)

--- a/ogma-cli/tests/fcs-example1.json
+++ b/ogma-cli/tests/fcs-example1.json
@@ -1,0 +1,21 @@
+{
+  "RTSASpec": {
+    "Internal_variables": [],
+    "Other_variables": [
+      {"name":"param_is_short", "type":"bool"},
+      {"name":"param_value_short", "type":"real"},
+      {"name":"param_value_long", "type":"real"},
+      {"name":"upper_param_limit", "type":"real"},
+      {"name":"lower_param_limit", "type":"real"},
+      {"name":"envelope_issue", "type":"bool"}
+    ],
+    "Requirements": [
+      {
+        "name": "behnazOne",
+        "CoCoSpecCode": "true",
+        "ptLTL": "((H ((((! <b><i>flight_mode</i></b>) & (Y <b><i>flight_mode</i></b>)) & (Y TRUE)) -> (Y (((O[=<b><i>10</i></b>] ((<b><i>(conflict_detected)</i></b> & ((Y (! <b><i>(conflict_detected)</i></b>)) | (<b><i>flight_mode</i></b> & ((! (Y TRUE)) | (Y (! <b><i>flight_mode</i></b>)))))) & (! <b><i>(( replanning_mode ))</i></b>))) -> (O[<<b><i>10</i></b>] ((<b><i>flight_mode</i></b> & ((! (Y TRUE)) | (Y (! <b><i>flight_mode</i></b>)))) | <b><i>(( replanning_mode ))</i></b>))) S (((O[=<b><i>10</i></b>] ((<b><i>(conflict_detected)</i></b> & ((Y (! <b><i>(conflict_detected)</i></b>)) | (<b><i>flight_mode</i></b> & ((! (Y TRUE)) | (Y (! <b><i>flight_mode</i></b>)))))) & (! <b><i>(( replanning_mode ))</i></b>))) -> (O[<<b><i>10</i></b>] ((<b><i>flight_mode</i></b> & ((! (Y TRUE)) | (Y (! <b><i>flight_mode</i></b>)))) | <b><i>(( replanning_mode ))</i></b>))) & (<b><i>flight_mode</i></b> & ((! (Y TRUE)) | (Y (! <b><i>flight_mode</i></b>))))))))) & (((! ((! <b><i>flight_mode</i></b>) & (Y <b><i>flight_mode</i></b>))) S ((! ((! <b><i>flight_mode</i></b>) & (Y <b><i>flight_mode</i></b>))) & (<b><i>flight_mode</i></b> & ((! (Y TRUE)) | (Y (! <b><i>flight_mode</i></b>)))))) -> (((O[=<b><i>10</i></b>] ((<b><i>(conflict_detected)</i></b> & ((Y (! <b><i>(conflict_detected)</i></b>)) | (<b><i>flight_mode</i></b> & ((! (Y TRUE)) | (Y (! <b><i>flight_mode</i></b>)))))) & (! <b><i>(( replanning_mode ))</i></b>))) -> (O[<<b><i>10</i></b>] ((<b><i>flight_mode</i></b> & ((! (Y TRUE)) | (Y (! <b><i>flight_mode</i></b>)))) | <b><i>(( replanning_mode ))</i></b>))) S (((O[=<b><i>10</i></b>] ((<b><i>(conflict_detected)</i></b> & ((Y (! <b><i>(conflict_detected)</i></b>)) | (<b><i>flight_mode</i></b> & ((! (Y TRUE)) | (Y (! <b><i>flight_mode</i></b>)))))) & (! <b><i>(( replanning_mode ))</i></b>))) -> (O[<<b><i>10</i></b>] ((<b><i>flight_mode</i></b> & ((! (Y TRUE)) | (Y (! <b><i>flight_mode</i></b>)))) | <b><i>(( replanning_mode ))</i></b>))) & (<b><i>flight_mode</i></b> & ((! (Y TRUE)) | (Y (! <b><i>flight_mode</i></b>))))))))",
+        "fretish": "Meaning not specified"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
This commit adds any examples needed by the tests to the `tests/` directory, adjust both the tests so that they can be located, and modifies the Cabal package to include all auxiliary test files in the Cabal source package, as prescribed in the solution proposed for #216.