### PR TITLE
`ogma-core`: Remove tabs from cFS template code. Refs #294.

### DIFF
--- a/ogma-core/CHANGELOG.md
+++ b/ogma-core/CHANGELOG.md
@@ -1,11 +1,12 @@
 # Revision history for ogma-core
 
-## [1.X.Y] - 2025-08-20
+## [1.X.Y] - 2025-08-28
 
 * Add to ROS 2 template handling methods for triggers with no args (#287).
 * Install packages locally in ROS 2 dockerfile (#288).
 * Fix handling of message fields in cFS template (#296).
 * Avoid unnecessary recompilation of generated cFS app (#299).
+* Remove tabs from cFS template code (#294).
 
 ## [1.9.0] - 2025-08-06
 

--- a/ogma-core/templates/copilot-cfs/fsw/platform_inc/copilot_cfs_msgids.h
+++ b/ogma-core/templates/copilot-cfs/fsw/platform_inc/copilot_cfs_msgids.h
@@ -12,9 +12,9 @@
 #ifndef _copilot_cfs_msgids_h_
 #define _copilot_cfs_msgids_h_
 
-#define COPILOT_CFS_CMD_MID            	0x1882
-#define COPILOT_CFS_SEND_HK_MID        	0x1883
-#define COPILOT_CFS_HK_TLM_MID		0x0883
+#define COPILOT_CFS_CMD_MID     0x1882
+#define COPILOT_CFS_SEND_HK_MID 0x1883
+#define COPILOT_CFS_HK_TLM_MID  0x0883
 
 #endif /* _copilot_cfs_msgids_h_ */
 

--- a/ogma-core/templates/copilot-cfs/fsw/src/copilot_cfs.c
+++ b/ogma-core/templates/copilot-cfs/fsw/src/copilot_cfs.c
@@ -144,7 +144,7 @@ void COPILOT_ProcessCommandPacket(void)
         default:
             COPILOT_HkTelemetryPkt.copilot_command_error_count++;
             CFE_EVS_SendEvent(COPILOT_COMMAND_ERR_EID,CFE_EVS_ERROR,
-			"COPILOT: invalid command packet,MID = 0x%x", MsgId);
+              "COPILOT: invalid command packet,MID = 0x%x", MsgId);
             break;
     }
 


### PR DESCRIPTION
Remove all tabs from the cFS template code and indent modified lines based on surrounding code, as prescribed in the solution proposed for #294.