### PR TITLE
`ogma-cli`: Augment `overview` command to report results of spec analysis. Refs #356.

### DIFF
--- a/ogma-cli/CHANGELOG.md
+++ b/ogma-cli/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Revision history for ogma-cli
 
-## [1.X.Y] - 2026-01-24
+## [1.X.Y] - 2026-02-17
 
 * Fix grammatical errors in ROS 2 tutorial (#341).
 * Make example file consistent with associated tutorial (#343).
@@ -8,6 +8,7 @@
 * Update installation instructions for Linux, Mac (#347).
 * Fix incorrect arguments to `diagram` command in tutorial (#349).
 * Adjust README, tutorial to account for Dockerfile in cFS template (#353).
+* Augment `overview` command to report results of spec analysis (#356).
 
 ## [1.12.0] - 2026-01-21
 

--- a/ogma-cli/README.md
+++ b/ogma-cli/README.md
@@ -80,16 +80,16 @@ $ ogma --help
 On other Linux distributions or older Debian-based distributions, to use Ogma
 you must compile it from source, for which you need a number of pre-requisites,
 such as a Haskell compiler (GHC) and the package manager Cabal
-(`cabal-install`), as well as the libraries `bz2` and `expat`. At this time, we
-recommend GHC 8.6 and a version of `cabal-install` between 2.4 and 3.2. (Ogma
-has been tested with GHC versions up to 9.2 and cabal-install versions up to
-3.6, although the installation steps may vary slightly depending on the version
-of `cabal-install` being used.)
+(`cabal-install`), the libraries `bz2` and `expat`, and the theorem prover
+`z3`. At this time, we recommend GHC 8.6 and a version of `cabal-install`
+between 2.4 and 3.2. (Ogma has been tested with GHC versions up to 9.2 and
+cabal-install versions up to 3.6, although the installation steps may vary
+slightly depending on the version of `cabal-install` being used.)
 
 On Debian or Ubuntu Linux, these dependencies can be installed with:
 
 ```sh
-$ apt-get install ghc cabal-install libz-dev libbz2-dev libexpat-dev
+$ apt-get install ghc cabal-install libz-dev libbz2-dev libexpat-dev z3
 ```
 
 Once the compiler is installed, install Ogma from
@@ -133,10 +133,11 @@ Like before, the `ogma` executable will be placed in the directory
 
 On macOS, to use Ogma you must compile it from source, for which you need a
 number of pre-requisites, such as a Haskell compiler (GHC) and the package
-manager Cabal (`cabal-install`), as well as the libraries `bz2` and `expat`.
+manager Cabal (`cabal-install`), as well as the libraries `bz2` and `expat`,
+and the theorem prover `z3`.
 
 ```sh
-$ brew install ghc cabal-install bzip2 expat
+$ brew install ghc cabal-install bzip2 expat z3
 ```
 
 Once the compiler is installed, install Ogma from

--- a/ogma-cli/examples/analysis/expressions.json
+++ b/ogma-cli/examples/analysis/expressions.json
@@ -1,0 +1,23 @@
+{
+  "internal_variables": [],
+  "external_variables": [
+    {"name": "input_value", "type": "Int32", "meaning": "InputI32"}
+  ],
+  "properties": [
+    {
+      "id":      "ReqUseful",
+      "formula": "input_value <= 0",
+      "text":    "input_value shall always be lower than or equal to zero"
+    },
+    {
+      "id":      "ReqAlwaysTrue",
+      "formula": "input_value == input_value",
+      "text":    "input_value shall always be equal to itself"
+    },
+    {
+      "id":      "ReqAlwaysFalse",
+      "formula": "input_value /= input_value",
+      "text":    "input_value shall never be equal to itself"
+    }
+  ]
+}

--- a/ogma-cli/examples/analysis/json-format.cfg
+++ b/ogma-cli/examples/analysis/json-format.cfg
@@ -1,0 +1,15 @@
+JSONFormat
+   { specInternalVars          = Just ".internal_variables[*]"
+   , specInternalVarId         = ".name"
+   , specInternalVarExpr       = ".meaning"
+   , specInternalVarType       = Just ".type"
+   , specExternalVars          = Just ".external_variables[*]"
+   , specExternalVarId         = ".name"
+   , specExternalVarType       = Just ".type"
+   , specRequirements          = ".properties[*]"
+   , specRequirementId         = ".id"
+   , specRequirementDesc       = Just ".text"
+   , specRequirementExpr       = ".formula"
+   , specRequirementResultType = Nothing
+   , specRequirementResultExpr = Nothing
+   }

--- a/ogma-cli/src/CLI/CommandOverview.hs
+++ b/ogma-cli/src/CLI/CommandOverview.hs
@@ -80,6 +80,8 @@ command c = do
       , " - {{commandExternalVariables}} external variables."
       , " - {{commandInternalVariables}} internal variables."
       , " - {{commandRequirements}} requirements."
+      , "   - {{commandRequirementsTrue}} requirements are constantly or always true."
+      , "   - {{commandRequirementsFalse}} requirements are constantly or always false."
       ]
 
 -- * CLI

--- a/ogma-core/CHANGELOG.md
+++ b/ogma-core/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Revision history for ogma-core
 
-## [1.X.Y] - 2026-01-25
+## [1.X.Y] - 2026-02-17
 
 * Remove unused functions from diagram template (#351).
 * Add dockerfile to cFS template (#353).
+* Augment overview command to formally analyze specs (#356).
 
 ## [1.12.0] - 2026-01-21
 

--- a/ogma-core/ogma-core.cabal
+++ b/ogma-core/ogma-core.cabal
@@ -123,6 +123,7 @@ library
     Command.Common
     Command.Errors
     Command.VariableDB
+    Language.Trans.SpecAnalysis
 
   autogen-modules:
     Paths_ogma_core
@@ -132,9 +133,13 @@ library
     , aeson                   >= 2.0.0.0  && < 2.3
     , bytestring              >= 0.10.8.2 && < 0.13
     , containers              >= 0.5      && < 0.8
+    , copilot-core            >= 4.6.1    && < 4.7
+    , copilot-language        >= 4.6.1    && < 4.7
+    , copilot-theorem         >= 4.6.1    && < 4.7
     , directory               >= 1.3.1.5  && < 1.4
     , filepath                >= 1.4.2    && < 1.6
     , graphviz                >= 2999.20  && < 2999.21
+    , hint                    >= 0.9.0    && < 1.10
     , megaparsec              >= 8.0.0    && < 9.10
     , mtl                     >= 2.2.2    && < 2.4
     , process                 >= 1.6      && < 1.7

--- a/ogma-core/src/Command/Overview.hs
+++ b/ogma-core/src/Command/Overview.hs
@@ -39,11 +39,12 @@ import Data.OgmaSpec (ExternalVariableDef (..), InternalVariableDef (..),
                       Requirement (..), Spec (..))
 
 -- Internal imports
-import Command.Common
-import Command.Errors              (ErrorCode, ErrorTriplet(..))
-import Command.Result              (Result (..))
-import Data.Location               (Location (..))
-import Language.Trans.Spec2Copilot (specAnalyze)
+import           Command.Common
+import           Command.Errors              (ErrorCode, ErrorTriplet (..))
+import           Command.Result              (Result (..))
+import           Data.Location               (Location (..))
+import qualified Language.Trans.Spec2Copilot as Spec2Copilot
+import qualified Language.Trans.SpecAnalysis as SpecAnalysis
 
 -- | Generate overview of a spec given in an input file.
 --
@@ -77,15 +78,25 @@ command' :: FilePath
           -> IO (Either String CommandSummary)
 command' fp options (ExprPair exprT) = do
     spec <- runExceptT $ parseInputFile' fp
-    let spec' = either (\(ErrorTriplet _ec msg _loc) -> Left msg) Right spec
+    case spec of
+      Left (ErrorTriplet _ec msg _loc) -> return $ Left msg
 
-    let summary = do
-          spec1 <- spec'
-          spec3 <- specAnalyze $ addMissingIdentifiers ids spec1
-          return $ CommandSummary (length (externalVariables spec3))
-                                  (length (internalVariables spec3))
-                                  (length (requirements spec3))
-    return summary
+      Right spec' -> do
+        let specCompleted = addMissingIdentifiers ids spec'
+            specAnalyzed  = Spec2Copilot.specAnalyze specCompleted
+
+        numConstantReqs <-
+          SpecAnalysis.specAnalyze [] replace printExpr specCompleted
+
+        pure $ do
+          numExterns  <- length . externalVariables <$> specAnalyzed
+          numInternal <- length . internalVariables <$> specAnalyzed
+          numReqs     <- length . requirements      <$> specAnalyzed
+          numTrues    <- SpecAnalysis.numAlwaysTrue  <$> numConstantReqs
+          numFalses   <- SpecAnalysis.numAlwaysFalse <$> numConstantReqs
+
+          pure $
+            CommandSummary numExterns numInternal numReqs numTrues numFalses
 
   where
 
@@ -94,12 +105,14 @@ command' fp options (ExprPair exprT) = do
     propFormatName    = commandPropFormat options
     propVia           = commandPropVia options
 
-    ExprPairT _parse _replace _print ids _def = exprT
+    ExprPairT _parse replace printExpr ids _def = exprT
 
 data CommandSummary = CommandSummary
   { commandExternalVariables :: Int
   , commandInternalVariables :: Int
   , commandRequirements      :: Int
+  , commandRequirementsTrue  :: Int
+  , commandRequirementsFalse :: Int
   }
   deriving (Generic, Show)
 

--- a/ogma-core/src/Language/Trans/SpecAnalysis.hs
+++ b/ogma-core/src/Language/Trans/SpecAnalysis.hs
@@ -1,0 +1,300 @@
+-- Copyright 2024 United States Government as represented by the Administrator
+-- of the National Aeronautics and Space Administration. All Rights Reserved.
+--
+-- Disclaimers
+--
+-- Licensed under the Apache License, Version 2.0 (the "License"); you may
+-- not use this file except in compliance with the License. You may obtain a
+-- copy of the License at
+--
+--      https://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+-- WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+-- License for the specific language governing permissions and limitations
+-- under the License.
+
+-- | Formally analyze specifications and provide information about them.
+module Language.Trans.SpecAnalysis
+    ( AnalysisResult(..)
+    , specAnalyze
+    )
+  where
+
+-- External imports
+import qualified Copilot.Core                 as Core
+import qualified Copilot.Language             as Copilot
+import qualified Copilot.Language.Reify       as Copilot
+import           Copilot.Theorem.What4        (SatResult (..), Solver (Z3),
+                                               prove)
+import           Data.List                    (intercalate, lookup)
+import           Data.Maybe                   (fromMaybe)
+import qualified Language.Haskell.Interpreter as HI
+
+-- External imports: auxiliary
+import Data.String.Extra (sanitizeLCIdentifier, sanitizeUCIdentifier)
+
+-- External imports: ogma-spec
+import Data.OgmaSpec (ExternalVariableDef (..), InternalVariableDef (..),
+                      Requirement (..), Spec (..))
+
+-- * Analysis of Specs
+
+-- | Result of analyzing a specification.
+data AnalysisResult = AnalysisResult
+  { numAlwaysTrue  :: Int -- ^ Number of always true requirements.
+  , numAlwaysFalse :: Int -- ^ Number of always false requirements.
+  }
+
+-- | Formally analyze a specification for redundancies, conflicts, etc.
+specAnalyze :: [(String, String)]             -- Type substitution table
+            -> ([(String, String)] -> a -> a) -- Expr substitution function
+            -> (a -> String)                  -- Expr show function
+            -> Spec a                         -- Specification
+            -> IO (Either String AnalysisResult)
+specAnalyze typeMaps exprTransform showExpr spec = do
+  let structuredSpec =
+        spec2Copilot typeMaps exprTransform showExpr spec
+
+  coreSpec <- reifySpec defaultSpecImports $ showSpec structuredSpec
+
+  let properties     = zip propertyNames propertyGuards
+      propertyNames  = map (\(_, p, _, _, _) -> p)
+                     $ copilotProperties structuredSpec
+      propertyGuards = map Core.triggerGuard $ Core.specTriggers coreSpec
+
+  constantProperties <- mapM (uncurry $ exprIsConstant coreSpec) properties
+
+  let numTrue  = length $ filter fst constantProperties
+      numFalse = length $ filter snd constantProperties
+
+  return $ Right $ AnalysisResult numTrue numFalse
+
+-- * Auxiliary
+
+-- ** Structured Copilot specifications
+
+-- | A structured Copilot specification.
+data CopilotSpec = CopilotSpec
+  { copilotProperties :: [(String, String, String, String, String)]
+                      -- ^ Requirement name, property name, handler name,
+                      -- implementation and arguments.
+
+  , copilotAuxDefs    :: [(String, String, String)]
+                      -- ^ Name, type, implementation
+  }
+
+-- | Given a 'Spec', return a structured version the corresponding Copilot spec
+-- that differentiates between the auxiliary definitions (inputs, outputs) and
+-- the properties or requirements to check.
+--
+-- PRE: There are no name clashes between the variables and names used in the
+-- specification and any definitions in Haskell's Prelude or in Copilot.
+spec2Copilot :: [(String, String)]             -- Type substitution table
+             -> ([(String, String)] -> a -> a) -- Expr substitution function
+             -> (a -> String)                  -- Expr show function
+             -> Spec a                         -- Specification
+             -> CopilotSpec
+spec2Copilot typeMaps exprTransform showExpr spec = CopilotSpec reqs auxDefs
+  where
+    -- Encoding of requirements as boolean streams
+    reqs :: [(String, String, String, String, String)]
+    reqs = map reqToDecl (requirements spec)
+      where
+        reqToDecl i =
+            ( reqName
+            , propName
+            , handlerName
+            , reqBody nameSubstitutions
+            , handlerArg
+            )
+          where
+            reqName = requirementName i
+
+            propName = safeMap nameSubstitutions (requirementName i)
+
+            handlerName = "handler" ++ sanitizeUCIdentifier (requirementName i)
+
+            -- Definition implementation. We use an auxiliary function to
+            -- transform the implementation into Copilot, applying a
+            -- substitution.
+            reqBody subs = showExpr (exprTransform subs (requirementExpr i))
+
+            handlerArg  =
+              case (requirementResultType i, requirementResultExpr i) of
+                (Just _, Just ex) -> "[ arg (" ++ showExpr ex ++ " ) ]"
+                _                 -> "[]"
+
+    auxDefs :: [(String, String, String)]
+    auxDefs = externs ++ internals
+
+    externs :: [(String, String, String)]
+    externs = map externVarToDecl (externalVariables spec)
+      where
+        externVarToDecl i = (propName, streamType, implementation)
+          where
+            propName = safeMap nameSubstitutions (externalVariableName i)
+
+            streamType = "Stream " ++ "(" ++ valueType ++ ")"
+            valueType  = safeMap typeMaps (externalVariableType i)
+
+            implementation = "extern" ++ " " ++ show (externalVariableName i)
+                          ++ " " ++ "Nothing"
+
+    -- Internal stream definitions
+    internals :: [(String, String, String)]
+    internals = map internalVarToDecl (internalVariables spec)
+      where
+        internalVarToDecl i = (propName, streamType, implementation)
+          where
+            propName = safeMap nameSubstitutions (internalVariableName i)
+
+            streamType = "Stream " ++ "(" ++ valueType ++ ")"
+            valueType  = safeMap typeMaps (internalVariableType i)
+
+            implementation = internalVariableExpr i
+
+    nameSubstitutions = internalVariableMap
+                     ++ externalVariableMap
+                     ++ requirementNameMap
+
+    -- Map from a variable name to its desired identifier in the code
+    -- generated.
+    internalVariableMap =
+      map (\x -> (x, sanitizeLCIdentifier x)) internalVariableNames
+
+    externalVariableMap =
+      map (\x -> (x, sanitizeLCIdentifier x)) externalVariableNames
+
+    requirementNameMap =
+      map (\x -> (x, "prop" ++ sanitizeUCIdentifier x)) requirementNames
+
+    -- Variable/requirement names used in the input spec.
+    internalVariableNames = map internalVariableName
+                          $ internalVariables spec
+
+    externalVariableNames = map externalVariableName
+                          $ externalVariables spec
+
+    requirementNames = map requirementName
+                     $ requirements spec
+
+-- | Render a 'CopilotSpec' as a Haskell definition of a 'Copilot.Spec',
+-- listing the elements in the spec with the necessary indentation.
+--
+-- The shown 'Copilot.Spec' has a list of top-level triggers, as well as
+-- several auxiliary definitions.
+showSpec :: CopilotSpec -> String
+showSpec spec = template ++ "\n" ++ extra ++ "\n" ++ triggers
+  where
+    -- Initial template used for analysis purposes.
+    template :: String
+    template = unlines
+      [ "do let"
+      , ""
+      , "       clock :: Stream Int64"
+      , "       clock = [0] ++ (clock + 1)"
+      , ""
+      , "       ftp :: Stream Bool"
+      , "       ftp = [True] ++ false"
+      , ""
+      , "       pre :: Stream Bool -> Stream Bool"
+      , "       pre = ([False] ++)"
+      , ""
+      , "       tpre :: Stream Bool -> Stream Bool"
+      , "       tpre = ([True] ++)"
+      , ""
+      , "       notPreviousNot :: Stream Bool -> Stream Bool"
+      , "       notPreviousNot = not . PTLTL.previous . not"
+      ]
+
+    extra = unlines
+          $ intercalate [""]
+          $ map formatDef
+          $ copilotAuxDefs spec
+
+    triggers = unlines
+             $ intercalate [""]
+             $ map formatTrigger
+             $ copilotProperties spec
+
+    formatDef (n, t, i) =
+      map ("       " ++) [ n ++ " :: " ++ t, n ++ " = " ++ i ]
+
+    formatTrigger (_, _, h, g, a) =
+      map ("   " ++) [ "trigger " ++ show h ++ " (" ++ g ++ ") " ++ a ]
+
+-- | Default imports for a 'Spec' that was converted into a 'Copilot.Spec'.
+defaultSpecImports :: [(String, Maybe String)]
+defaultSpecImports =
+  [ ("Control.Monad.Writer",  Nothing)
+  , ("Copilot.Language",      Nothing)
+  , ("Copilot.Language.Spec", Nothing)
+  , ("Data.Functor.Identity", Nothing)
+  , ("Language.Copilot",      Nothing)
+  , ("Copilot.Library.PTLTL", Just "PTLTL")
+  , ("Prelude",               Just "P")
+  ]
+
+-- ** Typechecking of Copilot specs
+
+-- | Read a specification from a 'String' and reify it.
+--
+-- This function receives a list of possibly qualified imports.
+reifySpec :: [(String, Maybe String)] -> String -> IO Core.Spec
+reifySpec imports specText = do
+  coreSpecE <- HI.runInterpreter $ do
+                 HI.setImportsQ imports
+                 copilotSpec <- HI.interpret specText (HI.as :: Copilot.Spec)
+                 HI.liftIO $ Copilot.reify copilotSpec
+
+  case coreSpecE of
+    Left err -> do putStrLn $ "Error: " ++ show err
+                   error $ show err
+
+    Right coreSpec -> return coreSpec
+
+-- ** Analysis of Copilot specs
+
+-- | Determine if a boolean expression is always 'True' or always 'False'.
+--
+-- The first boolean in the result is 'True' if the expression can be proven
+-- always 'True'. The second boolean in the expression is 'True' is the
+-- expression can be proven always 'False'.
+--
+-- They values in the tuple cannot both 'True' at the same time.
+exprIsConstant :: Core.Spec
+               -> Core.Name
+               -> Core.Expr Bool
+               -> IO (Bool, Bool)
+exprIsConstant spec name expr = do
+  r1 <- propIsValid spec name (Core.Forall expr)
+  r2 <- propIsValid spec name (Core.Forall (Core.Op1 Core.Not expr))
+  pure (r1, r2)
+
+-- | 'True' if the Copilot 'Prop' with the given name and expression is
+-- constantly 'True', or valid, and 'False' otherwise (not always 'True' or
+-- unknown).
+propIsValid :: Core.Spec
+            -> Core.Name
+            -> Core.Prop
+            -> IO Bool
+propIsValid spec name expr =
+    maybe False isValid . lookup name <$> prove Z3 spec'
+  where
+    spec' = spec { Core.specProperties = prop' : Core.specProperties spec }
+    prop' = Core.Property name expr
+
+    isValid :: SatResult -> Bool
+    isValid Valid = True
+    isValid _     = False
+
+-- ** Auxiliary list functions
+
+-- | Substitute a key based on a given substitution table from key to
+-- alternative key.
+--
+-- They key is left unchanged if it cannot be found in the substitution table.
+safeMap :: Eq k => [(k, k)] -> k -> k
+safeMap ls k = fromMaybe k $ lookup k ls


### PR DESCRIPTION
Augment `ogma-core` to formally analyze specs and adjust `ogma-cli`'s `overview` command to report the results of the analysis to the user, as prescribed in the solution proposed for #356.