### PR TITLE
`ogma-core`: Avoid unnecessary recompilation of generated cFS app. Refs #299.

### DIFF
--- a/ogma-core/CHANGELOG.md
+++ b/ogma-core/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Add to ROS 2 template handling methods for triggers with no args (#287).
 * Install packages locally in ROS 2 dockerfile (#288).
 * Fix handling of message fields in cFS template (#296).
+* Avoid unnecessary recompilation of generated cFS app (#299).
 
 ## [1.9.0] - 2025-08-06
 

--- a/ogma-core/templates/copilot-cfs/CMakeLists.txt
+++ b/ogma-core/templates/copilot-cfs/CMakeLists.txt
@@ -14,5 +14,30 @@ aux_source_directory(fsw/src APP_SRC_FILES)
 # Create the app module
 add_cfe_app(copilot_cfs ${APP_SRC_FILES})
 
-add_custom_target(HASKELL_COPILOT COMMAND cabal v1-sandbox init COMMAND cabal update COMMAND cabal v1-install copilot COMMAND cabal v1-exec "--" ghc --make Properties.hs COMMAND ./Properties WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/fsw/src/ SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/fsw/src/Properties.hs)
+add_custom_command(
+    OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/fsw/src/cabal.sandbox.config
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/fsw/src/
+    COMMAND cabal v1-sandbox init
+    COMMAND cabal update
+    COMMAND cabal v1-install copilot
+    COMMENT "Installing Copilot"
+)
+
+add_custom_command(
+   DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/fsw/src/cabal.sandbox.config
+   DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/fsw/src/Properties.hs
+   OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/fsw/src/copilot.c
+          ${CMAKE_CURRENT_SOURCE_DIR}/fsw/src/copilot.h
+          ${CMAKE_CURRENT_SOURCE_DIR}/fsw/src/copilot_types.h
+   WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/fsw/src/
+   COMMAND cabal v1-exec "--" runhaskell Properties.hs
+   COMMENT "Compiling Copilot code"
+)
+
+add_custom_target(HASKELL_COPILOT
+   DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/fsw/src/copilot.c
+           ${CMAKE_CURRENT_SOURCE_DIR}/fsw/src/copilot.h
+           ${CMAKE_CURRENT_SOURCE_DIR}/fsw/src/copilot_types.h
+   SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/fsw/src/Properties.hs
+)
 add_dependencies(copilot_cfs HASKELL_COPILOT)


### PR DESCRIPTION
Modify `CMakeLists.txt` of cFS template to indicate dependencies between the commands executed, source files and generated files, as prescribed in the solution proposed for #299.