### PR TITLE
`ogma-extra`: Remove deprecated functions from System.Directory.Extra. Refs #278.

### DIFF
--- a/ogma-extra/CHANGELOG.md
+++ b/ogma-extra/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Revision history for ogma-extra
 
+## [1.X.Y] - 2025-08-04
+
+* Remove deprecated functions from System.Directory.Extra (#278).
+
 ## [1.8.0] - 2025-07-13
 
 * Version bump 1.8.0 (#275).


### PR DESCRIPTION
Remove deprecated functions from `ogma-extra: System.Directory.Extra`, as prescribed in the solution proposed for #278.