### PR TITLE
`ogma-core`: Re-structure cFS backend to avoid nested conditions. Refs #242.

### DIFF
--- a/ogma-core/CHANGELOG.md
+++ b/ogma-core/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Revision history for ogma-core
 
-## [1.X.Y] - 2025-02-04
+## [1.X.Y] - 2025-02-06
 
 * Import liftIO from Control.Monad.IO.Class (#215).
 * Remove references to old design of Ogma from hlint files (#220).
@@ -13,6 +13,7 @@
 * Update cFS backend to process a template variables file (#106).
 * Remove dependency on ICAROUS from generated cFS applications (#237).
 * Remove incorrect function declaration from template (#240).
+* Re-structure cFS backend to avoid nested conditions (#242).
 
 ## [1.6.0] - 2025-01-21
 


### PR DESCRIPTION
Re-structure the cFS backend to make code sequential instead of nested by means of the `ExceptT` monad transformer, as prescribed in the solution proposed for #242.