### PR TITLE
Make structured data available to FPrime template. Refs #246.

### DIFF
--- a/ogma-cli/CHANGELOG.md
+++ b/ogma-cli/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Document new template variables in README (#237).
 * Fix formatting of template variables in README (#222).
 * Update README with new ROS template variables (#244).
+* Update README with new FPrime template variables (#246).
 
 ## [1.6.0] - 2025-01-21
 

--- a/ogma-cli/README.md
+++ b/ogma-cli/README.md
@@ -478,46 +478,21 @@ $ ogma fprime --app-template-dir my_template/ --handlers filename --variable-fil
 ```
 
 Ogma will copy the files in that directory to the target path, filling in
-several holes with specific information. For the component interface, the
-variables are:
+several holes with specific information from template variables. The template
+variables available are:
 
-- `{{{ifaceTypePorts}}}`: Contain the type declarations for the types used by
-  the ports.
+- `{{variables}}`: list of inputs to monitor, one for each external data source
+  needed to be read from an F' component port and made accessible to the
+  monitoring code. For each variable, the fields defined are:
+  - `{{varDeclName}}`: name of the variable or input.
+  - `{{varDeclType}}`: raw type of the variable or input.
+  - `{{varDeclFPrimeType}}`: type in F' for ports carrying data of this type.
 
-- `{{{ifaceInputPorts}}}`: Contains the declarations of the `async input` port,
-  to provide information needed by the monitors.
-
-- `{{{ifaceViolationEvents}}}`: Contains the output port declarations, used to
-  emit property violations.
-
-For the monitor's header file, the variables are:
-
-- `{{{hdrHandlers}}}`: Contains the declarations of operations to execute when
-  new information is received in an input port, prior to re-evaluating the
-  monitors.
-
-For the monitor's implementation, the variables are:
-
-- `{{{implInputs}}}`: Contains the declarations of the variables with inputs
-  needed by the monitor.
-
-- `{{{implMonitorResults}}}`: Contains the declarations of boolean variables,
-  each holding the result of the evaluation of one of the monitors.
-
-- `{{{implInputHandlers}}}`: Contains the implementations of operations to
-  execute when new information is received in an input port, prior to
-  re-evaluating the monitors.
-
-- `{{{implTriggerResultReset}}}`: Contains instructions that reset the status of
-  the monitors.
-
-- `{{{implTriggerChecks}}}`: Contains instructions that check whether any
-  monitor has resulted in a violation and, if so, sends an event via the
-corresponding port.
-
-- `{{{implTriggers}}}`: Contains the implementations of the functions that set
-  the result of a monitor evaluation to true when the Copilot implementation
-  finds a violation.
+- `{{monitors}}`: list of monitors or error handlers, which will be used by the
+  monitoring application to notify of faults or updates from the monitoring
+  system. For each monitor, the fields defined are:
+  - `{{monitorName}}`: name of the monitor.
+  - `{{monitorUC}}`: name of the monitor, in capital letters.
 
 We understand that this level of customization may be insufficient for your
 application. If that is the case, feel free to reach out to our team to discuss

--- a/ogma-core/CHANGELOG.md
+++ b/ogma-core/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Remove incorrect function declaration from template (#240).
 * Re-structure cFS backend to avoid nested conditions (#242).
 * Make structured data available to ROS template (#244).
+* Make structured data available to FPrime template (#246).
 
 ## [1.6.0] - 2025-01-21
 

--- a/ogma-core/templates/fprime/Copilot.cpp
+++ b/ogma-core/templates/fprime/Copilot.cpp
@@ -19,8 +19,12 @@ extern "C" {
 }
 #endif
 
-{{{implInputs}}}
-{{{implMonitorResults}}}
+{{#variables}}
+{{varDeclType}} {{varDeclName}};
+{{/variables}}
+{{#monitors}}
+bool {{monitorName}}_result;
+{{/monitors}}
 
 namespace Ref {
 
@@ -55,8 +59,17 @@ namespace Ref {
   // Handler implementations for user-defined typed input ports
   // ----------------------------------------------------------------------
 
-{{{implInputHandlers}}}
+{{#variables}}
+  void Copilot :: 
+    {{varDeclName}}In_handler(
+        const NATIVE_INT_TYPE portNum,
+        {{varDeclType}} value
+    )
+  {
+    {{varDeclName}} = ({{varDeclType}}) value;
+  }
 
+{{/variables}}
   // ----------------------------------------------------------------------
   // Command handler implementations
   // ----------------------------------------------------------------------
@@ -67,12 +80,22 @@ namespace Ref {
         const U32 cmdSeq
     )
   {
-{{{implTriggerResultReset}}}
+{{#monitors}}
+    {{monitorName}}_result = false;
+{{/monitors}}
     step();
     this->cmdResponse_out(opCode,cmdSeq,Fw::CmdResponse::OK);
-{{{implTriggerChecks}}}
+{{#monitors}}
+    if ({{monitorName}}_result) {
+       this->log_ACTIVITY_HI_{{monitorUC}}_VIOLATION();
+    }
+{{/monitors}}
   }
 
 } // end namespace Ref
+{{#monitors}}
 
-{{{implTriggers}}}
+void {{monitorName}}() {
+  {{monitorName}}_result = true;
+}
+{{/monitors}}

--- a/ogma-core/templates/fprime/Copilot.fpp
+++ b/ogma-core/templates/fprime/Copilot.fpp
@@ -1,7 +1,9 @@
 module Ref {
 
-{{{ifaceTypePorts}}}
+{{#variables}}
+    port {{varDeclFPrimeType}}Value(value: {{varDeclFPrimeType}})
 
+{{/variables}}
   @ Monitoring component
   queued component Copilot {
 
@@ -9,8 +11,10 @@ module Ref {
     # General ports
     # ----------------------------------------------------------------------
 
-{{{ifaceInputPorts}}}
+{{#variables}}
+    async input port {{varDeclName}}In : {{varDeclFPrimeType}}Value
 
+{{/variables}}
     # ----------------------------------------------------------------------
     # Special ports
     # ----------------------------------------------------------------------
@@ -52,8 +56,14 @@ module Ref {
     # Events
     # ----------------------------------------------------------------------
 
-{{{ifaceViolationEvents}}}
+{{#monitors}}
+    @ {{monitorName}} violation
+    event {{monitorUC}}_VIOLATION() \
+      severity activity high \
+      id 0 \
+      format "{{monitorName}} violation"
 
+{{/monitors}}
     # ----------------------------------------------------------------------
     # Commands
     # ----------------------------------------------------------------------

--- a/ogma-core/templates/fprime/Copilot.hpp
+++ b/ogma-core/templates/fprime/Copilot.hpp
@@ -44,8 +44,15 @@ namespace Ref {
       // Handler implementations for user-defined typed input ports
       // ----------------------------------------------------------------------
 
-{{{hdrHandlers}}}
+{{#variables}}
+      //! Handler implementation for {{varDeclName}}In
+      //!
+      void {{varDeclName}}In_handler(
+            const NATIVE_INT_TYPE portNum, /*!< The port number*/
+            {{varDeclType}} value
+        );
 
+{{/variables}}
     PRIVATE:
 
       // ----------------------------------------------------------------------


### PR DESCRIPTION
Modify FPrime backend to make more structured data directly available to the FPrime template, as prescribed in the solution proposed for #246.