### PR TITLE
Remove references to old design of Ogma from config files, docs. Refs #220.

### DIFF
--- a/ogma-core/.hlint.yaml
+++ b/ogma-core/.hlint.yaml
@@ -3,8 +3,3 @@
 
 # Ignore in automatically generated files.
 - ignore: {within: [Paths_ogma_core]}
-
-# We use data instead of newtype for uniformity.
-- ignore: { name: Use newtype instead of data
-          , within: [ Command.FRETReqsDB2Copilot ]
-          }

--- a/ogma-core/CHANGELOG.md
+++ b/ogma-core/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Revision history for ogma-core
 
-## [1.X.Y] - 2025-01-26
+## [1.X.Y] - 2025-01-27
 
 * Import liftIO from Control.Monad.IO.Class (#215).
+* Remove references to old design of Ogma from hlint files (#220).
 
 ## [1.6.0] - 2025-01-21
 

--- a/ogma-language-cocospec/CHANGELOG.md
+++ b/ogma-language-cocospec/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Revision history for ogma-language-cocospec
 
+## [1.X.Y] - 2025-01-27
+
+* Remove references to old design of Ogma from documentation (#220).
+
 ## [1.6.0] - 2025-01-21
 
 * Version bump 1.6.0 (#208).

--- a/ogma-language-cocospec/ogma-language-cocospec.cabal
+++ b/ogma-language-cocospec/ogma-language-cocospec.cabal
@@ -53,8 +53,7 @@ description:         Ogma is a tool to facilitate the integration of safe runtim
                      <https://github.com/Copilot-Language/copilot Copilot>, a high-level runtime
                      verification framework that generates hard real-time C99 code.
                      .
-                     This library contains a frontend to read CoCoSpec Boolean expressions, used by
-                     the tool FRET to capture requirement specifications.
+                     This library contains a frontend to read CoCoSpec Boolean expressions.
 
 -- Ogma packages should be uncurated so that only the official maintainers make
 -- changes.

--- a/ogma-language-smv/CHANGELOG.md
+++ b/ogma-language-smv/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Revision history for ogma-language-smv
 
+## [1.X.Y] - 2025-01-27
+
+* Remove references to old design of Ogma from documentation (#220).
+
 ## [1.6.0] - 2025-01-21
 
 * Version bump 1.6.0 (#208).

--- a/ogma-language-smv/grammar/SMV.cf
+++ b/ogma-language-smv/grammar/SMV.cf
@@ -28,11 +28,9 @@
 -- FOR ANY SUCH MATTER SHALL BE THE IMMEDIATE, UNILATERAL TERMINATION OF THIS
 -- AGREEMENT.
 
--- This is a simplified grammar of SMV temporal logic expressions, extended
--- with the tags that FRET uses around names.
---
--- The format of FRET files itself uses JSON, so this grammar applies
--- only to specific fields in those files.
+-- This is a simplified grammar of SMV temporal logic expressions. This grammar
+-- allows for the presence of tags around some expressions, which some tools
+-- that produce SMV include in expressions.
 
 entrypoints BoolSpec;
 

--- a/ogma-language-smv/ogma-language-smv.cabal
+++ b/ogma-language-smv/ogma-language-smv.cabal
@@ -53,8 +53,7 @@ description:         Ogma is a tool to facilitate the integration of safe runtim
                      <https://github.com/Copilot-Language/copilot Copilot>, a high-level runtime
                      verification framework that generates hard real-time C99 code.
                      .
-                     This library contains a frontend to read SMV Boolean expressions, used by
-                     the tool FRET to capture requirement specifications.
+                     This library contains a frontend to read SMV Boolean expressions.
 
 -- Ogma packages should be uncurated so that only the official maintainers make
 -- changes.


### PR DESCRIPTION
This commit removes old references to an earlier design of Ogma from both documentation and configuration files, as prescribed in the solution proposed for #220.