### PR TITLE
`ogma-cli`: Fix incorrect arguments to `diagram` command in tutorial. Refs #349.

### DIFF
--- a/ogma-cli/CHANGELOG.md
+++ b/ogma-cli/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Make example file consistent with associated tutorial (#343).
 * Add syntax information to code blocks in tutorials (#345).
 * Update installation instructions for Linux, Mac (#347).
+* Fix incorrect arguments to `diagram` command in tutorial (#349).
 
 ## [1.12.0] - 2026-01-21
 

--- a/ogma-cli/examples/diagram-001-hello-ogma/README.md
+++ b/ogma-cli/examples/diagram-001-hello-ogma/README.md
@@ -52,10 +52,10 @@ machine implementations, users need to provide the following information:
 An invocation of Ogma's diagram backend may look like the following:
 
 ```sh
-$ ogma diagram --app-target-dir demo \
+$ ogma diagram --target-dir demo \
                --mode calculate \
                --input-file ogma-cli/examples/diagram-001-hello-ogma/diagram-copilot.dot \
-               --file-format dot \
+               --input-format dot \
                --prop-format literal
 ```
 
@@ -195,10 +195,10 @@ To generate the application from the diagram above, we invoke `ogma` with the
 following arguments:
 
 ```sh
-$ ogma diagram --app-target-dir demo \
+$ ogma diagram --target-dir demo \
                --prop-format literal \
                --mode calculate \
-               --file-format dot \
+               --input-format dot \
                --input-file ogma-cli/examples/diagram-001-hello-ogma/diagram-copilot.dot
 ```
 


### PR DESCRIPTION
Fix invocations of Ogma in the diagrams tutorial to use argument names that Ogma supports, as prescribed in the solution proposed for #349.