### PR TITLE
`ogma-core`: Remove incorrect function declaration from template. Refs #240.

### DIFF
--- a/ogma-core/CHANGELOG.md
+++ b/ogma-core/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Update cFS backend to process a handlers file (#234).
 * Update cFS backend to process a template variables file (#106).
 * Remove dependency on ICAROUS from generated cFS applications (#237).
+* Remove incorrect function declaration from template (#240).
 
 ## [1.6.0] - 2025-01-21
 

--- a/ogma-core/templates/copilot-cfs/fsw/src/copilot_cfs.c
+++ b/ogma-core/templates/copilot-cfs/fsw/src/copilot_cfs.c
@@ -24,7 +24,6 @@
 {{varDeclType}} {{varDeclName}};
 {{/variables}}
 
-void split(void);
 void step(void);
 
 /*


### PR DESCRIPTION
Remove incorrect mention of an undefined function `split` from the cFS template, as prescribed in the solution proposed for #240 .