### PR TITLE
`ogma-core`: Fix handling of message fields in cFS template. Refs #296.

### DIFF
--- a/ogma-core/CHANGELOG.md
+++ b/ogma-core/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Revision history for ogma-core
 
-## [1.X.Y] - 2025-08-09
+## [1.X.Y] - 2025-08-20
 
 * Add to ROS 2 template handling methods for triggers with no args (#287).
 * Install packages locally in ROS 2 dockerfile (#288).
+* Fix handling of message fields in cFS template (#296).
 
 ## [1.9.0] - 2025-08-06
 

--- a/ogma-core/templates/copilot-cfs/fsw/src/copilot_cfs.c
+++ b/ogma-core/templates/copilot-cfs/fsw/src/copilot_cfs.c
@@ -158,9 +158,20 @@ void COPILOT_ProcessCommandPacket(void)
 */
 void COPILOT_Process{{msgDataDesc}}(void)
 {
+    {{#msgDataFromType}}
+    {{msgDataFromType}}* msg;
+    msg = ({{.}}*) COPILOTMsgPtr;
+    {{/msgDataFromType}}
+    {{^msgDataFromType}}
     {{msgDataVarType}}* msg;
     msg = ({{msgDataVarType}}*) COPILOTMsgPtr;
+    {{/msgDataFromType}}
+    {{#msgDataFromField}}
+    {{msgDataVarName}} = msg->{{.}};
+    {{/msgDataFromField}}
+    {{^msgDataFromField}}
     {{msgDataVarName}} = *msg;
+    {{/msgDataFromField}}
 
     // Run all copilot monitors.
     step();


### PR DESCRIPTION
Fix handling of message fields in cFS template when applicable, and adjust cFS backend to provide necessary information, as prescribed in the solution propose for #296.