### PR TITLE
`ogma-core`: Expand extra definitions in Copilot specs in templates. Refs #368.

### DIFF
--- a/ogma-core/CHANGELOG.md
+++ b/ogma-core/CHANGELOG.md
@@ -1,11 +1,12 @@
 # Revision history for ogma-core
 
-## [1.X.Y] - 2026-03-13
+## [1.X.Y] - 2026-03-21
 
 * Remove unused functions from diagram template (#351).
 * Add dockerfile to cFS template (#353).
 * Augment overview command to formally analyze specs (#356).
 * Augment overview command to determine consistency of specs (#366).
+* Expand extra definitions in Copilot specs in templates (#368).
 
 ## [1.12.0] - 2026-01-21
 

--- a/ogma-core/templates/cfs/copilot/fsw/src/Properties.hs
+++ b/ogma-core/templates/cfs/copilot/fsw/src/Properties.hs
@@ -10,6 +10,9 @@ import qualified Copilot.Library.MTL       as MTL
 import           Language.Copilot          (reify)
 import           Prelude                   hiding ((&&), (||), (++), (<=), (>=), (<), (>), (==), (/=), not)
 
+{{#copilot_extra_defs}}
+{{{.}}}
+{{/copilot_extra_defs}}
 {{{copilot.externs}}}
 {{{copilot.internals}}}
 {{{copilot.reqs}}}

--- a/ogma-core/templates/fprime/Copilot.hs
+++ b/ogma-core/templates/fprime/Copilot.hs
@@ -10,6 +10,9 @@ import qualified Copilot.Library.MTL       as MTL
 import           Language.Copilot          (reify)
 import           Prelude                   hiding ((&&), (||), (++), (<=), (>=), (<), (>), (==), (/=), not)
 
+{{#copilot_extra_defs}}
+{{{.}}}
+{{/copilot_extra_defs}}
 {{{copilot.externs}}}
 {{{copilot.internals}}}
 {{{copilot.reqs}}}

--- a/ogma-core/templates/ros/copilot/src/Copilot.hs
+++ b/ogma-core/templates/ros/copilot/src/Copilot.hs
@@ -10,6 +10,9 @@ import qualified Copilot.Library.MTL       as MTL
 import           Language.Copilot          (reify)
 import           Prelude                   hiding ((&&), (||), (++), (<=), (>=), (<), (>), (==), (/=), not)
 
+{{#copilot_extra_defs}}
+{{{.}}}
+{{/copilot_extra_defs}}
 {{{copilot.externs}}}
 {{{copilot.internals}}}
 {{{copilot.reqs}}}

--- a/ogma-core/templates/standalone/Copilot.hs
+++ b/ogma-core/templates/standalone/Copilot.hs
@@ -9,6 +9,9 @@ import qualified Copilot.Library.MTL       as MTL
 import           Language.Copilot          (reify)
 import           Prelude                   hiding ((&&), (||), (++), (<=), (>=), (<), (>), (==), (/=), not)
 
+{{#copilot_extra_defs}}
+{{{.}}}
+{{/copilot_extra_defs}}
 {{{externs}}}
 {{{internals}}}
 {{{reqs}}}


### PR DESCRIPTION
Modify templates to allow for extra definitions to be expanded within Copilot specs, as prescribed in the solution proposed for #368.
