### PR TITLE
`ogma-core`: Simplify Copilot struct definitions by using generics. Refs #199.

### DIFF
--- a/ogma-core/CHANGELOG.md
+++ b/ogma-core/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Remove extraneous EOL character (#224).
 * Make structured data available to cFS template (#229).
 * Update Copilot struct code generator to use new function names (#231).
+* Simplify Copilot struct definitions by using generics (#199).
 
 ## [1.6.0] - 2025-01-21
 


### PR DESCRIPTION
Simplify the struct definitions generated by Ogma by leveraging generics, making data structs derive `Generic` and modifying type class methods to use the default versions of all methods, as prescribed in the solution proposed for #199.