### PR TITLE
`ogma-cli`: Add example containing requirements in CSV format. Refs #358.

### DIFF
--- a/ogma-cli/CHANGELOG.md
+++ b/ogma-cli/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Revision history for ogma-cli
 
-## [1.X.Y] - 2026-02-17
+## [1.X.Y] - 2026-02-28
 
 * Fix grammatical errors in ROS 2 tutorial (#341).
 * Make example file consistent with associated tutorial (#343).
@@ -9,6 +9,7 @@
 * Fix incorrect arguments to `diagram` command in tutorial (#349).
 * Adjust README, tutorial to account for Dockerfile in cFS template (#353).
 * Augment `overview` command to report results of spec analysis (#356).
+* Add example containing requirements in CSV format (#358).
 
 ## [1.12.0] - 2026-01-21
 

--- a/ogma-cli/examples/csv/csv-format.cfg
+++ b/ogma-cli/examples/csv/csv-format.cfg
@@ -1,0 +1,8 @@
+CSVFormat
+  { skipHeaders               = True
+  , specRequirementId         = 0
+  , specRequirementDesc       = Just 1
+  , specRequirementExpr       = 3
+  , specRequirementResultType = Nothing
+  , specRequirementResultExpr = Nothing
+  }

--- a/ogma-cli/examples/csv/requirements.csv
+++ b/ogma-cli/examples/csv/requirements.csv
@@ -1,0 +1,4 @@
+Requirement ID,Text,Rationale,Formalization,Notes
+Req001,The system shall only be in autopilot mode if there is a GPS fix.,,autopilot -> gps_fix,This requirement is not always true or false in principle.
+Req002,The system shall have a GPS fix if and only if it has a GPS fix.,,gps_fix = gps_fix,"This requirement is always true, and therefore doesn't add value. The monitor should never report a violation."
+Req003,The system shall have a GPS fix if and only if it does not have a GPS fix.,,gps_fix != gps_fix,"This requirement is always false, and therefore cannot be realized. The monitor should always report a violation."


### PR DESCRIPTION
Add CSV file under `ogma-cli/examples` containing requirements, together with the configuration file that specifies the format of the CSV file, as prescribed in the solution proposed for #358.