### PR TITLE
`ogma-core`: Use alternate name for Copilot's step function in cFS template. Refs #303.

### DIFF
--- a/ogma-core/CHANGELOG.md
+++ b/ogma-core/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Avoid unnecessary recompilation of generated cFS app (#299).
 * Remove tabs from cFS template code (#294).
 * Fix duplicate linkage of Copilot code in generated cFS app (#297).
+* Use alternate name for Copilot's step function in cFS template (#303).
 
 ## [1.9.0] - 2025-08-06
 

--- a/ogma-core/templates/copilot-cfs/fsw/src/Properties.hs
+++ b/ogma-core/templates/copilot-cfs/fsw/src/Properties.hs
@@ -38,7 +38,9 @@ spec = do
 {{{copilot.triggers}}}
 
 main :: IO ()
-main = reify spec >>= compile "{{{copilot.specName}}}"
+main = reify spec >>= compileWith settings "{{{copilot.specName}}}"
+  where
+    settings = mkDefaultCSettings { cSettingsStepFunctionName = "copilot_step" }
 {{/copilot}}
 {{^copilot}}
 -- No specification provided. Place your specification in this file.

--- a/ogma-core/templates/copilot-cfs/fsw/src/copilot_cfs.c
+++ b/ogma-core/templates/copilot-cfs/fsw/src/copilot_cfs.c
@@ -173,7 +173,7 @@ void COPILOT_Process{{msgDataDesc}}(void)
     {{/msgDataFromField}}
 
     // Run all copilot monitors.
-    step();
+    copilot_step();
 }
 
 {{/msgHandlers}}


### PR DESCRIPTION
Use alternate name for Copilot's main entry point in Copilot spec in cFS template, and adjust cFS application code accordingly, as prescribed in the solution proposed for #303.