### PR TITLE
`ogma-cli`: Add CI job to test diagram backend. Refs #332.

### DIFF
--- a/.github/workflows/repo-ghc-8.6-cabal-2.4-diagram.yml
+++ b/.github/workflows/repo-ghc-8.6-cabal-2.4-diagram.yml
@@ -1,0 +1,69 @@
+name: diagram-ghc-8.6-cabal-2.4
+
+on:
+  - pull_request
+  - push
+
+jobs:
+  cabal:
+    name: ${{ matrix.os }} / ghc ${{ matrix.ghc }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        cabal: ["2.4"]
+        ghc:
+          - "8.6"
+
+    steps:
+
+    - uses: haskell-actions/setup@main
+      id: setup-haskell-cabal
+      name: Setup Haskell
+      with:
+        ghc-version: ${{ matrix.ghc }}
+        cabal-version: ${{ matrix.cabal }}
+
+    - name: Prepare environment
+      run: |
+        echo "$HOME/.ghcup/bin" >> $GITHUB_PATH
+        echo "$HOME/.cabal/bin" >> $GITHUB_PATH
+
+    - uses: actions/checkout@v4
+
+    - name: Create sandbox
+      run: |
+        echo "$PWD/.cabal-sandbox/bin" >> $GITHUB_PATH
+        cabal v1-sandbox init
+
+    - name: Install dependencies
+      run: |
+        sudo apt-get install -y libz-dev libbz2-dev libexpat-dev
+        cabal v1-install alex happy
+        cabal v1-install BNFC
+
+    - name: Install ogma
+      run: |
+        cabal v1-install copilot-4.6 ogma-**/ --constraint="aeson >= 2.0.3.0"
+
+    - name: Generate and enable app from diagram
+      run: |
+        ogma diagram --target-dir demo \
+                     --prop-format literal \
+                     --mode calculate \
+                     --input-format dot \
+                     --file-name ogma-cli/examples/diagram-001-hello-ogma/diagram-copilot.dot
+        cd demo/
+        cabal v1-sandbox init --sandbox=$PWD/../.cabal-sandbox
+        cabal v1-exec -- runhaskell Copilot.hs
+        gcc $PWD/../ogma-cli/examples/diagram-001-hello-ogma/main.c monitor.c -I$PWD -o main
+
+    - name: Run app and compare against expectation
+      run: |
+        cd demo/
+        if [ "$(./main | sed -n 's/.*new state: \([0-9]\+\).*/\1/p' | paste -sd' ' -)" = "0 1 1 0 2 2 0" ]; then \
+          echo "Execution of diagram test matches expectation"; \
+        else \
+          echo "Mismatch"; \
+          exit 1; \
+        fi

--- a/ogma-cli/CHANGELOG.md
+++ b/ogma-cli/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Revision history for ogma-cli
 
+## [1.X.Y] - 2025-11-26
+
+* Add CI job to test diagram backend (#332).
+
 ## [1.11.0] - 2025-11-21
 
 * Version bump 1.11.0 (#325).


### PR DESCRIPTION
Add a CI action file that generates a Copilot spec from a state machine diagram, compiles the Copilot spec to C99, links the resulting C code with a main driver, and compares its execution with an expected result, as prescribed in the solution proposed for #332.