### PR TITLE
`ogma-core`: Update Copilot struct code generator to use new function names. Refs #231.

### DIFF
--- a/ogma-core/CHANGELOG.md
+++ b/ogma-core/CHANGELOG.md
@@ -1,12 +1,13 @@
 # Revision history for ogma-core
 
-## [1.X.Y] - 2025-02-02
+## [1.X.Y] - 2025-02-03
 
 * Import liftIO from Control.Monad.IO.Class (#215).
 * Remove references to old design of Ogma from hlint files (#220).
 * Bump upper version constraint on aeson, text (#225).
 * Remove extraneous EOL character (#224).
 * Make structured data available to cFS template (#229).
+* Update Copilot struct code generator to use new function names (#231).
 
 ## [1.6.0] - 2025-01-21
 

--- a/ogma-core/src/Language/Trans/CStructs2Copilot.hs
+++ b/ogma-core/src/Language/Trans/CStructs2Copilot.hs
@@ -151,9 +151,9 @@ structInstance cstruct =
     instanceHead = "Struct" ++ " " ++ instanceName
     instanceName = cStructName2Haskell $ cStructName cstruct
 
-    instanceBody = [ instanceTypename, instanceToValues ]
+    instanceBody = [ instanceTypeName, instanceToValues ]
 
-    instanceTypename = "typename" ++ " " ++ "_" ++ " = " ++ show (cStructName cstruct)
+    instanceTypeName = "typeName" ++ " " ++ "_" ++ " = " ++ show (cStructName cstruct)
 
     instanceToValues =
       "toValues" ++ " " ++ "v" ++ " = " ++ "[ " ++ intercalate ", " valueDecls ++ " ]"


### PR DESCRIPTION
This commit updates the Copilot struct code generator to use the new function name `typeName` as `typename` has been removed, as prescribed in the solution proposed for #231.