### PR TITLE
`ogma-cli`: Make example file consistent with associated tutorial. Refs #343.

### DIFF
--- a/ogma-cli/CHANGELOG.md
+++ b/ogma-cli/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [1.X.Y] - 2026-01-24
 
 * Fix grammatical errors in ROS 2 tutorial (#341).
+* Make example file consistent with associated tutorial (#343).
 
 ## [1.12.0] - 2026-01-21
 

--- a/ogma-cli/examples/ros2-001-hello-ogma/expressions.json
+++ b/ogma-cli/examples/ros2-001-hello-ogma/expressions.json
@@ -7,8 +7,8 @@
     "properties": [
       {
         "id":      "TestOgma",
-        "formula": "input_value > 0",
-        "text":    "input_value is greater than zero"
+        "formula": "input_value <= 0",
+        "text":    "input_value shall always be lower than or equal to zero"
       }
     ]
   }


### PR DESCRIPTION
Modify file `expressions.json` to match associated ROS 2 tutorial in `README.md`, as prescribed in the solution proposed for #343.