### PR TITLE
`ogma-core`: Fix duplicate linkage of Copilot code in generated cFS app. Refs #297.

### DIFF
--- a/ogma-core/CHANGELOG.md
+++ b/ogma-core/CHANGELOG.md
@@ -1,12 +1,13 @@
 # Revision history for ogma-core
 
-## [1.X.Y] - 2025-08-28
+## [1.X.Y] - 2025-08-29
 
 * Add to ROS 2 template handling methods for triggers with no args (#287).
 * Install packages locally in ROS 2 dockerfile (#288).
 * Fix handling of message fields in cFS template (#296).
 * Avoid unnecessary recompilation of generated cFS app (#299).
 * Remove tabs from cFS template code (#294).
+* Fix duplicate linkage of Copilot code in generated cFS app (#297).
 
 ## [1.9.0] - 2025-08-06
 

--- a/ogma-core/templates/copilot-cfs/CMakeLists.txt
+++ b/ogma-core/templates/copilot-cfs/CMakeLists.txt
@@ -12,7 +12,12 @@ include_directories(fsw/platform_inc)
 aux_source_directory(fsw/src APP_SRC_FILES)
 
 # Create the app module
-add_cfe_app(copilot_cfs ${APP_SRC_FILES})
+add_cfe_app(copilot_cfs
+  ${APP_SRC_FILES}
+  ${CMAKE_CURRENT_SOURCE_DIR}/fsw/src/copilot.c
+  ${CMAKE_CURRENT_SOURCE_DIR}/fsw/src/copilot.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/fsw/src/copilot_types.h
+)
 
 add_custom_command(
     OUTPUT ${CMAKE_CURRENT_SOURCE_DIR}/fsw/src/cabal.sandbox.config

--- a/ogma-core/templates/copilot-cfs/fsw/src/copilot_cfs.c
+++ b/ogma-core/templates/copilot-cfs/fsw/src/copilot_cfs.c
@@ -22,7 +22,6 @@
 {{#copilot}}
 #include "{{{copilot.specName}}}_types.h"
 #include "{{{copilot.specName}}}.h"
-#include "{{{copilot.specName}}}.c"
 {{/copilot}}
 
 {{#variables}}


### PR DESCRIPTION
Modify cFS template to adjust `CMakeLists.txt` to list dependency on Copilot-generated C sources explicitly, and remove inclusion of Copilot monitor implementation directly into cFS application's main module, as prescribed in the solution proposed for #297.