### PR TITLE
`ogma-cli`: Update installation instructions for Linux, Mac. Refs #347.

### DIFF
--- a/ogma-cli/CHANGELOG.md
+++ b/ogma-cli/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Fix grammatical errors in ROS 2 tutorial (#341).
 * Make example file consistent with associated tutorial (#343).
 * Add syntax information to code blocks in tutorials (#345).
+* Update installation instructions for Linux, Mac (#347).
 
 ## [1.12.0] - 2026-01-21
 

--- a/ogma-cli/README.md
+++ b/ogma-cli/README.md
@@ -39,8 +39,9 @@ verification framework that generates hard real-time C99 code.
 ## Table of Contents
 
 - [Installation](#installation)
-  - [Pre-requisites](#pre-requisites)
-  - [Compilation](#compilation)
+  - [Linux installation](#linux-installation)
+  - [Mac installation](#mac-installation)
+  - [Troubleshooting](#troubleshooting)
 - [Usage](#usage)
   - [cFS Application Generation](#cfs-application-generation)
   - [ROS Application Generation](#ros-application-generation)
@@ -55,15 +56,35 @@ verification framework that generates hard real-time C99 code.
 # Installation
 <sup>[(Back to top)](#table-of-contents)</sup>
 
-## Pre-requisites
+## Linux Installation
 <sup>[(Back to top)](#table-of-contents)</sup>
 
-To install Ogma from source, users must have the tools GHC and cabal-install,
-as well as the libraries `bz2` and `expat`. At this time, we recommend GHC 8.6
-and a version of cabal-install between 2.4 and 3.2. (Ogma has been tested with
-GHC versions up to 9.2 and cabal-install versions up to 3.6, although the
-installation steps may vary slightly depending on the version of cabal-install
-being used.)
+### Ubuntu 25.10 / Debian Forky or newer
+
+On Ubuntu 25.10 / Debian Forky or newer, Ogma can be installed directly from
+the package repositories with:
+
+```sh
+$ sudo apt-get install ogma
+```
+
+To test that Ogma is available, execute the following to print the list of
+commands supported:
+
+```sh
+$ ogma --help
+```
+
+### Other Linux distributions
+
+On other Linux distributions or older Debian-based distributions, to use Ogma
+you must compile it from source, for which you need a number of pre-requisites,
+such as a Haskell compiler (GHC) and the package manager Cabal
+(`cabal-install`), as well as the libraries `bz2` and `expat`. At this time, we
+recommend GHC 8.6 and a version of `cabal-install` between 2.4 and 3.2. (Ogma
+has been tested with GHC versions up to 9.2 and cabal-install versions up to
+3.6, although the installation steps may vary slightly depending on the version
+of `cabal-install` being used.)
 
 On Debian or Ubuntu Linux, these dependencies can be installed with:
 
@@ -71,28 +92,99 @@ On Debian or Ubuntu Linux, these dependencies can be installed with:
 $ apt-get install ghc cabal-install libz-dev libbz2-dev libexpat-dev
 ```
 
-On Mac, they can be installed with:
+Once the compiler is installed, install Ogma from
+[Hackage](https://hackage.haskell.org/package/ogma-cli) with:
 
 ```sh
-$ brew install ghc cabal-install bzip2 expat
-```
-
-## Compilation
-<sup>[(Back to top)](#table-of-contents)</sup>
-
-Once GHC and cabal are installed, the simplest way to install Ogma is with:
-```sh
-$ git clone https://github.com/nasa/ogma.git
-$ cd ogma
-$ export PATH="$HOME/.local/bin/:$PATH"
 $ cabal update
-$ cabal install --lib copilot copilot-c99 copilot-language copilot-theorem \
-    copilot-libraries copilot-interpreter
+$ cabal install --lib copilot copilot-core copilot-c99 copilot-language \
+    copilot-theorem copilot-libraries copilot-interpreter copilot-prettyprinter
 $ cabal install ogma-cli:ogma
 ```
 
 After that, the `ogma` executable will be placed in the directory
 `$HOME/.local/bin/`, where `$HOME` represents your user's home directory.
+
+To test that Ogma is available, execute the following to print the list of
+commands supported:
+
+```sh
+$ ogma --help
+```
+
+Alternatively, you may want to install the latest development version of Ogma
+from the official repository, which you can do as follows:
+
+```sh
+$ git clone https://github.com/nasa/ogma.git
+$ cd ogma
+$ export PATH="$HOME/.local/bin/:$PATH"
+$ cabal update
+$ cabal install --lib copilot copilot-core copilot-c99 copilot-language \
+    copilot-theorem copilot-libraries copilot-interpreter copilot-prettyprinter
+$ cabal install ogma-cli:ogma
+```
+
+Like before, the `ogma` executable will be placed in the directory
+`$HOME/.local/bin/`, where `$HOME` represents your user's home directory.
+
+## Mac installation
+<sup>[(Back to top)](#table-of-contents)</sup>
+
+On macOS, to use Ogma you must compile it from source, for which you need a
+number of pre-requisites, such as a Haskell compiler (GHC) and the package
+manager Cabal (`cabal-install`), as well as the libraries `bz2` and `expat`.
+
+```sh
+$ brew install ghc cabal-install bzip2 expat
+```
+
+Once the compiler is installed, install Ogma from
+[Hackage](https://hackage.haskell.org/package/ogma-cli) with:
+
+```sh
+$ cabal update
+$ cabal install --lib copilot copilot-core copilot-c99 copilot-language \
+    copilot-theorem copilot-libraries copilot-interpreter copilot-prettyprinter
+$ cabal install ogma-cli:ogma
+```
+
+After that, the `ogma` executable will be placed in the directory
+`$HOME/.local/bin/`, where `$HOME` represents your user's home directory.
+
+To test that Ogma is available, execute the following to print the list of
+commands supported:
+
+```sh
+$ ogma --help
+```
+
+Alternatively, you may want to install the latest development version of Ogma
+from the official repository, which you can do as follows:
+
+```sh
+$ git clone https://github.com/nasa/ogma.git
+$ cd ogma
+$ export PATH="$HOME/.local/bin/:$PATH"
+$ cabal update
+$ cabal install --lib copilot copilot-core copilot-c99 copilot-language \
+    copilot-theorem copilot-libraries copilot-interpreter copilot-prettyprinter
+$ cabal install ogma-cli:ogma
+```
+
+Like before, the `ogma` executable will be placed in the directory
+`$HOME/.local/bin/`, where `$HOME` represents your user's home directory.
+
+## Troubleshooting
+<sup>[(Back to top)](#table-of-contents)</sup>
+
+
+Feel free to open an issue if you are unable to install Ogma following these
+instructions.
+
+There is a `.github/` directory at the root of the repository that may help
+with troubleshooting the installation. Also, our issues often include comments
+with Dockerfiles listing the steps necessary to install Ogma from scratch.
 
 # Usage
 <sup>[(Back to top)](#table-of-contents)</sup>


### PR DESCRIPTION
Modify installation instructions include separate Linux from Mac, and installation from the official package repositories for modern versions of Ubuntu and Debian, as prescribed in the solution proposed for #347.