### PR TITLE
Remove dependency on ICAROUS from generated cFS applications. Refs #237.

### DIFF
--- a/ogma-cli/CHANGELOG.md
+++ b/ogma-cli/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Revision history for ogma-cli
 
-## [1.X.Y] - 2025-02-03
+## [1.X.Y] - 2025-02-04
 
 * Add all auxiliary test files to distributable Cabal package (#216).
 * Remove extraneous EOL character (#224).
@@ -8,6 +8,7 @@
 * Update README with new cFS template variables (#229).
 * Expose handlers-file argument to cFS backend (#234).
 * Expose template-vars argument to cFS backend (#106).
+* Document new template variables in README (#237).
 
 ## [1.6.0] - 2025-01-21
 

--- a/ogma-cli/README.md
+++ b/ogma-cli/README.md
@@ -246,6 +246,19 @@ contains an object key `"APP_NAME"` with the value `"Monitor"`, a file or
 directory in the template named `My_{{APP_NAME}}` will be expanded in the
 destination directory as `My_Monitor`.
 
+Using this flag, you can expand two more variables in the default template:
+
+- `{{impl_extra_header}}`: contains a list of lines to add at the top of the
+  CFS application implementation, after the default includes. The value
+assigned to this JSON key must be an array or list (each element will be
+expanded in a separate line).
+
+- `{{included_libraries}}`: contains a list of additional libraries that must
+  be included as dependencies in the `CMakeLists.txt` file for the moniroting
+application in order to be able to compile it. The value assigned this JSON key
+must be an array or list of dependencies, relative to the directory of the
+monitoring app).
+
 We understand that this level of customization may be insufficient for your
 application. If that is the case, feel free to reach out to our team to discuss
 how we could make the template expansion system more versatile.

--- a/ogma-core/CHANGELOG.md
+++ b/ogma-core/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Revision history for ogma-core
 
-## [1.X.Y] - 2025-02-03
+## [1.X.Y] - 2025-02-04
 
 * Import liftIO from Control.Monad.IO.Class (#215).
 * Remove references to old design of Ogma from hlint files (#220).
@@ -11,6 +11,7 @@
 * Simplify Copilot struct definitions by using generics (#199).
 * Update cFS backend to process a handlers file (#234).
 * Update cFS backend to process a template variables file (#106).
+* Remove dependency on ICAROUS from generated cFS applications (#237).
 
 ## [1.6.0] - 2025-01-21
 

--- a/ogma-core/src/Command/CFSApp.hs
+++ b/ogma-core/src/Command/CFSApp.hs
@@ -93,7 +93,7 @@ cFSApp targetDir mTemplateDir varNameFile varDBFile handlersFile
   -- format).
   varDBE <- E.try $
                 case varDBFile of
-                  Nothing -> return knownVars
+                  Nothing -> return []
                   Just fn -> fmap read <$> lines <$> readFile fn
 
   handlersE <- parseOptionalRequirementsListFile handlersFile
@@ -143,11 +143,6 @@ cFSApp targetDir mTemplateDir varNameFile varDBFile handlersFile
             copyTemplate templateDir subst' targetDir
 
             return Success
-
--- | Predefined list of Icarous variables that are known to Ogma
-knownVars :: [(String, String, String, String)]
-knownVars =
-  [ ("position", "position_t", "ICAROUS_POSITION_MID", "IcarousPosition") ]
 
 -- | Return the variable information needed to generate declarations
 -- and subscriptions for a given variable name and variable database.

--- a/ogma-core/templates/copilot-cfs/CMakeLists.txt
+++ b/ogma-core/templates/copilot-cfs/CMakeLists.txt
@@ -2,7 +2,9 @@ cmake_minimum_required(VERSION 2.6.4)
 project(CFE_COPILOT_APP C)
 
 include_directories(../../Modules/Core/Interfaces)
-include_directories(../Icarouslib/fsw/platform_inc)
+{{#included_libraries}}
+include_directories({{{.}}})
+{{/included_libraries}}
 include_directories(../inc)
 include_directories(fsw/mission_inc)
 include_directories(fsw/platform_inc)

--- a/ogma-core/templates/copilot-cfs/fsw/src/copilot_cfs.c
+++ b/ogma-core/templates/copilot-cfs/fsw/src/copilot_cfs.c
@@ -16,8 +16,9 @@
 #include "copilot_cfs_msg.h"
 #include "copilot_cfs_events.h"
 #include "copilot_cfs_version.h"
-#include "Icarous_msgids.h"
-#include "Icarous_msg.h"
+{{#impl_extra_header}}
+{{{.}}}
+{{/impl_extra_header}}
 
 {{#variables}}
 {{varDeclType}} {{varDeclName}};

--- a/ogma-core/templates/copilot-cfs/fsw/src/copilot_cfs.c
+++ b/ogma-core/templates/copilot-cfs/fsw/src/copilot_cfs.c
@@ -152,7 +152,7 @@ void COPILOT_ProcessCommandPacket(void)
 
 {{#msgHandlers}}
 /**
-* Make ICAROUS data available to Copilot and run monitors.
+* Make received data available to Copilot and run monitors.
 */
 void COPILOT_Process{{msgDataDesc}}(void)
 {

--- a/ogma-core/templates/copilot-cfs/fsw/src/copilot_cfs.h
+++ b/ogma-core/templates/copilot-cfs/fsw/src/copilot_cfs.h
@@ -41,7 +41,9 @@
 void COPILOT_AppMain(void);
 void COPILOT_AppInit(void);
 void COPILOT_ProcessCommandPacket(void);
-void COPILOT_ProcessIcarousPosition(void);
+{{#msgCases}}
+void COPILOT_Process{{msgInfoDesc}}(void);
+{{/msgCases}}
 void COPILOT_ResetCounters(void);
 
 boolean COPILOT_VerifyCmdLength(CFE_SB_MsgPtr_t msg, uint16 ExpectedLength);


### PR DESCRIPTION
Remove all references to ICAROUS-specific data from the template and the cFS backend, and add new variables in places where we expect that users may need them, as prescribed in the solution proposed for #237.