### PR TITLE
`ogma-cli`: Bump upper version constraint on `optparse-applicative`. Refs #279.

### DIFF
--- a/ogma-cli/CHANGELOG.md
+++ b/ogma-cli/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Revision history for ogma-cli
 
-## [1.X.Y] - 2025-08-03
+## [1.X.Y] - 2025-08-05
 
 * Extend ROS command with flags to control testing package (#280).
+* Bump upper version constraint on optparse-applicative (#279).
 
 ## [1.8.0] - 2025-07-13
 

--- a/ogma-cli/ogma-cli.cabal
+++ b/ogma-cli/ogma-cli.cabal
@@ -152,7 +152,7 @@ executable ogma
   build-depends:
       base                 >= 4.11.0.0 && < 5
     , aeson                >= 2.0.0.0  && < 2.3
-    , optparse-applicative >= 0.14     && < 0.19
+    , optparse-applicative >= 0.14     && < 0.20
     , microstache          >= 1.0      && < 1.1
     , text                 >= 1.2.3.1  && < 2.2
 


### PR DESCRIPTION
Bump upper version constraint on `optparse-applicative`, as prescribed in the solution proposed for #279.