### PR TITLE
`ogma-core`: Install packages locally in ROS 2 dockerfile. Refs #288.

### DIFF
--- a/ogma-core/CHANGELOG.md
+++ b/ogma-core/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [1.X.Y] - 2025-08-09
 
 * Add to ROS 2 template handling methods for triggers with no args (#287).
+* Install packages locally in ROS 2 dockerfile (#288).
 
 ## [1.9.0] - 2025-08-06
 

--- a/ogma-core/templates/ros/Dockerfile
+++ b/ogma-core/templates/ros/Dockerfile
@@ -14,8 +14,8 @@ USER ${USER}
 SHELL ["/bin/bash", "-c"]
 WORKDIR ${PACKAGE_PATH}
 RUN source /opt/spaceros/install/setup.bash && \
-    colcon build --packages-select copilot           --install-base /opt/spaceros/install/ && \
-    colcon build --packages-select test_requirements --install-base /opt/spaceros/install/
+    colcon build --packages-select copilot           && \
+    colcon build --packages-select test_requirements
 
 ADD screenrc /home/spaceros-user/.screenrc
 USER root


### PR DESCRIPTION
Modify the installation step for the generated ROS 2 packages in the Dockerfile that accompanies the ROS 2 template so that the packages are installed locally, as prescribed in the solution proposed for #288.