### PR TITLE
`ogma-core`: Import `liftIO` from `Control.Monad.IO.Class`. Refs #215.

### DIFF
--- a/ogma-core/CHANGELOG.md
+++ b/ogma-core/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Revision history for ogma-core
 
+## [1.X.Y] - 2025-01-26
+
+* Import liftIO from Control.Monad.IO.Class (#215).
+
 ## [1.6.0] - 2025-01-21
 
 * Version bump 1.6.0 (#208).

--- a/ogma-core/src/Command/FPrimeApp.hs
+++ b/ogma-core/src/Command/FPrimeApp.hs
@@ -44,18 +44,19 @@ module Command.FPrimeApp
   where
 
 -- External imports
-import qualified Control.Exception    as E
-import           Control.Monad.Except ( ExceptT(..), liftEither, liftIO,
-                                        runExceptT, throwError )
-import           Data.Aeson           ( eitherDecode, object, (.=) )
-import           Data.Char            ( toUpper )
-import           Data.List            ( isInfixOf, isPrefixOf, find,
-                                        intercalate, nub, sort )
-import           Data.Maybe           ( fromMaybe )
-import           Data.Text.Lazy       ( pack )
-import           System.Directory     ( doesFileExist )
-import           System.FilePath      ( (</>) )
-import           System.Process       ( readProcess )
+import qualified Control.Exception      as E
+import           Control.Monad.Except   ( ExceptT(..), liftEither, runExceptT,
+                                          throwError )
+import           Control.Monad.IO.Class ( liftIO )
+import           Data.Aeson             ( eitherDecode, object, (.=) )
+import           Data.Char              ( toUpper )
+import           Data.List              ( isInfixOf, isPrefixOf, find,
+                                          intercalate, nub, sort )
+import           Data.Maybe             ( fromMaybe )
+import           Data.Text.Lazy         ( pack )
+import           System.Directory       ( doesFileExist )
+import           System.FilePath        ( (</>) )
+import           System.Process         ( readProcess )
 
 -- External imports: auxiliary
 import Data.ByteString.Extra  as B ( safeReadFile )

--- a/ogma-core/src/Command/ROSApp.hs
+++ b/ogma-core/src/Command/ROSApp.hs
@@ -48,16 +48,18 @@ module Command.ROSApp
   where
 
 -- External imports
-import qualified Control.Exception    as E
-import           Control.Monad.Except (ExceptT(..), liftEither, liftIO,
-                                       runExceptT, throwError)
-import           Data.Aeson           (eitherDecode, object, (.=))
-import           Data.List            (isInfixOf, isPrefixOf, find, intersperse)
-import           Data.Maybe           (fromMaybe)
-import           Data.Text.Lazy       (pack)
-import           System.Directory     (doesFileExist)
-import           System.FilePath      ((</>))
-import           System.Process       (readProcess)
+import qualified Control.Exception      as E
+import           Control.Monad.Except   (ExceptT (..), liftEither, runExceptT,
+                                         throwError)
+import           Control.Monad.IO.Class (liftIO)
+import           Data.Aeson             (eitherDecode, object, (.=))
+import           Data.List              (isInfixOf, isPrefixOf, find,
+                                         intersperse)
+import           Data.Maybe             (fromMaybe)
+import           Data.Text.Lazy         (pack)
+import           System.Directory       (doesFileExist)
+import           System.FilePath        ((</>))
+import           System.Process         (readProcess)
 
 -- External imports: auxiliary
 import Data.ByteString.Extra  as B (safeReadFile)


### PR DESCRIPTION
Replace all imports of `liftIO` from `Control.Monad.Except` with imports from `Control.Monad.IO.Class` in both `ogma-core:Command.ROSApp` and `ogma-core:Command.FPrimeApp`, as prescribed in the solution proposed for #215.