### PR TITLE
Equalize backends. Refs #248.

### DIFF
--- a/ogma-cli/CHANGELOG.md
+++ b/ogma-cli/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Revision history for ogma-cli
 
-## [1.X.Y] - 2025-02-07
+## [1.X.Y] - 2025-02-08
 
 * Add all auxiliary test files to distributable Cabal package (#216).
 * Remove extraneous EOL character (#224).
@@ -12,6 +12,7 @@
 * Fix formatting of template variables in README (#222).
 * Update README with new ROS template variables (#244).
 * Update README with new FPrime template variables (#246).
+* Adjust CLI to match new backend API (#248).
 
 ## [1.6.0] - 2025-01-21
 

--- a/ogma-cli/src/CLI/CommandCFSApp.hs
+++ b/ogma-cli/src/CLI/CommandCFSApp.hs
@@ -50,7 +50,8 @@ import Options.Applicative ( Parser, help, long, metavar, optional, showDefault,
 import Command.Result ( Result )
 
 -- External imports: actions or commands supported
-import Command.CFSApp ( ErrorCode, cFSApp )
+import           Command.CFSApp ( ErrorCode )
+import qualified Command.CFSApp
 
 -- * Command
 
@@ -58,7 +59,7 @@ import Command.CFSApp ( ErrorCode, cFSApp )
 data CommandOpts = CommandOpts
   { cFSAppTarget       :: String
   , cFSAppTemplateDir  :: Maybe String
-  , cFSAppVarNames     :: String
+  , cFSAppVarNames     :: Maybe String
   , cFSAppVarDB        :: Maybe String
   , cFSAppHandlers     :: Maybe String
   , cFSAppTemplateVars :: Maybe String
@@ -70,14 +71,16 @@ data CommandOpts = CommandOpts
 --
 -- This is just an uncurried version of "Command.CFSApp".
 command :: CommandOpts -> IO (Result ErrorCode)
-command c =
-  cFSApp
-    (cFSAppTarget c)
-    (cFSAppTemplateDir c)
-    (cFSAppVarNames c)
-    (cFSAppVarDB c)
-    (cFSAppHandlers c)
-    (cFSAppTemplateVars c)
+command c = Command.CFSApp.command options
+  where
+    options = Command.CFSApp.CommandOptions
+                { Command.CFSApp.commandTargetDir   = cFSAppTarget c
+                , Command.CFSApp.commandTemplateDir = cFSAppTemplateDir c
+                , Command.CFSApp.commandVariables   = cFSAppVarNames c
+                , Command.CFSApp.commandVariableDB  = cFSAppVarDB c
+                , Command.CFSApp.commandHandlers    = cFSAppHandlers c
+                , Command.CFSApp.commandExtraVars   = cFSAppTemplateVars c
+                }
 
 -- * CLI
 
@@ -103,12 +106,14 @@ commandOptsParser = CommandOpts
             <> help strCFSAppTemplateDirArgDesc
             )
         )
-  <*> strOption
-        (  long "variable-file"
-        <> metavar "FILENAME"
-        <> showDefault
-        <> value "variables"
-        <> help strCFSAppVarListArgDesc
+  <*> optional
+        ( strOption
+            (  long "variable-file"
+            <> metavar "FILENAME"
+            <> showDefault
+            <> value "variables"
+            <> help strCFSAppVarListArgDesc
+            )
         )
   <*> optional
         ( strOption

--- a/ogma-cli/src/CLI/CommandFPrimeApp.hs
+++ b/ogma-cli/src/CLI/CommandFPrimeApp.hs
@@ -50,7 +50,7 @@ import Options.Applicative ( Parser, help, long, metavar, optional, short,
 import Command.Result ( Result )
 
 -- External imports: actions or commands supported
-import           Command.FPrimeApp (ErrorCode, fprimeApp)
+import           Command.FPrimeApp (ErrorCode)
 import qualified Command.FPrimeApp
 
 -- * Command
@@ -60,7 +60,7 @@ data CommandOpts = CommandOpts
   { fprimeAppInputFile   :: Maybe String
   , fprimeAppTarget      :: String
   , fprimeAppTemplateDir :: Maybe String
-  , fprimeAppVarNames    :: Maybe String
+  , fprimeAppVariables   :: Maybe String
   , fprimeAppVarDB       :: Maybe String
   , fprimeAppHandlers    :: Maybe String
   , fprimeAppFormat      :: String
@@ -74,18 +74,19 @@ data CommandOpts = CommandOpts
 --
 -- This is just a wrapper around "Command.fprimeApp".
 command :: CommandOpts -> IO (Result ErrorCode)
-command c = fprimeApp (fprimeAppInputFile c) options
+command c = Command.FPrimeApp.command options
   where
     options =
-      Command.FPrimeApp.FPrimeAppOptions
-        { Command.FPrimeApp.fprimeAppTargetDir   = fprimeAppTarget c
-        , Command.FPrimeApp.fprimeAppTemplateDir = fprimeAppTemplateDir c
-        , Command.FPrimeApp.fprimeAppVarNames    = fprimeAppVarNames c
-        , Command.FPrimeApp.fprimeAppVariableDB  = fprimeAppVarDB c
-        , Command.FPrimeApp.fprimeAppHandlers    = fprimeAppHandlers c
-        , Command.FPrimeApp.fprimeAppFormat      = fprimeAppFormat c
-        , Command.FPrimeApp.fprimeAppPropFormat  = fprimeAppPropFormat c
-        , Command.FPrimeApp.fprimeAppPropVia     = fprimeAppPropVia c
+      Command.FPrimeApp.CommandOptions
+        { Command.FPrimeApp.commandInputFile   = fprimeAppInputFile c
+        , Command.FPrimeApp.commandTargetDir   = fprimeAppTarget c
+        , Command.FPrimeApp.commandTemplateDir = fprimeAppTemplateDir c
+        , Command.FPrimeApp.commandVariables   = fprimeAppVariables c
+        , Command.FPrimeApp.commandVariableDB  = fprimeAppVarDB c
+        , Command.FPrimeApp.commandHandlers    = fprimeAppHandlers c
+        , Command.FPrimeApp.commandFormat      = fprimeAppFormat c
+        , Command.FPrimeApp.commandPropFormat  = fprimeAppPropFormat c
+        , Command.FPrimeApp.commandPropVia     = fprimeAppPropVia c
         }
 
 -- * CLI

--- a/ogma-cli/src/CLI/CommandROSApp.hs
+++ b/ogma-cli/src/CLI/CommandROSApp.hs
@@ -50,7 +50,7 @@ import Options.Applicative ( Parser, help, long, metavar, optional, short,
 import Command.Result ( Result )
 
 -- External imports: actions or commands supported
-import           Command.ROSApp (ErrorCode, rosApp)
+import           Command.ROSApp (ErrorCode)
 import qualified Command.ROSApp
 
 -- * Command
@@ -74,17 +74,18 @@ data CommandOpts = CommandOpts
 --
 -- This is just a wrapper around "Command.ROSApp".
 command :: CommandOpts -> IO (Result ErrorCode)
-command c = rosApp (rosAppInputFile c) options
+command c = Command.ROSApp.command options
   where
-    options = Command.ROSApp.ROSAppOptions
-                { Command.ROSApp.rosAppTargetDir   = rosAppTarget c
-                , Command.ROSApp.rosAppTemplateDir = rosAppTemplateDir c
-                , Command.ROSApp.rosAppVariables   = rosAppVarNames c
-                , Command.ROSApp.rosAppVariableDB  = rosAppVarDB c
-                , Command.ROSApp.rosAppHandlers    = rosAppHandlers c
-                , Command.ROSApp.rosAppFormat      = rosAppFormat c
-                , Command.ROSApp.rosAppPropFormat  = rosAppPropFormat c
-                , Command.ROSApp.rosAppPropVia     = rosAppPropVia c
+    options = Command.ROSApp.CommandOptions
+                { Command.ROSApp.commandInputFile   = rosAppInputFile c
+                , Command.ROSApp.commandTargetDir   = rosAppTarget c
+                , Command.ROSApp.commandTemplateDir = rosAppTemplateDir c
+                , Command.ROSApp.commandVariables   = rosAppVarNames c
+                , Command.ROSApp.commandVariableDB  = rosAppVarDB c
+                , Command.ROSApp.commandHandlers    = rosAppHandlers c
+                , Command.ROSApp.commandFormat      = rosAppFormat c
+                , Command.ROSApp.commandPropFormat  = rosAppPropFormat c
+                , Command.ROSApp.commandPropVia     = rosAppPropVia c
                 }
 
 -- * CLI

--- a/ogma-cli/src/CLI/CommandStandalone.hs
+++ b/ogma-cli/src/CLI/CommandStandalone.hs
@@ -51,7 +51,7 @@ import Command.Result ( Result(..) )
 import Data.Location  ( Location(..) )
 
 -- External imports: actions or commands supported
-import           Command.Standalone (standalone)
+import           Command.Standalone (ErrorCode)
 import qualified Command.Standalone
 
 -- * Command
@@ -70,17 +70,19 @@ data CommandOpts = CommandOpts
 
 -- | Transform an input specification into a Copilot specification.
 command :: CommandOpts -> IO (Result ErrorCode)
-command c = standalone (standaloneFileName c) internalCommandOpts
+command c =
+    Command.Standalone.command internalCommandOpts
   where
-    internalCommandOpts :: Command.Standalone.StandaloneOptions
-    internalCommandOpts = Command.Standalone.StandaloneOptions
-      { Command.Standalone.standaloneTargetDir   = standaloneTargetDir c
-      , Command.Standalone.standaloneTemplateDir = standaloneTemplateDir c
-      , Command.Standalone.standaloneFormat      = standaloneFormat c
-      , Command.Standalone.standalonePropFormat  = standalonePropFormat c
-      , Command.Standalone.standaloneTypeMapping = types
-      , Command.Standalone.standaloneFilename    = standaloneTarget c
-      , Command.Standalone.standalonePropVia     = standalonePropVia c
+    internalCommandOpts :: Command.Standalone.CommandOptions
+    internalCommandOpts = Command.Standalone.CommandOptions
+      { Command.Standalone.commandInputFile   = standaloneFileName c
+      , Command.Standalone.commandTargetDir   = standaloneTargetDir c
+      , Command.Standalone.commandTemplateDir = standaloneTemplateDir c
+      , Command.Standalone.commandFormat      = standaloneFormat c
+      , Command.Standalone.commandPropFormat  = standalonePropFormat c
+      , Command.Standalone.commandTypeMapping = types
+      , Command.Standalone.commandFilename    = standaloneTarget c
+      , Command.Standalone.commandPropVia     = standalonePropVia c
       }
 
     types :: [(String, String)]
@@ -193,15 +195,3 @@ strStandaloneTargetDesc =
 strStandalonePropViaDesc :: String
 strStandalonePropViaDesc =
   "Command to pre-process individual properties"
-
--- * Error codes
-
--- | Encoding of reasons why the command can fail.
---
--- The error code used is 1 for user error.
-type ErrorCode = Int
-
--- | Error: the specification file cannot be read due to the format being
--- unknown.
-ecSpecError :: ErrorCode
-ecSpecError = 2

--- a/ogma-core/CHANGELOG.md
+++ b/ogma-core/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Revision history for ogma-core
 
-## [1.X.Y] - 2025-02-07
+## [1.X.Y] - 2025-02-08
 
 * Import liftIO from Control.Monad.IO.Class (#215).
 * Remove references to old design of Ogma from hlint files (#220).
@@ -16,6 +16,7 @@
 * Re-structure cFS backend to avoid nested conditions (#242).
 * Make structured data available to ROS template (#244).
 * Make structured data available to FPrime template (#246).
+* Equalize backends (#248).
 
 ## [1.6.0] - 2025-01-21
 

--- a/ogma-core/src/Command/ROSApp.hs
+++ b/ogma-core/src/Command/ROSApp.hs
@@ -42,9 +42,9 @@
 
 {- HLINT ignore "Functor law" -}
 module Command.ROSApp
-    ( rosApp
+    ( command
+    , CommandOptions(..)
     , ErrorCode
-    , ROSAppOptions(..)
     )
   where
 
@@ -72,11 +72,7 @@ import Data.OgmaSpec            (Spec, externalVariableName, externalVariables,
 import Language.JSONSpec.Parser (JSONFormat (..), parseJSONSpec)
 import Language.XMLSpec.Parser  (parseXMLSpec)
 
--- Internal imports: auxiliary
-import Command.Result                 (Result (..))
-import Data.Location                  (Location (..))
-
--- Internal imports: language ASTs, transformers
+-- External imports: language ASTs, transformers
 import qualified Language.CoCoSpec.AbsCoCoSpec as CoCoSpec
 import qualified Language.CoCoSpec.ParCoCoSpec as CoCoSpec ( myLexer,
                                                              pBoolSpec )
@@ -90,241 +86,88 @@ import qualified Language.Trans.CoCoSpec2Copilot as CoCoSpec (boolSpec2Copilot,
 import           Language.Trans.SMV2Copilot      as SMV (boolSpec2Copilot,
                                                          boolSpecNames)
 
--- Internal imports
-import Paths_ogma_core ( getDataDir )
-
--- * ROS app generation
+-- Internal imports: auxiliary
+import Command.Result  (Result (..))
+import Data.Location   (Location (..))
+import Paths_ogma_core (getDataDir)
 
 -- | Generate a new ROS application connected to Copilot.
-rosApp :: Maybe FilePath -- ^ Input specification file.
-       -> ROSAppOptions  -- ^ Options to the ROS backend.
-       -> IO (Result ErrorCode)
-rosApp fp options =
-    processResult $ do
-      spec  <- parseOptionalInputFile
-                 fp
-                 options
-                 (exprPair (rosAppPropFormat options))
-      vs    <- parseOptionalVariablesFile varNameFile
-      rs    <- parseOptionalRequirementsListFile handlersFile
-      varDB <- parseOptionalVarDBFile varDBFile
-
-      liftEither $ checkArguments spec vs rs
-
-      let varNames = fromMaybe (specExtractExternalVariables spec) vs
-          monitors = fromMaybe (specExtractHandlers spec) rs
-
-      e <- liftIO $
-             rosApp' targetDir mTemplateDir varNames varDB monitors
-      liftEither e
-  where
-    targetDir    = rosAppTargetDir options
-    mTemplateDir = rosAppTemplateDir options
-    varNameFile  = rosAppVariables options
-    varDBFile    = rosAppVariableDB options
-    handlersFile = rosAppHandlers options
-
--- | Generate a new ROS application connected to Copilot, by copying the
--- template and filling additional necessary files.
-rosApp' :: FilePath                           -- ^ Target directory where the
-                                              -- application should be created.
-        -> Maybe FilePath                     -- ^ Directory where the template
-                                              -- is to be found.
-        -> [String]                           -- ^ List of variable names
-                                              -- (data sources).
-        -> [(String, String, String, String)] -- ^ List of variables with their
-                                              -- types, and the message IDs
-                                              -- (topics) they can be obtained
-                                              -- from.
-        -> [String]                           -- ^ List of handlers associated
-                                              -- to the monitors (or
-                                              -- requirements monitored).
-        -> IO (Either ErrorTriplet ())
-rosApp' targetDir mTemplateDir varNames varDB monitors =
-  E.handle (return . Left . cannotCopyTemplate) $ do
+command :: CommandOptions -- ^ Options to the ROS backend.
+        -> IO (Result ErrorCode)
+command options = processResult $ do
     -- Obtain template dir
-    templateDir <- case mTemplateDir of
-                     Just x  -> return x
-                     Nothing -> do
-                       dataDir <- getDataDir
-                       return $ dataDir </> "templates" </> "ros"
+    templateDir <- locateTemplateDir mTemplateDir "ros"
 
-    let subst     = toJSON appData
-        appData   = AppData variables monitors
+    appData <- command' options functions
+
+    let subst = toJSON appData
+
+    -- Expand template
+    ExceptT $ fmap (makeLeftE cannotCopyTemplate) $ E.try $
+      copyTemplate templateDir subst targetDir
+
+  where
+
+    targetDir    = commandTargetDir options
+    mTemplateDir = commandTemplateDir options
+    functions    = exprPair (commandPropFormat options)
+
+command' :: CommandOptions
+         -> ExprPair
+         -> ExceptT ErrorTriplet IO AppData
+command' options (ExprPair exprT) = do
+    -- Open files needed to fill in details in the template.
+    vs    <- parseVariablesFile varNameFile
+    rs    <- parseRequirementsListFile handlersFile
+    varDB <- parseVarDBFile varDBFile
+
+    spec  <- maybe (return Nothing)
+                   (\f -> Just <$> parseInputFile f options exprT)
+                   fp
+
+    liftEither $ checkArguments spec vs rs
+
+    let varNames = fromMaybe (specExtractExternalVariables spec) vs
+        monitors = fromMaybe (specExtractHandlers spec) rs
+
+    let appData   = AppData variables monitors
         variables = mapMaybe (variableMap varDB) varNames
 
-    copyTemplate templateDir subst targetDir
+    return appData
 
-    return $ Right ()
+  where
+
+    fp           = commandInputFile options
+    varNameFile  = commandVariables options
+    varDBFile    = commandVariableDB options
+    handlersFile = commandHandlers options
 
 -- ** Argument processing
 
 -- | Options used to customize the conversion of specifications to ROS
 -- applications.
-data ROSAppOptions = ROSAppOptions
-  { rosAppTargetDir   :: FilePath       -- ^ Target directory where the
-                                        -- application should be created.
-  , rosAppTemplateDir :: Maybe FilePath -- ^ Directory where the template is
-                                        -- to be found.
-  , rosAppVariables   :: Maybe FilePath -- ^ File containing a list of
-                                        -- variables to make available to
-                                        -- Copilot.
-  , rosAppVariableDB  :: Maybe FilePath -- ^ File containing a list of known
-                                        -- variables with their types and the
-                                        -- message IDs they can be obtained
-                                        -- from.
-  , rosAppHandlers    :: Maybe FilePath -- ^ File containing a list of
-                                        -- handlers used in the Copilot
-                                        -- specification. The handlers are
-                                        -- assumed to receive no arguments.
-  , rosAppFormat      :: String         -- ^ Format of the input file.
-  , rosAppPropFormat  :: String         -- ^ Format used for input properties.
-  , rosAppPropVia     :: Maybe String   -- ^ Use external command to
-                                        -- pre-process system properties.
+data CommandOptions = CommandOptions
+  { commandInputFile   :: Maybe FilePath -- ^ Input specification file.
+  , commandTargetDir   :: FilePath       -- ^ Target directory where the
+                                         -- application should be created.
+  , commandTemplateDir :: Maybe FilePath -- ^ Directory where the template is
+                                         -- to be found.
+  , commandVariables   :: Maybe FilePath -- ^ File containing a list of
+                                         -- variables to make available to
+                                         -- Copilot.
+  , commandVariableDB  :: Maybe FilePath -- ^ File containing a list of known
+                                         -- variables with their types and the
+                                         -- message IDs they can be obtained
+                                         -- from.
+  , commandHandlers    :: Maybe FilePath -- ^ File containing a list of
+                                         -- handlers used in the Copilot
+                                         -- specification. The handlers are
+                                         -- assumed to receive no arguments.
+  , commandFormat      :: String         -- ^ Format of the input file.
+  , commandPropFormat  :: String         -- ^ Format used for input properties.
+  , commandPropVia     :: Maybe String   -- ^ Use external command to
+                                         -- pre-process system properties.
   }
-
--- | Process input specification, if available, and return its abstract
--- representation.
-parseOptionalInputFile :: Maybe FilePath
-                       -> ROSAppOptions
-                       -> ExprPair
-                       -> ExceptT ErrorTriplet IO (Maybe (Spec String))
-parseOptionalInputFile Nothing   _    _ =
-  return Nothing
-parseOptionalInputFile (Just fp) opts (ExprPair parse replace print ids def) =
-  ExceptT $ do
-    let wrapper = wrapVia (rosAppPropVia opts) parse
-    -- Obtain format file.
-    --
-    -- A format name that exists as a file in the disk always takes preference
-    -- over a file format included with Ogma. A file format with a forward
-    -- slash in the name is always assumed to be a user-provided filename.
-    -- Regardless of whether the file is user-provided or known to Ogma, we
-    -- check (again) whether the file exists, and print an error message if
-    -- not.
-    let formatName = rosAppFormat opts
-    exists  <- doesFileExist formatName
-    dataDir <- getDataDir
-    let formatFile
-          | isInfixOf "/" formatName || exists
-          = formatName
-          | otherwise
-          = dataDir </> "data" </> "formats" </>
-               (formatName ++ "_" ++ rosAppPropFormat opts)
-    formatMissing <- not <$> doesFileExist formatFile
-
-    if formatMissing
-      then return $ Left $ rosAppIncorrectFormatSpec formatFile
-      else do
-        res <- do
-          format <- readFile formatFile
-
-          -- All of the following operations use Either to return error
-          -- messages.  The use of the monadic bind to pass arguments from one
-          -- function to the next will cause the program to stop at the
-          -- earliest error.
-          if | isPrefixOf "XMLFormat" format
-             -> do let xmlFormat = read format
-                   content <- readFile fp
-                   parseXMLSpec
-                     (fmap (fmap print) . wrapper) (print def) xmlFormat content
-             | otherwise
-             -> do let jsonFormat = read format
-                   content <- B.safeReadFile fp
-                   case content of
-                     Left e  -> return $ Left e
-                     Right b -> do case eitherDecode b of
-                                     Left e  -> return $ Left e
-                                     Right v ->
-                                       parseJSONSpec
-                                         (fmap (fmap print) . wrapper)
-                                         jsonFormat
-                                         v
-        case res of
-          Left e  -> return $ Left $ cannotOpenInputFile fp e
-          Right x -> return $ Right $ Just x
-
--- | Process a variable selection file, if available, and return the variable
--- names.
-parseOptionalVariablesFile :: Maybe FilePath
-                           -> ExceptT ErrorTriplet IO (Maybe [String])
-parseOptionalVariablesFile Nothing = return Nothing
-parseOptionalVariablesFile (Just fp) = do
-  -- Fail if the file cannot be opened.
-  varNamesE <- liftIO $ E.try $ lines <$> readFile fp
-  case varNamesE of
-    Left e         -> throwError $ cannotOpenVarFile fp e
-    Right varNames -> return $ Just varNames
-
--- | Process a requirements / handlers list file, if available, and return the
--- handler names.
-parseOptionalRequirementsListFile :: Maybe FilePath
-                                  -> ExceptT ErrorTriplet IO (Maybe [String])
-parseOptionalRequirementsListFile Nothing = return Nothing
-parseOptionalRequirementsListFile (Just fp) = do
-  -- Fail if the file cannot be opened.
-  handlerNamesE <- liftIO $ E.try $ lines <$> readFile fp
-  case handlerNamesE of
-    Left e         -> throwError $ cannotOpenHandlersFile fp e
-    Right monitors -> return $ Just monitors
-
--- | Process a variable database file, if available, and return the rows in it.
-parseOptionalVarDBFile :: Maybe FilePath
-                       -> ExceptT ErrorTriplet
-                                  IO
-                                  [(String, String, String, String)]
-parseOptionalVarDBFile Nothing   = return []
-parseOptionalVarDBFile (Just fp) = do
-  -- We first try to open the files we need to fill in details in the ROS app
-  -- template.
-  --
-  -- The variable DB is optional, so this check only fails if the filename
-  -- provided does not exist or if the file cannot be opened or parsed (wrong
-  -- format).
-  varDBE <- liftIO $ E.try $ fmap read <$> lines <$> readFile fp
-  case varDBE of
-    Left  e     -> throwError $ cannotOpenDB fp e
-    Right varDB -> return varDB
-
--- | Check that the arguments provided are sufficient to operate.
---
--- The ROS backend provides several modes of operation, which are selected
--- by providing different arguments to the `ros` command.
---
--- When an input specification file is provided, the variables and requirements
--- defined in it are used unless variables or handlers files are provided, in
--- which case the latter take priority.
---
--- If an input file is not provided, then the user must provide BOTH a variable
--- list, and a list of handlers.
-checkArguments :: Maybe (Spec String)
-               -> Maybe [String]
-               -> Maybe [String]
-               -> Either ErrorTriplet ()
-checkArguments Nothing Nothing   Nothing   = Left wrongArguments
-checkArguments Nothing Nothing   _         = Left wrongArguments
-checkArguments Nothing _         Nothing   = Left wrongArguments
-checkArguments _       (Just []) _         = Left wrongArguments
-checkArguments _       _         (Just []) = Left wrongArguments
-checkArguments _       _         _         = Right ()
-
--- | Extract the variables from a specification, and sanitize them to be used
--- in ROS.
-specExtractExternalVariables :: Maybe (Spec String) -> [String]
-specExtractExternalVariables Nothing   = []
-specExtractExternalVariables (Just cs) = map sanitizeLCIdentifier
-                                       $ map externalVariableName
-                                       $ externalVariables cs
-
--- | Extract the requirements from a specification, and sanitize them to match
--- the names of the handlers used by Copilot.
-specExtractHandlers :: Maybe (Spec String) -> [String]
-specExtractHandlers Nothing   = []
-specExtractHandlers (Just cs) = map handlerNameF
-                              $ map requirementName
-                              $ requirements cs
-  where
-    handlerNameF = ("handler" ++) . sanitizeUCIdentifier
 
 -- | Return the variable information needed to generate declarations
 -- and subscriptions for a given variable name and variable database.
@@ -400,6 +243,135 @@ data AppData = AppData
 
 instance ToJSON AppData
 
+-- | Process input specification, if available, and return its abstract
+-- representation.
+parseInputFile :: FilePath
+               -> CommandOptions
+               -> ExprPairT a
+               -> ExceptT ErrorTriplet IO (Spec a)
+parseInputFile fp opts (ExprPairT parse replace print ids def) =
+  ExceptT $ do
+    let wrapper = wrapVia (commandPropVia opts) parse
+    -- Obtain format file.
+    --
+    -- A format name that exists as a file in the disk always takes preference
+    -- over a file format included with Ogma. A file format with a forward
+    -- slash in the name is always assumed to be a user-provided filename.
+    -- Regardless of whether the file is user-provided or known to Ogma, we
+    -- check (again) whether the file exists, and print an error message if
+    -- not.
+    let formatName = commandFormat opts
+    exists  <- doesFileExist formatName
+    dataDir <- getDataDir
+    let formatFile
+          | isInfixOf "/" formatName || exists
+          = formatName
+          | otherwise
+          = dataDir </> "data" </> "formats" </>
+               (formatName ++ "_" ++ commandPropFormat opts)
+    formatMissing <- not <$> doesFileExist formatFile
+
+    if formatMissing
+      then return $ Left $ commandIncorrectFormatSpec formatFile
+      else do
+        res <- do
+          format <- readFile formatFile
+
+          -- All of the following operations use Either to return error
+          -- messages.  The use of the monadic bind to pass arguments from one
+          -- function to the next will cause the program to stop at the
+          -- earliest error.
+          if | isPrefixOf "XMLFormat" format
+             -> do let xmlFormat = read format
+                   content <- readFile fp
+                   parseXMLSpec
+                     (wrapper) (def) xmlFormat content
+                     -- (fmap (fmap print) . wrapper) (print def) xmlFormat content
+             | otherwise
+             -> do let jsonFormat = read format
+                   content <- B.safeReadFile fp
+                   case content of
+                     Left e  -> return $ Left e
+                     Right b -> do case eitherDecode b of
+                                     Left e  -> return $ Left e
+                                     Right v ->
+                                       parseJSONSpec
+                                         (wrapper)
+                                         jsonFormat
+                                         v
+        case res of
+          Left e  -> return $ Left $ cannotOpenInputFile fp
+          Right x -> return $ Right x
+
+-- | Process a variable selection file, if available, and return the variable
+-- names.
+parseVariablesFile :: Maybe FilePath
+                   -> ExceptT ErrorTriplet IO (Maybe [String])
+parseVariablesFile Nothing   = return Nothing
+parseVariablesFile (Just fp) = do
+  -- Fail if the file cannot be opened.
+  varNamesE <- liftIO $ E.try $ lines <$> readFile fp
+  case (varNamesE :: Either E.SomeException [String]) of
+    Left _         -> throwError $ cannotOpenVarFile fp
+    Right varNames -> return $ Just varNames
+
+-- | Process a requirements / handlers list file, if available, and return the
+-- handler names.
+parseRequirementsListFile :: Maybe FilePath
+                          -> ExceptT ErrorTriplet IO (Maybe [String])
+parseRequirementsListFile Nothing   = return Nothing
+parseRequirementsListFile (Just fp) =
+  ExceptT $ makeLeftE (cannotOpenHandlersFile fp) <$>
+    (E.try $ Just . lines <$> readFile fp)
+
+-- | Process a variable database file, if available, and return the rows in it.
+parseVarDBFile :: Read a
+               => Maybe FilePath
+               -> ExceptT ErrorTriplet IO [a]
+parseVarDBFile Nothing   = return []
+parseVarDBFile (Just fn) =
+  ExceptT $ makeLeftE (cannotOpenDB fn) <$>
+    (E.try $ fmap read <$> lines <$> readFile fn)
+
+-- | Check that the arguments provided are sufficient to operate.
+--
+-- The backend provides several modes of operation, which are selected
+-- by providing different arguments to the `ros` command.
+--
+-- When an input specification file is provided, the variables and requirements
+-- defined in it are used unless variables or handlers files are provided, in
+-- which case the latter take priority.
+--
+-- If an input file is not provided, then the user must provide BOTH a variable
+-- list, and a list of handlers.
+checkArguments :: Maybe (Spec a)
+               -> Maybe [String]
+               -> Maybe [String]
+               -> Either ErrorTriplet ()
+checkArguments Nothing Nothing   Nothing   = Left wrongArguments
+checkArguments Nothing Nothing   _         = Left wrongArguments
+checkArguments Nothing _         Nothing   = Left wrongArguments
+checkArguments _       (Just []) _         = Left wrongArguments
+checkArguments _       _         (Just []) = Left wrongArguments
+checkArguments _       _         _         = Right ()
+
+-- | Extract the variables from a specification, and sanitize them.
+specExtractExternalVariables :: Maybe (Spec a) -> [String]
+specExtractExternalVariables Nothing   = []
+specExtractExternalVariables (Just cs) = map sanitizeLCIdentifier
+                                       $ map externalVariableName
+                                       $ externalVariables cs
+
+-- | Extract the requirements from a specification, and sanitize them to match
+-- the names of the handlers used by Copilot.
+specExtractHandlers :: Maybe (Spec a) -> [String]
+specExtractHandlers Nothing   = []
+specExtractHandlers (Just cs) = map handlerNameF
+                              $ map requirementName
+                              $ requirements cs
+  where
+    handlerNameF = ("handler" ++) . sanitizeUCIdentifier
+
 -- * Handler for boolean expressions
 
 -- | Handler for boolean expressions that knows how to parse them, replace
@@ -408,33 +380,38 @@ instance ToJSON AppData
 -- It also contains a default value to be used whenever an expression cannot be
 -- found in the input file.
 data ExprPair = forall a . ExprPair
-  { exprParse   :: String -> Either String a
-  , exprReplace :: [(String, String)] -> a -> a
-  , exprPrint   :: a -> String
-  , exprIdents  :: a -> [String]
-  , exprUnknown :: a
+  { exprTPair   :: ExprPairT a
   }
+
+data ExprPairT a = ExprPairT
+  { exprTParse   :: String -> Either String a
+  , exprTReplace :: [(String, String)] -> a -> a
+  , exprTPrint   :: a -> String
+  , exprTIdents  :: a -> [String]
+  , exprTUnknown :: a
+  }
+
 
 -- | Return a handler depending on whether it should be for CoCoSpec boolean
 -- expressions or for SMV boolean expressions. We default to SMV if not format
 -- is given.
 exprPair :: String -> ExprPair
-exprPair "cocospec" =
-  ExprPair
+exprPair "cocospec" = ExprPair $
+  ExprPairT
     (CoCoSpec.pBoolSpec . CoCoSpec.myLexer)
     (\_ -> id)
     (CoCoSpec.boolSpec2Copilot)
     (CoCoSpec.boolSpecNames)
     (CoCoSpec.BoolSpecSignal (CoCoSpec.Ident "undefined"))
-exprPair "literal" =
-  ExprPair
+exprPair "literal" = ExprPair $
+  ExprPairT
     Right
     (\_ -> id)
     id
     (const [])
     "undefined"
-exprPair _ =
-  ExprPair
+exprPair _ = ExprPair $
+  ExprPairT
     (SMV.pBoolSpec . SMV.myLexer)
     (substituteBoolExpr)
     (SMV.boolSpec2Copilot)
@@ -458,7 +435,27 @@ wrapVia (Just f) parse s =
     out <- readProcess f [] s
     return $ parse out
 
--- * Exception handlers
+-- * Errors
+
+-- | A triplet containing error information.
+data ErrorTriplet = ErrorTriplet ErrorCode String Location
+
+-- | Encoding of reasons why the command can fail.
+--
+-- The error codes used are 1 for user error, and 2 for internal bug.
+type ErrorCode = Int
+
+-- | Process a computation that can fail with an error code, and turn it into a
+-- computation that returns a 'Result'.
+processResult :: Monad m => ExceptT ErrorTriplet m a -> m (Result ErrorCode)
+processResult m = do
+  r <- runExceptT m
+  case r of
+    Left (ErrorTriplet errorCode msg location)
+      -> return $ Error errorCode msg location
+    _ -> return Success
+
+-- ** Error messages
 
 -- | Exception handler to deal with the case in which the arguments
 -- provided are incorrect.
@@ -472,8 +469,8 @@ wrongArguments =
 
 -- | Exception handler to deal with the case in which the input file cannot be
 -- opened.
-cannotOpenInputFile :: FilePath -> String -> ErrorTriplet
-cannotOpenInputFile file _e =
+cannotOpenInputFile :: FilePath -> ErrorTriplet
+cannotOpenInputFile file =
     ErrorTriplet ecCannotOpenInputFile msg (LocationFile file)
   where
     msg =
@@ -481,71 +478,52 @@ cannotOpenInputFile file _e =
 
 -- | Exception handler to deal with the case in which the variable DB cannot be
 -- opened.
-cannotOpenDB :: FilePath -> E.SomeException -> ErrorTriplet
-cannotOpenDB file _e =
-    ErrorTriplet ecCannotOpenDBUser msg (LocationFile file)
+cannotOpenDB :: FilePath -> ErrorTriplet
+cannotOpenDB file =
+    ErrorTriplet ecCannotOpenDBFile msg (LocationFile file)
   where
     msg =
       "cannot open variable DB file " ++ file
 
 -- | Exception handler to deal with the case in which the variable file
 -- provided by the user cannot be opened.
-cannotOpenVarFile :: FilePath -> E.SomeException -> ErrorTriplet
-cannotOpenVarFile file _e =
+cannotOpenVarFile :: FilePath -> ErrorTriplet
+cannotOpenVarFile file =
     ErrorTriplet ecCannotOpenVarFile  msg (LocationFile file)
   where
     msg =
       "cannot open variable list file " ++ file
 
--- | Exception handler to deal with the case in which the handlers file
--- provided by the user cannot be opened.
-cannotOpenHandlersFile :: FilePath -> E.SomeException -> ErrorTriplet
-cannotOpenHandlersFile file _e =
-    ErrorTriplet ecCannotOpenHandlersFile  msg (LocationFile file)
+-- | Exception handler to deal with the case in which the handlers file cannot
+-- be opened.
+cannotOpenHandlersFile :: FilePath -> ErrorTriplet
+cannotOpenHandlersFile file =
+    ErrorTriplet ecCannotOpenHandlersFile msg (LocationFile file)
   where
     msg =
-      "cannot open handler list file " ++ file
+      "cannot open handlers file " ++ file
 
--- | Exception handler to deal with the case of files that cannot be
--- copied/generated due lack of space or permissions or some I/O error.
-cannotCopyTemplate :: E.SomeException -> ErrorTriplet
-cannotCopyTemplate e =
-    ErrorTriplet ecCannotCopyTemplate msg LocationNothing
-  where
-    msg =
-      "ROS app generation failed during copy/write operation. Check that"
-      ++ " there's free space in the disk and that you have the necessary"
-      ++ " permissions to write in the destination directory."
-      ++ show e
-
--- | Error messages associated to the format file not being found.
-rosAppIncorrectFormatSpec :: String -> ErrorTriplet
-rosAppIncorrectFormatSpec formatFile =
-    ErrorTriplet ecIncorrectFormatFile msg LocationNothing
+-- | Error message associated to the format file not being found.
+commandIncorrectFormatSpec :: FilePath -> ErrorTriplet
+commandIncorrectFormatSpec formatFile =
+    ErrorTriplet ecIncorrectFormatFile msg (LocationFile formatFile)
   where
     msg =
       "The format specification " ++ formatFile ++ " does not exist or is not "
       ++ "readable"
 
--- | A triplet containing error information.
-data ErrorTriplet = ErrorTriplet ErrorCode String Location
+-- | Exception handler to deal with the case of files that cannot be
+-- copied/generated due lack of space or permissions or some I/O error.
+cannotCopyTemplate :: ErrorTriplet
+cannotCopyTemplate =
+    ErrorTriplet ecCannotCopyTemplate msg LocationNothing
+  where
+    msg =
+      "Generation failed during copy/write operation. Check that"
+      ++ " there's free space in the disk and that you have the necessary"
+      ++ " permissions to write in the destination directory."
 
--- | Process a computation that can fail with an error code, and turn it into a
--- computation that returns a 'Result'.
-processResult :: Monad m => ExceptT ErrorTriplet m a -> m (Result ErrorCode)
-processResult m = do
-  r <- runExceptT m
-  case r of
-    Left (ErrorTriplet errorCode msg location)
-      -> return $ Error errorCode msg location
-    _ -> return Success
-
--- * Error codes
-
--- | Encoding of reasons why the command can fail.
---
--- The error codes used are 1 for user error, and 2 for internal bug.
-type ErrorCode = Int
+-- ** Error codes
 
 -- | Error: wrong arguments provided.
 ecWrongArguments :: ErrorCode
@@ -556,8 +534,8 @@ ecCannotOpenInputFile :: ErrorCode
 ecCannotOpenInputFile = 1
 
 -- | Error: the variable DB provided by the user cannot be opened.
-ecCannotOpenDBUser :: ErrorCode
-ecCannotOpenDBUser = 1
+ecCannotOpenDBFile :: ErrorCode
+ecCannotOpenDBFile = 1
 
 -- | Error: the variable file provided by the user cannot be opened.
 ecCannotOpenVarFile :: ErrorCode
@@ -567,11 +545,29 @@ ecCannotOpenVarFile = 1
 ecCannotOpenHandlersFile :: ErrorCode
 ecCannotOpenHandlersFile = 1
 
+-- | Error: the format file cannot be opened.
+ecIncorrectFormatFile :: ErrorCode
+ecIncorrectFormatFile = 1
+
 -- | Error: the files cannot be copied/generated due lack of space or
 -- permissions or some I/O error.
 ecCannotCopyTemplate :: ErrorCode
 ecCannotCopyTemplate = 1
 
--- | Error: the format file cannot be opened.
-ecIncorrectFormatFile :: ErrorCode
-ecIncorrectFormatFile = 1
+-- * Auxiliary Functions
+
+-- | Return the path to the template directory.
+locateTemplateDir :: Maybe FilePath
+                  -> FilePath
+                  -> ExceptT e IO FilePath
+locateTemplateDir mTemplateDir name =
+  case mTemplateDir of
+    Just x  -> return x
+    Nothing -> liftIO $ do
+      dataDir <- getDataDir
+      return $ dataDir </> "templates" </> name
+
+-- | Replace the left Exception in an Either.
+makeLeftE :: c -> Either E.SomeException b -> Either c b
+makeLeftE c (Left _)   = Left c
+makeLeftE _ (Right x)  = Right x

--- a/ogma-core/tests/Main.hs
+++ b/ogma-core/tests/Main.hs
@@ -10,7 +10,7 @@ import System.Directory               ( getTemporaryDirectory )
 -- Internal imports
 import Command.CStructs2Copilot (cstructs2Copilot)
 import Command.Result           (isSuccess)
-import Command.Standalone       (StandaloneOptions (..), standalone)
+import Command.Standalone       (CommandOptions (..), command)
 
 -- | Run all unit tests on ogma-core.
 main :: IO ()
@@ -102,16 +102,17 @@ testStandaloneFCS :: FilePath  -- ^ Path to a input file
                   -> IO ()
 testStandaloneFCS file success = do
     targetDir <- getTemporaryDirectory
-    let opts = StandaloneOptions
-                 { standaloneFormat      = "fcs"
-                 , standalonePropFormat  = "smv"
-                 , standaloneTypeMapping = [("int", "Int64"), ("real", "Float")]
-                 , standaloneFilename    = "monitor"
-                 , standaloneTargetDir   = targetDir
-                 , standaloneTemplateDir = Nothing
-                 , standalonePropVia     = Nothing
+    let opts = CommandOptions
+                 { commandInputFile   = file
+                 , commandFormat      = "fcs"
+                 , commandPropFormat  = "smv"
+                 , commandTypeMapping = [("int", "Int64"), ("real", "Float")]
+                 , commandFilename    = "monitor"
+                 , commandTargetDir   = targetDir
+                 , commandTemplateDir = Nothing
+                 , commandPropVia     = Nothing
                  }
-    result <- standalone file opts
+    result <- command opts
 
     -- True if success is expected and detected, or niether expected nor
     -- detected.
@@ -137,16 +138,17 @@ testStandaloneFDB :: FilePath  -- ^ Path to input file
                   -> IO ()
 testStandaloneFDB file success = do
     targetDir <- getTemporaryDirectory
-    let opts = StandaloneOptions
-                 { standaloneFormat      = "fdb"
-                 , standalonePropFormat  = "cocospec"
-                 , standaloneTypeMapping = []
-                 , standaloneFilename    = "monitor"
-                 , standaloneTargetDir   = targetDir
-                 , standaloneTemplateDir = Nothing
-                 , standalonePropVia     = Nothing
+    let opts = CommandOptions
+                 { commandInputFile   = file
+                 , commandFormat      = "fdb"
+                 , commandPropFormat  = "cocospec"
+                 , commandTypeMapping = []
+                 , commandFilename    = "monitor"
+                 , commandTargetDir   = targetDir
+                 , commandTemplateDir = Nothing
+                 , commandPropVia     = Nothing
                  }
-    result <- standalone file opts
+    result <- command opts
 
     -- True if success is expected and detected, or niether expected nor
     -- detected.


### PR DESCRIPTION
Equalize the backends in terms of top-level names and interface, file handling, error handling, function naming, and production of results, and adjust the CLI and tests accordingly, as prescribed in the solution proposed for #248.