### PR TITLE
`ogma-cli`: Augment overview command to report consistency of spec. Refs #366.

### DIFF
--- a/ogma-cli/CHANGELOG.md
+++ b/ogma-cli/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Revision history for ogma-cli
 
-## [1.X.Y] - 2026-03-05
+## [1.X.Y] - 2026-03-13
 
 * Fix grammatical errors in ROS 2 tutorial (#341).
 * Make example file consistent with associated tutorial (#343).
@@ -13,6 +13,7 @@
 * Add example containing requirements in XLSX format (#360).
 * Add CI job to test standalone backend using CSV file (#362).
 * Add CI job to test standalone backend using XLSX file (#364).
+* Augment `overview` command to report consistency of specs (#366).
 
 ## [1.12.0] - 2026-01-21
 

--- a/ogma-cli/src/CLI/CommandOverview.hs
+++ b/ogma-cli/src/CLI/CommandOverview.hs
@@ -82,6 +82,12 @@ command c = do
       , " - {{commandRequirements}} requirements."
       , "   - {{commandRequirementsTrue}} requirements are constantly or always true."
       , "   - {{commandRequirementsFalse}} requirements are constantly or always false."
+      , "{{#commandRequirementsConsistent}}"
+      , "   - No inconsistencies detected in the requirements."
+      , "{{/commandRequirementsConsistent}}"
+      , "{{^commandRequirementsConsistent}}"
+      , "   - The requirements are not mutually consistent."
+      , "{{/commandRequirementsConsistent}}"
       ]
 
 -- * CLI

--- a/ogma-core/CHANGELOG.md
+++ b/ogma-core/CHANGELOG.md
@@ -1,10 +1,11 @@
 # Revision history for ogma-core
 
-## [1.X.Y] - 2026-02-17
+## [1.X.Y] - 2026-03-13
 
 * Remove unused functions from diagram template (#351).
 * Add dockerfile to cFS template (#353).
 * Augment overview command to formally analyze specs (#356).
+* Augment overview command to determine consistency of specs (#366).
 
 ## [1.12.0] - 2026-01-21
 

--- a/ogma-core/src/Command/Overview.hs
+++ b/ogma-core/src/Command/Overview.hs
@@ -85,18 +85,20 @@ command' fp options (ExprPair exprT) = do
         let specCompleted = addMissingIdentifiers ids spec'
             specAnalyzed  = Spec2Copilot.specAnalyze specCompleted
 
-        numConstantReqs <-
+        specFormalAnalysis <-
           SpecAnalysis.specAnalyze [] replace printExpr specCompleted
 
         pure $ do
           numExterns  <- length . externalVariables <$> specAnalyzed
           numInternal <- length . internalVariables <$> specAnalyzed
           numReqs     <- length . requirements      <$> specAnalyzed
-          numTrues    <- SpecAnalysis.numAlwaysTrue  <$> numConstantReqs
-          numFalses   <- SpecAnalysis.numAlwaysFalse <$> numConstantReqs
+          numTrues    <- SpecAnalysis.numAlwaysTrue  <$> specFormalAnalysis
+          numFalses   <- SpecAnalysis.numAlwaysFalse <$> specFormalAnalysis
+          consistent  <- SpecAnalysis.consistent     <$> specFormalAnalysis
 
           pure $
-            CommandSummary numExterns numInternal numReqs numTrues numFalses
+            CommandSummary
+              numExterns numInternal numReqs numTrues numFalses consistent
 
   where
 
@@ -108,11 +110,12 @@ command' fp options (ExprPair exprT) = do
     ExprPairT _parse replace printExpr ids _def = exprT
 
 data CommandSummary = CommandSummary
-  { commandExternalVariables :: Int
-  , commandInternalVariables :: Int
-  , commandRequirements      :: Int
-  , commandRequirementsTrue  :: Int
-  , commandRequirementsFalse :: Int
+  { commandExternalVariables      :: Int
+  , commandInternalVariables      :: Int
+  , commandRequirements           :: Int
+  , commandRequirementsTrue       :: Int
+  , commandRequirementsFalse      :: Int
+  , commandRequirementsConsistent :: Bool
   }
   deriving (Generic, Show)
 

--- a/ogma-core/src/Language/Trans/SpecAnalysis.hs
+++ b/ogma-core/src/Language/Trans/SpecAnalysis.hs
@@ -43,8 +43,9 @@ import Data.OgmaSpec (ExternalVariableDef (..), InternalVariableDef (..),
 
 -- | Result of analyzing a specification.
 data AnalysisResult = AnalysisResult
-  { numAlwaysTrue  :: Int -- ^ Number of always true requirements.
-  , numAlwaysFalse :: Int -- ^ Number of always false requirements.
+  { numAlwaysTrue  :: Int  -- ^ Number of always true requirements.
+  , numAlwaysFalse :: Int  -- ^ Number of always false requirements.
+  , consistent     :: Bool -- ^ Whether requirements are mutually consistent.
   }
 
 -- | Formally analyze a specification for redundancies, conflicts, etc.
@@ -69,7 +70,18 @@ specAnalyze typeMaps exprTransform showExpr spec = do
   let numTrue  = length $ filter fst constantProperties
       numFalse = length $ filter snd constantProperties
 
-  return $ Right $ AnalysisResult numTrue numFalse
+  let negatedConjunction = Core.Op1 Core.Not
+                         $ foldr (Core.Op2 Core.And) true propertyGuards
+      true               = Core.Const Core.Bool True
+
+  provedNegatedConjunction <-
+    exprIsConstant coreSpec "ogma_inc" negatedConjunction
+
+  -- The requirements are considered consistent if it was *not* possible to
+  -- prove that their conjunction is always false.
+  let consistent = not $ fst provedNegatedConjunction
+
+  return $ Right $ AnalysisResult numTrue numFalse consistent
 
 -- * Auxiliary
 


### PR DESCRIPTION
Augment `ogma-core` to analyze the consistency of the properties provided and adjust `ogma-cli`'s `overview` command to report consistency information, as prescribed in the solution proposed for #366.