### PR TITLE
`ogma-cli`: Extend code commands to accept expressions to monitor as CLI arguments. Refs #121.

### DIFF
--- a/ogma-cli/CHANGELOG.md
+++ b/ogma-cli/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Revision history for ogma-cli
 
-## [1.X.Y] - 2025-07-09
+## [1.X.Y] - 2025-07-12
 
 * Expose overview command (#272).
+* Extend code commands to accept expressions to monitor as CLI arguments (#121).
 
 ## [1.7.0] - 2025-03-21
 

--- a/ogma-cli/src/CLI/CommandCFSApp.hs
+++ b/ogma-cli/src/CLI/CommandCFSApp.hs
@@ -57,7 +57,8 @@ import qualified Command.CFSApp
 
 -- | Options needed to generate the cFS application.
 data CommandOpts = CommandOpts
-  { cFSAppInputFile    :: Maybe String
+  { cFSAppConditionExpr  :: Maybe String
+  , cFSAppInputFile    :: Maybe String
   , cFSAppTarget       :: String
   , cFSAppTemplateDir  :: Maybe String
   , cFSAppVarNames     :: Maybe String
@@ -78,7 +79,8 @@ command :: CommandOpts -> IO (Result ErrorCode)
 command c = Command.CFSApp.command options
   where
     options = Command.CFSApp.CommandOptions
-                { Command.CFSApp.commandInputFile   = cFSAppInputFile c
+                { Command.CFSApp.commandConditionExpr = cFSAppConditionExpr c
+                , Command.CFSApp.commandInputFile   = cFSAppInputFile c
                 , Command.CFSApp.commandTargetDir   = cFSAppTarget c
                 , Command.CFSApp.commandTemplateDir = cFSAppTemplateDir c
                 , Command.CFSApp.commandVariables   = cFSAppVarNames c
@@ -101,6 +103,13 @@ commandDesc = "Generate a complete cFS/Copilot application"
 commandOptsParser :: Parser CommandOpts
 commandOptsParser = CommandOpts
   <$> optional
+        ( strOption
+            (  long "condition-expr"
+            <> metavar "EXPRESSION"
+            <> help strCFSAppConditionExprArgDesc
+            )
+        )
+  <*> optional
         ( strOption
             (  long "input-file"
             <> metavar "FILENAME"
@@ -181,6 +190,11 @@ strCFSAppDirArgDesc = "Target directory"
 strCFSAppTemplateDirArgDesc :: String
 strCFSAppTemplateDirArgDesc =
   "Directory holding cFS application source template"
+
+-- | Argument expression to CFS app generation command.
+strCFSAppConditionExprArgDesc :: String
+strCFSAppConditionExprArgDesc =
+  "Expression used as guard or trigger condition"
 
 -- | Argument input file to CFS app generation command
 strCFSAppFileNameArgDesc :: String

--- a/ogma-cli/src/CLI/CommandFPrimeApp.hs
+++ b/ogma-cli/src/CLI/CommandFPrimeApp.hs
@@ -57,7 +57,8 @@ import qualified Command.FPrimeApp
 
 -- | Options needed to generate the FPrime component.
 data CommandOpts = CommandOpts
-  { fprimeAppInputFile    :: Maybe String
+  { fprimeAppConditionExpr  :: Maybe String
+  , fprimeAppInputFile    :: Maybe String
   , fprimeAppTarget       :: String
   , fprimeAppTemplateDir  :: Maybe String
   , fprimeAppVariables    :: Maybe String
@@ -79,7 +80,8 @@ command c = Command.FPrimeApp.command options
   where
     options =
       Command.FPrimeApp.CommandOptions
-        { Command.FPrimeApp.commandInputFile   = fprimeAppInputFile c
+        { Command.FPrimeApp.commandConditionExpr = fprimeAppConditionExpr c
+        , Command.FPrimeApp.commandInputFile   = fprimeAppInputFile c
         , Command.FPrimeApp.commandTargetDir   = fprimeAppTarget c
         , Command.FPrimeApp.commandTemplateDir = fprimeAppTemplateDir c
         , Command.FPrimeApp.commandVariables   = fprimeAppVariables c
@@ -102,6 +104,13 @@ commandDesc = "Generate a complete F' monitoring component"
 commandOptsParser :: Parser CommandOpts
 commandOptsParser = CommandOpts
   <$> optional
+        ( strOption
+            (  long "condition-expr"
+            <> metavar "EXPRESSION"
+            <> help strFPrimeAppConditionExprArgDesc
+            )
+        )
+  <*> optional
         ( strOption
             (  long "input-file"
             <> metavar "FILENAME"
@@ -182,6 +191,10 @@ strFPrimeAppDirArgDesc = "Target directory"
 strFPrimeAppTemplateDirArgDesc :: String
 strFPrimeAppTemplateDirArgDesc =
   "Directory holding F' component source template"
+
+-- | Argument expression to FPrime app generation command.
+strFPrimeAppConditionExprArgDesc :: String
+strFPrimeAppConditionExprArgDesc = "Expression used as guard or trigger condition"
 
 -- | Argument input file to FPrime component generation command
 strFPrimeAppFileNameArgDesc :: String

--- a/ogma-cli/src/CLI/CommandROSApp.hs
+++ b/ogma-cli/src/CLI/CommandROSApp.hs
@@ -57,7 +57,8 @@ import qualified Command.ROSApp
 
 -- | Options needed to generate the ROS application.
 data CommandOpts = CommandOpts
-  { rosAppInputFile    :: Maybe String
+  { rosAppConditionExpr  :: Maybe String
+  , rosAppInputFile    :: Maybe String
   , rosAppTarget       :: String
   , rosAppTemplateDir  :: Maybe String
   , rosAppVarNames     :: Maybe String
@@ -78,7 +79,8 @@ command :: CommandOpts -> IO (Result ErrorCode)
 command c = Command.ROSApp.command options
   where
     options = Command.ROSApp.CommandOptions
-                { Command.ROSApp.commandInputFile   = rosAppInputFile c
+                { Command.ROSApp.commandConditionExpr = rosAppConditionExpr c
+                , Command.ROSApp.commandInputFile   = rosAppInputFile c
                 , Command.ROSApp.commandTargetDir   = rosAppTarget c
                 , Command.ROSApp.commandTemplateDir = rosAppTemplateDir c
                 , Command.ROSApp.commandVariables   = rosAppVarNames c
@@ -101,6 +103,13 @@ commandDesc = "Generate a ROS 2 monitoring package"
 commandOptsParser :: Parser CommandOpts
 commandOptsParser = CommandOpts
   <$> optional
+        ( strOption
+            (  long "condition-expr"
+            <> metavar "EXPRESSION"
+            <> help strROSAppConditionExprArgDesc
+            )
+        )
+  <*> optional
         ( strOption
             (  long "input-file"
             <> metavar "FILENAME"
@@ -181,6 +190,10 @@ strROSAppDirArgDesc = "Target directory"
 strROSAppTemplateDirArgDesc :: String
 strROSAppTemplateDirArgDesc =
   "Directory holding ROS application source template"
+
+-- | Argument expression to ROS app generation command.
+strROSAppConditionExprArgDesc :: String
+strROSAppConditionExprArgDesc = "Expression used as guard or trigger condition"
 
 -- | Argument input file to ROS app generation command
 strROSAppFileNameArgDesc :: String

--- a/ogma-cli/src/CLI/CommandStandalone.hs
+++ b/ogma-cli/src/CLI/CommandStandalone.hs
@@ -60,7 +60,8 @@ import qualified Command.Standalone
 data CommandOpts = CommandOpts
   { standaloneTargetDir    :: FilePath
   , standaloneTemplateDir  :: Maybe FilePath
-  , standaloneFileName     :: FilePath
+  , standaloneConditionExpr  :: Maybe String
+  , standaloneFileName     :: Maybe FilePath
   , standaloneFormat       :: String
   , standalonePropFormat   :: String
   , standaloneTypes        :: [String]
@@ -76,7 +77,8 @@ command c =
   where
     internalCommandOpts :: Command.Standalone.CommandOptions
     internalCommandOpts = Command.Standalone.CommandOptions
-      { Command.Standalone.commandInputFile   = standaloneFileName c
+      { Command.Standalone.commandConditionExpr = standaloneConditionExpr c
+      , Command.Standalone.commandInputFile   = standaloneFileName c
       , Command.Standalone.commandTargetDir   = standaloneTargetDir c
       , Command.Standalone.commandTemplateDir = standaloneTemplateDir c
       , Command.Standalone.commandFormat      = standaloneFormat c
@@ -121,10 +123,19 @@ commandOptsParser = CommandOpts
             <> help strStandaloneTemplateDirArgDesc
             )
         )
-  <*> strOption
-        (  long "file-name"
-        <> metavar "FILENAME"
-        <> help strStandaloneFilenameDesc
+  <*> optional
+        ( strOption
+          (  long "condition-expr"
+          <> metavar "FILENAME"
+          <> help strStandaloneConditionExprDesc
+          )
+        )
+  <*> optional
+        ( strOption
+          (  long "file-name"
+          <> metavar "FILENAME"
+          <> help strStandaloneFilenameDesc
+          )
         )
   <*> strOption
         (  long "input-format"
@@ -178,6 +189,11 @@ strStandaloneTargetDirDesc = "Target directory"
 -- | Template dir flag description.
 strStandaloneTemplateDirArgDesc :: String
 strStandaloneTemplateDirArgDesc = "Directory holding standalone source template"
+
+-- | Condition flag description.
+strStandaloneConditionExprDesc :: String
+strStandaloneConditionExprDesc =
+  "Condition upon which the monitor will fire or notify"
 
 -- | Filename flag description.
 strStandaloneFilenameDesc :: String

--- a/ogma-core/CHANGELOG.md
+++ b/ogma-core/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Revision history for ogma-core
 
-## [1.X.Y] - 2025-07-09
+## [1.X.Y] - 2025-07-12
 
 * Introduce overview command (#272).
+* Extend code backends to accept expressions to monitor as arguments (#121).
 
 ## [1.7.0] - 2025-03-21
 

--- a/ogma-core/src/Command/CFSApp.hs
+++ b/ogma-core/src/Command/CFSApp.hs
@@ -50,7 +50,7 @@ module Command.CFSApp
   where
 
 -- External imports
-import           Control.Applicative    ( liftA2 )
+import           Control.Applicative    ( liftA2, (<|>) )
 import qualified Control.Exception      as E
 import           Control.Monad.Except   ( ExceptT (..), liftEither )
 import           Data.Aeson             ( ToJSON (..) )
@@ -106,11 +106,14 @@ command' options (ExprPair exprT) = do
     rs    <- parseRequirementsListFile handlersFile
     varDB <- openVarDBFilesWithDefault varDBFile
 
-    spec  <- maybe (return Nothing) (\f -> Just <$> parseInputFile' f) fp
+    specT <- maybe (return Nothing) (\e -> Just <$> parseInputExpr' e) cExpr
+    specF <- maybe (return Nothing) (\f -> Just <$> parseInputFile' f) fp
+
+    let spec = specT <|> specF
 
     liftEither $ checkArguments spec vs rs
 
-    copilotM <- sequenceA $ liftA2 processSpec spec fp
+    copilotM <- sequenceA $ (\spec' -> processSpec spec' fp cExpr) <$> spec
 
     let varNames = fromMaybe (specExtractExternalVariables spec) vs
         monitors = maybe
@@ -125,6 +128,7 @@ command' options (ExprPair exprT) = do
 
   where
 
+    cExpr          = commandConditionExpr options
     fp             = commandInputFile options
     varNameFile    = commandVariables options
     varDBFile      = maybeToList $ commandVariableDB options
@@ -133,11 +137,14 @@ command' options (ExprPair exprT) = do
     propFormatName = commandPropFormat options
     propVia        = commandPropVia options
 
+    parseInputExpr' e =
+      parseInputExpr e propFormatName propVia exprT
+
     parseInputFile' f =
       parseInputFile f formatName propFormatName propVia exprT
 
-    processSpec spec' fp' =
-      Command.Standalone.commandLogic fp' "copilot" [] exprT spec'
+    processSpec spec' expr' fp' =
+      Command.Standalone.commandLogic expr' fp' "copilot" [] exprT spec'
 
 -- | Generate a variable substitution map for a cFS application.
 commandLogic :: VariableDB
@@ -163,7 +170,8 @@ commandLogic varDB varNames handlers copilotM =
 -- | Options used to customize the conversion of specifications to ROS
 -- applications.
 data CommandOptions = CommandOptions
-  { commandInputFile   :: Maybe FilePath -- ^ Input specification file.
+  { commandConditionExpr :: Maybe String   -- ^ Trigger condition.
+  , commandInputFile   :: Maybe FilePath -- ^ Input specification file.
   , commandTargetDir   :: FilePath       -- ^ Target directory where the
                                          -- application should be created.
   , commandTemplateDir :: Maybe FilePath -- ^ Directory where the template is

--- a/ogma-core/src/Command/ROSApp.hs
+++ b/ogma-core/src/Command/ROSApp.hs
@@ -49,7 +49,7 @@ module Command.ROSApp
   where
 
 -- External imports
-import           Control.Applicative  (liftA2)
+import           Control.Applicative  (liftA2, (<|>))
 import qualified Control.Exception    as E
 import           Control.Monad.Except (ExceptT (..), liftEither)
 import           Data.Aeson           (ToJSON (..))
@@ -104,11 +104,14 @@ command' options (ExprPair exprT) = do
     rs    <- parseRequirementsListFile handlersFile
     varDB <- openVarDBFilesWithDefault varDBFile
 
-    spec  <- maybe (return Nothing) (\f -> Just <$> parseInputFile' f) fp
+    specT <- maybe (return Nothing) (\e -> Just <$> parseInputExpr' e) cExpr
+    specF <- maybe (return Nothing) (\f -> Just <$> parseInputFile' f) fp
+
+    let spec = specT <|> specF
 
     liftEither $ checkArguments spec vs rs
 
-    copilotM <- sequenceA $ liftA2 processSpec spec fp
+    copilotM <- sequenceA $ (\spec' -> processSpec spec' fp cExpr) <$> spec
 
     let varNames = fromMaybe (specExtractExternalVariables spec) vs
         monitors = maybe
@@ -124,6 +127,7 @@ command' options (ExprPair exprT) = do
 
   where
 
+    cExpr          = commandConditionExpr options
     fp             = commandInputFile options
     varNameFile    = commandVariables options
     varDBFile      = maybeToList $ commandVariableDB options
@@ -132,18 +136,22 @@ command' options (ExprPair exprT) = do
     propFormatName = commandPropFormat options
     propVia        = commandPropVia options
 
+    parseInputExpr' e =
+      parseInputExpr e propFormatName propVia exprT
+
     parseInputFile' f =
       parseInputFile f formatName propFormatName propVia exprT
 
-    processSpec spec' fp' =
-      Command.Standalone.commandLogic fp' "copilot" [] exprT spec'
+    processSpec spec' expr' fp' =
+      Command.Standalone.commandLogic expr' fp' "copilot" [] exprT spec'
 
 -- ** Argument processing
 
 -- | Options used to customize the conversion of specifications to ROS
 -- applications.
 data CommandOptions = CommandOptions
-  { commandInputFile   :: Maybe FilePath -- ^ Input specification file.
+  { commandConditionExpr :: Maybe String   -- ^ Trigger condition.
+  , commandInputFile   :: Maybe FilePath -- ^ Input specification file.
   , commandTargetDir   :: FilePath       -- ^ Target directory where the
                                          -- application should be created.
   , commandTemplateDir :: Maybe FilePath -- ^ Directory where the template is

--- a/ogma-core/tests/Main.hs
+++ b/ogma-core/tests/Main.hs
@@ -103,7 +103,8 @@ testStandaloneFCS :: FilePath  -- ^ Path to a input file
 testStandaloneFCS file success = do
     targetDir <- getTemporaryDirectory
     let opts = CommandOptions
-                 { commandInputFile   = file
+                 { commandConditionExpr = Nothing
+                 , commandInputFile   = Just file
                  , commandFormat      = "fcs"
                  , commandPropFormat  = "smv"
                  , commandTypeMapping = [("int", "Int64"), ("real", "Float")]
@@ -140,7 +141,8 @@ testStandaloneFDB :: FilePath  -- ^ Path to input file
 testStandaloneFDB file success = do
     targetDir <- getTemporaryDirectory
     let opts = CommandOptions
-                 { commandInputFile   = file
+                 { commandConditionExpr = Nothing
+                 , commandInputFile   = Just file
                  , commandFormat      = "fdb"
                  , commandPropFormat  = "lustre"
                  , commandTypeMapping = []


### PR DESCRIPTION
Extend both `ogma-core` and `ogma-cli` so that all code-generating backends accept as input expression to monitor an expression passed as argument, as prescribed in the solution proposed for #121.