### PR TITLE
`ogma-core`: Add all auxiliary test files to distributable Cabal package. Refs #258.

### DIFF
--- a/ogma-core/CHANGELOG.md
+++ b/ogma-core/CHANGELOG.md
@@ -24,6 +24,7 @@
 * Make backends accept additional data to be passed to handlers (#219).
 * Add support to read properties from CSV files (#261).
 * Add support to read properties from XLSX files (#263).
+* Add all auxiliary test files to distributable Cabal package (#258).
 
 ## [1.6.0] - 2025-01-21
 

--- a/ogma-core/ogma-core.cabal
+++ b/ogma-core/ogma-core.cabal
@@ -41,6 +41,13 @@ author:              Ivan Perez, Alwyn Goodloe
 maintainer:          ivan.perezdominguez@nasa.gov
 category:            Aerospace
 extra-source-files:  CHANGELOG.md
+                     tests/commands-fcs-error-parsing-failed-1.json
+                     tests/commands-fcs-error-parsing-failed-2.json
+                     tests/commands-fcs-error-parsing-failed-3.json
+                     tests/fcs_good.json
+                     tests/fdb-example1.json
+                     tests/reduced_geofence_msgs_bad.h
+                     tests/reduced_geofence_msgs.h
 
 synopsis:            Ogma: Helper tool to interoperate between Copilot and other languages.
 


### PR DESCRIPTION
Modify Cabal package to include all auxiliary test files in the Cabal source package, as prescribed in the solution proposed for #258.