### PR TITLE
Bump version bounds of dependencies on Cabal. Refs #213. 

### DIFF
--- a/ogma-extra/CHANGELOG.md
+++ b/ogma-extra/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Revision history for ogma-extra
 
+## [1.X.Y] - 2025-01-30
+* Bump upper version constraint on Cabal (#213).
+
 ## [1.6.0] - 2025-01-21
 
 * Version bump 1.6.0 (#208).

--- a/ogma-extra/ogma-extra.cabal
+++ b/ogma-extra/ogma-extra.cabal
@@ -77,7 +77,7 @@ library
       base        >= 4.11.0.0 && < 5
     , aeson       >= 2.0.0.0  && < 2.2
     , bytestring  >= 0.10.8.2 && < 0.13
-    , Cabal       >= 2.2.0.0  && < 3.9
+    , Cabal       >= 2.2.0.0  && < 3.15
     , directory   >= 1.3.1.5  && < 1.4
     , filepath    >= 1.4.2    && < 1.6
     , microstache >= 1.0      && < 1.1

--- a/ogma-language-c/CHANGELOG.md
+++ b/ogma-language-c/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Revision history for ogma-language-c
 
+## [1.X.Y] - 2025-01-30
+* Bump upper version constraint on Cabal (#213).
+
 ## [1.6.0] - 2025-01-21
 
 * Version bump 1.6.0 (#208).

--- a/ogma-language-c/ogma-language-c.cabal
+++ b/ogma-language-c/ogma-language-c.cabal
@@ -70,7 +70,7 @@ source-repository head
 custom-setup
   setup-depends:
       base    >= 4.11.0.0 && < 5
-    , Cabal   >= 2.0 && < 3.9
+    , Cabal   >= 2.0 && < 3.15
     , process >= 1.6      && < 1.7
     , BNFC    >= 2.9.1    && < 2.10
 

--- a/ogma-language-cocospec/CHANGELOG.md
+++ b/ogma-language-cocospec/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Revision history for ogma-language-cocospec
 
-## [1.X.Y] - 2025-01-27
+## [1.X.Y] - 2025-01-30
 
 * Remove references to old design of Ogma from documentation (#220).
+* Bump upper version constraint on Cabal (#213).
 
 ## [1.6.0] - 2025-01-21
 

--- a/ogma-language-cocospec/ogma-language-cocospec.cabal
+++ b/ogma-language-cocospec/ogma-language-cocospec.cabal
@@ -70,7 +70,7 @@ source-repository head
 custom-setup
   setup-depends:
       base    >= 4.11.0.0 && < 5
-    , Cabal   >= 2.0 && < 3.9
+    , Cabal   >= 2.0 && < 3.15
     , process >= 1.6      && < 1.7
     , BNFC    >= 2.9.1    && < 2.10
 

--- a/ogma-language-smv/CHANGELOG.md
+++ b/ogma-language-smv/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Revision history for ogma-language-smv
 
-## [1.X.Y] - 2025-01-27
+## [1.X.Y] - 2025-01-30
 
 * Remove references to old design of Ogma from documentation (#220).
+* Bump upper version constraint on Cabal (#213).
 
 ## [1.6.0] - 2025-01-21
 

--- a/ogma-language-smv/ogma-language-smv.cabal
+++ b/ogma-language-smv/ogma-language-smv.cabal
@@ -70,7 +70,7 @@ source-repository head
 custom-setup
   setup-depends:
       base    >= 4.11.0.0 && < 5
-    , Cabal   >= 2.0 && < 3.9
+    , Cabal   >= 2.0 && < 3.15
     , process >= 1.6      && < 1.7
     , BNFC    >= 2.9.1    && < 2.10
 


### PR DESCRIPTION
This commit modifies version bounds of all libraries depending directly on Cabal to allow installation with Cabal 3.14, the most recent version of Cabal that does not require a change to the Haskell code, per the desired result and proposed solution in #213.

These changes enable Ogma to be used in Debian sid.