### PR TITLE
Support passing additional template variables to the cFS backend. Refs #106.

### DIFF
--- a/ogma-cli/CHANGELOG.md
+++ b/ogma-cli/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Update installation instructions to use cabal install (#149).
 * Update README with new cFS template variables (#229).
 * Expose handlers-file argument to cFS backend (#234).
+* Expose template-vars argument to cFS backend (#106).
 
 ## [1.6.0] - 2025-01-21
 

--- a/ogma-cli/README.md
+++ b/ogma-cli/README.md
@@ -135,6 +135,8 @@ be made available to the monitor.
 and the message they are included with.
 - `--handlers-file FILENAME`: a file containing a list of known fault handlers
   or triggers.
+- `--template-vars FILENAME`: a JSON file containing a list of additional
+  variables to expand in the template.
 
 The following execution generates an initial cFS application for runtime
 monitoring using Copilot:
@@ -234,6 +236,15 @@ the processing to an auxiliary function.
 - `{{triggers}}`: list of error handlers or fault triggers, which will be used
   by the monitoring application to notify of faults or updates from the
   monitoring system.
+
+Additionally, the `cfs` command accepts a file with a JSON object listing
+additional variables to be expanded in the template. To make use of this
+feature, we encourage users to modify the template to fit their needs, and pass
+the file as an argument via the flag `--template-vars`. Values passed to the
+template are also respected in file names; for example, if the JSON file
+contains an object key `"APP_NAME"` with the value `"Monitor"`, a file or
+directory in the template named `My_{{APP_NAME}}` will be expanded in the
+destination directory as `My_Monitor`.
 
 We understand that this level of customization may be insufficient for your
 application. If that is the case, feel free to reach out to our team to discuss

--- a/ogma-cli/src/CLI/CommandCFSApp.hs
+++ b/ogma-cli/src/CLI/CommandCFSApp.hs
@@ -56,11 +56,12 @@ import Command.CFSApp ( ErrorCode, cFSApp )
 
 -- | Options needed to generate the cFS application.
 data CommandOpts = CommandOpts
-  { cFSAppTarget      :: String
-  , cFSAppTemplateDir :: Maybe String
-  , cFSAppVarNames    :: String
-  , cFSAppVarDB       :: Maybe String
-  , cFSAppHandlers    :: Maybe String
+  { cFSAppTarget       :: String
+  , cFSAppTemplateDir  :: Maybe String
+  , cFSAppVarNames     :: String
+  , cFSAppVarDB        :: Maybe String
+  , cFSAppHandlers     :: Maybe String
+  , cFSAppTemplateVars :: Maybe String
   }
 
 -- | Create <https://cfs.gsfc.nasa.gov/ NASA core Flight System> (cFS)
@@ -76,6 +77,7 @@ command c =
     (cFSAppVarNames c)
     (cFSAppVarDB c)
     (cFSAppHandlers c)
+    (cFSAppTemplateVars c)
 
 -- * CLI
 
@@ -122,6 +124,13 @@ commandOptsParser = CommandOpts
             <> help strCFSAppHandlerListArgDesc
             )
         )
+  <*> optional
+        ( strOption
+            (  long "template-vars"
+            <> metavar "FILENAME"
+            <> help strCFSAppTemplateVarsArgDesc
+            )
+        )
 
 -- | Argument target directory to cFS app generation command
 strCFSAppDirArgDesc :: String
@@ -146,3 +155,8 @@ strCFSAppVarDBArgDesc =
 strCFSAppHandlerListArgDesc :: String
 strCFSAppHandlerListArgDesc =
   "File containing list of Copilot handlers used in the specification"
+
+-- | Argument template variables to cFS app generation command
+strCFSAppTemplateVarsArgDesc :: String
+strCFSAppTemplateVarsArgDesc =
+  "JSON file containing additional variables to expand in template"

--- a/ogma-core/CHANGELOG.md
+++ b/ogma-core/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Update Copilot struct code generator to use new function names (#231).
 * Simplify Copilot struct definitions by using generics (#199).
 * Update cFS backend to process a handlers file (#234).
+* Update cFS backend to process a template variables file (#106).
 
 ## [1.6.0] - 2025-01-21
 


### PR DESCRIPTION
Extend `cfs` command and the cFS backend to accept and use an optional JSON file containing additional variables to expand in the template, as prescribed in the solution proposed for #106.