### PR TITLE
`ogma-cli`: Make cFS backend accept spec as input. Refs #252.

### DIFF
--- a/ogma-cli/CHANGELOG.md
+++ b/ogma-cli/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Update README with new FPrime template variables (#246).
 * Adjust CLI to match new backend API (#248).
 * Expose template-vars argument to ROS, FPrime, standalone backends (#250).
+* Expose spec processing arguments to cFS backend in CLI (#252).
 
 ## [1.6.0] - 2025-01-21
 

--- a/ogma-cli/README.md
+++ b/ogma-cli/README.md
@@ -124,19 +124,42 @@ necessary messages and make it available to Copilot. Ogma provides additional
 flags to customize the list of known variables, so that projects can maintain
 their own variable databases beyond what Ogma includes by default.
 
-cFS applications are generated using the Ogma command `cfs`, which receives
-four main arguments:
+cFS applications are generated using the Ogma command `cfs`, which accepts
+the following arguments:
+- `--input-file FILENAME`: location of the specification or source file for
+  which a cFS application is being generated.
 - `--app-target-dir DIR`: location where the cFS application files must be
   stored.
 - `--app-template-dir DIR`: location of the cFS application template to use.
-- `--variable-file FILENAME`: a file containing a list of variables that must
-be made available to the monitor.
+- `--variable-file FILENAME`: a file containing a list of variables to monitor
+in the cFS application.
 - `--variable-db FILENAME`: a file containing a database of known variables,
 and the message they are included with.
 - `--handlers-file FILENAME`: a file containing a list of known fault handlers
   or triggers.
+- `--input-format FORMAT_NAME`: the name of a know input format description
+  file in JSON or XML. It can be a path to a file containing such description.
+- `--prop-format FORMAT_NAME`: the name of the format or language in which the
+  properties are encoded. For example, a file may contain a list of properties,
+  and each property may contain a field with a formula in SMV (`smv`) or
+  Copilot (`literal`).
+- `--parse-prop-via COMMAND`: a command in the `PATH` capable of translating
+  properties as listed in the specification file into properties in the target
+  property language. This external process may be a translation tool, or an LLM
+  capable of translating into the target language.
 - `--template-vars FILENAME`: a JSON file containing a list of additional
   variables to expand in the template.
+
+> [!NOTE]
+> Ogma does not guarantee that the result of a translation carried out by
+> calling an external command or LLM with the flag `--parse-prop-via` is
+> correct. It is your responsibility as the user to check the output produced
+> by the auxiliary translation command for accuracy. Ogma will accept whatever
+> output the command produces as a replacement for the property's formula, and
+> use it without changes if the property format selected is `literal`, or try
+> to translate it into Copilot if a different property format has been
+> selected. This limitation applies even in the case where the subsequent
+> translation to Copilot succeeds.
 
 The following execution generates an initial cFS application for runtime
 monitoring using Copilot:

--- a/ogma-cli/src/CLI/CommandCFSApp.hs
+++ b/ogma-cli/src/CLI/CommandCFSApp.hs
@@ -43,8 +43,8 @@ module CLI.CommandCFSApp
   where
 
 -- External imports
-import Options.Applicative ( Parser, help, long, metavar, optional, showDefault,
-                             strOption, value )
+import Options.Applicative ( Parser, help, long, metavar, optional, short,
+                             showDefault, strOption, value )
 
 -- External imports: command results
 import Command.Result ( Result )
@@ -57,11 +57,15 @@ import qualified Command.CFSApp
 
 -- | Options needed to generate the cFS application.
 data CommandOpts = CommandOpts
-  { cFSAppTarget       :: String
+  { cFSAppInputFile    :: Maybe String
+  , cFSAppTarget       :: String
   , cFSAppTemplateDir  :: Maybe String
   , cFSAppVarNames     :: Maybe String
   , cFSAppVarDB        :: Maybe String
   , cFSAppHandlers     :: Maybe String
+  , cFSAppFormat       :: String
+  , cFSAppPropFormat   :: String
+  , cFSAppPropVia      :: Maybe String
   , cFSAppTemplateVars :: Maybe String
   }
 
@@ -74,11 +78,15 @@ command :: CommandOpts -> IO (Result ErrorCode)
 command c = Command.CFSApp.command options
   where
     options = Command.CFSApp.CommandOptions
-                { Command.CFSApp.commandTargetDir   = cFSAppTarget c
+                { Command.CFSApp.commandInputFile   = cFSAppInputFile c
+                , Command.CFSApp.commandTargetDir   = cFSAppTarget c
                 , Command.CFSApp.commandTemplateDir = cFSAppTemplateDir c
                 , Command.CFSApp.commandVariables   = cFSAppVarNames c
                 , Command.CFSApp.commandVariableDB  = cFSAppVarDB c
                 , Command.CFSApp.commandHandlers    = cFSAppHandlers c
+                , Command.CFSApp.commandFormat      = cFSAppFormat c
+                , Command.CFSApp.commandPropFormat  = cFSAppPropFormat c
+                , Command.CFSApp.commandPropVia     = cFSAppPropVia c
                 , Command.CFSApp.commandExtraVars   = cFSAppTemplateVars c
                 }
 
@@ -92,7 +100,14 @@ commandDesc = "Generate a complete cFS/Copilot application"
 -- System application connected to Copilot monitors.
 commandOptsParser :: Parser CommandOpts
 commandOptsParser = CommandOpts
-  <$> strOption
+  <$> optional
+        ( strOption
+            (  long "input-file"
+            <> metavar "FILENAME"
+            <> help strCFSAppFileNameArgDesc
+            )
+        )
+  <*> strOption
         (  long "app-target-dir"
         <> metavar "DIR"
         <> showDefault
@@ -110,8 +125,6 @@ commandOptsParser = CommandOpts
         ( strOption
             (  long "variable-file"
             <> metavar "FILENAME"
-            <> showDefault
-            <> value "variables"
             <> help strCFSAppVarListArgDesc
             )
         )
@@ -127,6 +140,29 @@ commandOptsParser = CommandOpts
             (  long "handlers-file"
             <> metavar "FILENAME"
             <> help strCFSAppHandlerListArgDesc
+            )
+        )
+  <*> strOption
+        (  long "input-format"
+        <> short 'f'
+        <> metavar "FORMAT_NAME"
+        <> help strCFSAppFormatDesc
+        <> showDefault
+        <> value "fcs"
+        )
+  <*> strOption
+        (  long "prop-format"
+        <> short 'p'
+        <> metavar "FORMAT_NAME"
+        <> help strCFSAppPropFormatDesc
+        <> showDefault
+        <> value "smv"
+        )
+  <*> optional
+        ( strOption
+            (  long "parse-prop-via"
+            <> metavar "COMMAND"
+            <> help strCFSAppPropViaDesc
             )
         )
   <*> optional
@@ -146,6 +182,12 @@ strCFSAppTemplateDirArgDesc :: String
 strCFSAppTemplateDirArgDesc =
   "Directory holding cFS application source template"
 
+-- | Argument input file to CFS app generation command
+strCFSAppFileNameArgDesc :: String
+strCFSAppFileNameArgDesc =
+  "File containing input specification"
+
+
 -- | Argument variable list to cFS app generation command
 strCFSAppVarListArgDesc :: String
 strCFSAppVarListArgDesc =
@@ -160,6 +202,19 @@ strCFSAppVarDBArgDesc =
 strCFSAppHandlerListArgDesc :: String
 strCFSAppHandlerListArgDesc =
   "File containing list of Copilot handlers used in the specification"
+
+-- | Format flag description.
+strCFSAppFormatDesc :: String
+strCFSAppFormatDesc = "Format of the input file"
+
+-- | Property format flag description.
+strCFSAppPropFormatDesc :: String
+strCFSAppPropFormatDesc = "Format of temporal or boolean properties"
+
+-- | External command to pre-process individual properties.
+strCFSAppPropViaDesc :: String
+strCFSAppPropViaDesc =
+  "Command to pre-process individual properties"
 
 -- | Argument template variables to cFS app generation command
 strCFSAppTemplateVarsArgDesc :: String

--- a/ogma-core/CHANGELOG.md
+++ b/ogma-core/CHANGELOG.md
@@ -18,6 +18,7 @@
 * Make structured data available to FPrime template (#246).
 * Equalize backends (#248).
 * Update ROS, FPrime, standalone backends to process template vars file (#250).
+* Make cFS backend accept spec as input (#252).
 
 ## [1.6.0] - 2025-01-21
 


### PR DESCRIPTION
Extend the cFS backend to accept an additional argument filename containing an input specification, as well as arguments indicating the formats of the file and the properties, as well as a pre-processor, as prescribed in the solution proposed for #252.