### PR TITLE
Specify tool dependencies using `build-tool-depends`. Refs #149.

### DIFF
--- a/.github/workflows/repo-ghc-8.6-cabal-2.4-ros.yml
+++ b/.github/workflows/repo-ghc-8.6-cabal-2.4-ros.yml
@@ -40,6 +40,7 @@ jobs:
     - name: Install dependencies
       run: |
         cabal v1-install alex happy
+        cabal v1-install BNFC
 
     - name: Install ogma
       run: |

--- a/.github/workflows/repo-ghc-8.6-cabal-2.4.yml
+++ b/.github/workflows/repo-ghc-8.6-cabal-2.4.yml
@@ -40,6 +40,7 @@ jobs:
     - name: Install dependencies
       run: |
         cabal v1-install alex happy
+        cabal v1-install BNFC
 
     - name: Install ogma
       run: |

--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,2 @@
+packages:
+  */

--- a/ogma-cli/CHANGELOG.md
+++ b/ogma-cli/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Add all auxiliary test files to distributable Cabal package (#216).
 * Remove extraneous EOL character (#224).
+* Update installation instructions to use cabal install (#149).
 
 ## [1.6.0] - 2025-01-21
 

--- a/ogma-cli/README.md
+++ b/ogma-cli/README.md
@@ -83,15 +83,15 @@ Once GHC and cabal are installed, the simplest way to install Ogma is with:
 ```sh
 $ git clone https://github.com/nasa/ogma.git
 $ cd ogma
-$ export PATH="$HOME/.cabal/bin/:$PATH"
-$ cabal v1-update
-$ cabal v1-install alex happy
-$ cabal v1-install BNFC copilot
-$ cabal v1-install ogma-*/
+$ export PATH="$HOME/.local/bin/:$PATH"
+$ cabal update
+$ cabal install --lib copilot copilot-c99 copilot-language copilot-theorem \
+    copilot-libraries copilot-interpreter
+$ cabal install ogma-cli:ogma
 ```
 
 After that, the `ogma` executable will be placed in the directory
-`$HOME/.cabal/bin/`, where `$HOME` represents your user's home directory.
+`$HOME/.local/bin/`, where `$HOME` represents your user's home directory.
 
 # Usage
 <sup>[(Back to top)](#table-of-contents)</sup>

--- a/ogma-language-c/CHANGELOG.md
+++ b/ogma-language-c/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [1.X.Y] - 2025-02-01
 * Bump upper version constraint on Cabal (#213).
 * Remove extraneous EOL character (#224).
+* Specify tools needed using build-tool-depends (#149).
 
 ## [1.6.0] - 2025-01-21
 

--- a/ogma-language-c/ogma-language-c.cabal
+++ b/ogma-language-c/ogma-language-c.cabal
@@ -30,7 +30,6 @@
 
 cabal-version:       2.0
 build-type:          Custom
-
 name:                ogma-language-c
 version:             1.6.0
 homepage:            https://github.com/nasa/ogma
@@ -72,7 +71,6 @@ custom-setup
       base    >= 4.11.0.0 && < 5
     , Cabal   >= 2.0 && < 3.15
     , process >= 1.6      && < 1.7
-    , BNFC    >= 2.9.1    && < 2.10
 
 library
 
@@ -92,6 +90,11 @@ library
   build-depends:
       base  >= 4.11.0.0 && < 5
     , array >= 0.5.2.0  && < 0.6
+
+  build-tool-depends:
+      alex:alex   >= 3
+    , BNFC:bnfc   >= 2.9.4
+    , happy:happy >= 1.19
 
   hs-source-dirs:
     src

--- a/ogma-language-cocospec/CHANGELOG.md
+++ b/ogma-language-cocospec/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Remove references to old design of Ogma from documentation (#220).
 * Bump upper version constraint on Cabal (#213).
 * Remove extraneous EOL character (#224).
+* Specify tools needed using build-tool-depends (#149).
 
 ## [1.6.0] - 2025-01-21
 

--- a/ogma-language-cocospec/ogma-language-cocospec.cabal
+++ b/ogma-language-cocospec/ogma-language-cocospec.cabal
@@ -30,7 +30,6 @@
 
 cabal-version:       2.0
 build-type:          Custom
-
 name:                ogma-language-cocospec
 version:             1.6.0
 homepage:            https://github.com/nasa/ogma
@@ -72,7 +71,6 @@ custom-setup
       base    >= 4.11.0.0 && < 5
     , Cabal   >= 2.0 && < 3.15
     , process >= 1.6      && < 1.7
-    , BNFC    >= 2.9.1    && < 2.10
 
 library
 
@@ -92,6 +90,11 @@ library
   build-depends:
       base  >= 4.11.0.0 && < 5
     , array >= 0.5.2.0  && < 0.6
+
+  build-tool-depends:
+      alex:alex   >= 3
+    , BNFC:bnfc   >= 2.9.4
+    , happy:happy >= 1.19
 
   hs-source-dirs:
     src

--- a/ogma-language-smv/CHANGELOG.md
+++ b/ogma-language-smv/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Remove references to old design of Ogma from documentation (#220).
 * Bump upper version constraint on Cabal (#213).
 * Remove extraneous EOL character (#224).
+* Specify tools needed using build-tool-depends (#149).
 
 ## [1.6.0] - 2025-01-21
 

--- a/ogma-language-smv/ogma-language-smv.cabal
+++ b/ogma-language-smv/ogma-language-smv.cabal
@@ -30,7 +30,6 @@
 
 cabal-version:       2.0
 build-type:          Custom
-
 name:                ogma-language-smv
 version:             1.6.0
 homepage:            https://github.com/nasa/ogma
@@ -72,7 +71,6 @@ custom-setup
       base    >= 4.11.0.0 && < 5
     , Cabal   >= 2.0 && < 3.15
     , process >= 1.6      && < 1.7
-    , BNFC    >= 2.9.1    && < 2.10
 
 library
 
@@ -93,6 +91,11 @@ library
   build-depends:
       base  >= 4.11.0.0 && < 5
     , array >= 0.5.2.0  && < 0.6
+
+  build-tool-depends:
+      alex:alex   >= 3
+    , BNFC:bnfc   >= 2.9.4
+    , happy:happy >= 1.19
 
   hs-source-dirs:
     src


### PR DESCRIPTION
Specify dependencies on tools like `alex`, `happy` and `BNFC` using `build-tool-depends`, and update installation instructions accordingly, as prescribed in the solution proposed for #149.