### PR TITLE
`ogma-core`: Remove unused functions from diagram template. Refs #351.

### DIFF
--- a/ogma-core/CHANGELOG.md
+++ b/ogma-core/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Revision history for ogma-core
 
+## [1.X.Y] - 2026-01-25
+
+* Remove unused functions from diagram template (#351).
+
 ## [1.12.0] - 2026-01-21
 
 * Version bump 1.12.0 (#336).

--- a/ogma-core/src/Command/Diagram.hs
+++ b/ogma-core/src/Command/Diagram.hs
@@ -91,12 +91,11 @@ import           Language.Trans.SMV2Copilot    as SMV (boolSpec2Copilot,
 --
 -- PRE: The file given is readable, contains a valid file with recognizable
 -- format, the formulas in the file do not use any identifiers that exist in
--- Copilot, or any of @stateMachine@, @externalState@, @noneOf@,
--- @checkValidTransitions@, @main@, @spec@, @stateMachine1@, @clock@, @ftp@,
--- @notPreviousNot@. All identifiers used are valid C99 identifiers. The
--- template, if provided, exists and uses the variables needed by the diagram
--- application generator. The target directory is writable and there's enough
--- disk space to copy the files over.
+-- Copilot, or any of @stateMachine@, @externalState@, @main@, @spec@,
+-- @stateMachine1@, @clock@, @ftp@, @notPreviousNot@. All identifiers used are
+-- valid C99 identifiers. The template, if provided, exists and uses the
+-- variables needed by the diagram application generator. The target directory
+-- is writable and there's enough disk space to copy the files over.
 diagram :: FilePath       -- ^ Path to a file containing a diagram
         -> DiagramOptions -- ^ Customization options
         -> IO (Result ErrorCode)
@@ -138,12 +137,11 @@ diagram fp options = do
 --
 -- PRE: The file given is readable, contains a valid file with recognizable
 -- format, the formulas in the file do not use any identifiers that exist in
--- Copilot, or any of @stateMachine@, @externalState@, @noneOf@,
--- @checkValidTransitions@, @main@, @spec@, @stateMachine1@, @clock@, @ftp@,
--- @notPreviousNot@. All identifiers used are valid C99 identifiers. The
--- template, if provided, exists and uses the variables needed by the diagram
--- application generator. The target directory is writable and there's enough
--- disk space to copy the files over.
+-- Copilot, or any of @stateMachine@, @externalState@, @main@, @spec@,
+-- @stateMachine1@, @clock@, @ftp@, @notPreviousNot@. All identifiers used are
+-- valid C99 identifiers. The template, if provided, exists and uses the
+-- variables needed by the diagram application generator. The target directory
+-- is writable and there's enough disk space to copy the files over.
 diagram' :: FilePath
          -> DiagramOptions
          -> ExprPair

--- a/ogma-core/templates/diagram/Copilot.hs
+++ b/ogma-core/templates/diagram/Copilot.hs
@@ -46,33 +46,3 @@ stateMachineGF (initialState, finalState, noInputData, transitions, badState) = 
 
     ifThenElses ((s1,i,s2):ss) =
       ifThenElse (previousState == constant s1 && i) (constant s2) (ifThenElses ss)
-
--- | True when the given input stream does hold any of the values in the given
--- list.
-noneOf :: [Stream Bool] -> Stream Bool
-noneOf []     = true
-noneOf (x:xs) = not x && noneOf xs
-
--- | Given a list of transitions, and a current state, and a list of possible
--- destination states, produce a list of booleans indicating if a transition to
--- each of the destination states would be valid.
-checkValidTransitions :: [(Word8, Stream Bool, Word8)]
-                      -> Stream Word8
-                      -> [Word8]
-                      -> [Stream Bool]
-checkValidTransitions transitions curState destinations =
-  map (checkValidTransition transitions curState) destinations
-
--- | Given a list of transitions, and a current state, and destination states,
--- produce a list of booleans indicating if a transition to each of the
--- destination states would be valid.
-checkValidTransition :: [(Word8, Stream Bool, Word8)]
-                     -> Stream Word8
-                     -> Word8
-                     -> Stream Bool
-checkValidTransition []                 _   _   = true
-checkValidTransition ((so1, c, sd1):sx) so2 sd2 =
-  ifThenElse
-    ((constant so1 == so2) && (constant sd1 == constant sd2))
-    c
-    (checkValidTransition sx so2 sd2)


### PR DESCRIPTION
Remove unused functions from Copilot module of diagram template, and adjust documentation accordingly, as prescribed in the solution proposed for #351.