### PR TITLE
Constrain versions of `alex` in Cabal files and CI scripts. Refs #370.

### DIFF
--- a/.github/workflows/repo-ghc-8.6-cabal-2.4-cfs.yml
+++ b/.github/workflows/repo-ghc-8.6-cabal-2.4-cfs.yml
@@ -39,7 +39,7 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt-get install -y libbz2-dev libexpat-dev cmake make psmisc
-        cabal v1-install alex happy
+        cabal v1-install alex happy --constraint="alex <3.5.4.1 || >3.5.4.1"
         cabal v1-install BNFC
 
     - name: Install ogma

--- a/.github/workflows/repo-ghc-8.6-cabal-2.4-csv.yml
+++ b/.github/workflows/repo-ghc-8.6-cabal-2.4-csv.yml
@@ -39,7 +39,7 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt-get install -y libbz2-dev libexpat-dev cmake make psmisc
-        cabal v1-install alex happy
+        cabal v1-install alex happy --constraint="alex <3.5.4.1 || >3.5.4.1"
         cabal v1-install BNFC
 
     - name: Install ogma

--- a/.github/workflows/repo-ghc-8.6-cabal-2.4-diagram.yml
+++ b/.github/workflows/repo-ghc-8.6-cabal-2.4-diagram.yml
@@ -39,7 +39,7 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt-get install -y libz-dev libbz2-dev libexpat-dev
-        cabal v1-install alex happy
+        cabal v1-install alex happy --constraint="alex <3.5.4.1 || >3.5.4.1"
         cabal v1-install BNFC
 
     - name: Install ogma

--- a/.github/workflows/repo-ghc-8.6-cabal-2.4-xlsx.yml
+++ b/.github/workflows/repo-ghc-8.6-cabal-2.4-xlsx.yml
@@ -39,7 +39,7 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt-get install -y libbz2-dev libexpat-dev cmake make psmisc
-        cabal v1-install alex happy
+        cabal v1-install alex happy --constraint="alex <3.5.4.1 || >3.5.4.1"
         cabal v1-install BNFC
 
     - name: Install ogma

--- a/.github/workflows/repo-ghc-8.6-cabal-2.4.yml
+++ b/.github/workflows/repo-ghc-8.6-cabal-2.4.yml
@@ -40,7 +40,7 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt-get install -y libbz2-dev libexpat-dev
-        cabal v1-install alex happy
+        cabal v1-install alex happy --constraint="alex <3.5.4.1 || >3.5.4.1"
         cabal v1-install BNFC
 
     - name: Install ogma

--- a/ogma-cli/CHANGELOG.md
+++ b/ogma-cli/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Revision history for ogma-cli
 
-## [1.X.Y] - 2026-03-13
+## [1.X.Y] - 2026-03-21
 
 * Fix grammatical errors in ROS 2 tutorial (#341).
 * Make example file consistent with associated tutorial (#343).
@@ -14,6 +14,7 @@
 * Add CI job to test standalone backend using CSV file (#362).
 * Add CI job to test standalone backend using XLSX file (#364).
 * Augment `overview` command to report consistency of specs (#366).
+* Adjust CI jobs to avoid broken version of `alex` (#370).
 
 ## [1.12.0] - 2026-01-21
 

--- a/ogma-language-c/CHANGELOG.md
+++ b/ogma-language-c/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Revision history for ogma-language-c
 
+## [1.X.Y] - 2026-03-21
+
+* Constrain version of `alex` in Cabal file (#370).
+
 ## [1.12.0] - 2026-01-21
 
 * Version bump 1.12.0 (#336).

--- a/ogma-language-c/ogma-language-c.cabal
+++ b/ogma-language-c/ogma-language-c.cabal
@@ -79,7 +79,7 @@ library
     , array >= 0.5.2.0  && < 0.6
 
   build-tool-depends:
-      alex:alex   >= 3
+      alex:alex   >= 3 && (< 3.5.4.1 || > 3.5.4.1)
     , BNFC:bnfc   >= 2.9.4
     , happy:happy >= 1.19
 

--- a/ogma-language-lustre/CHANGELOG.md
+++ b/ogma-language-lustre/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Revision history for ogma-language-lustre
 
+## [1.X.Y] - 2026-03-21
+
+* Constrain version of `alex` in Cabal file (#370).
+
 ## [1.12.0] - 2026-01-21
 
 * Version bump 1.12.0 (#336).

--- a/ogma-language-lustre/ogma-language-lustre.cabal
+++ b/ogma-language-lustre/ogma-language-lustre.cabal
@@ -80,7 +80,7 @@ library
     , array >= 0.5.2.0  && < 0.6
 
   build-tool-depends:
-      alex:alex   >= 3
+      alex:alex   >= 3 && (< 3.5.4.1 || > 3.5.4.1)
     , BNFC:bnfc   >= 2.9.4
     , happy:happy >= 1.19
 

--- a/ogma-language-smv/CHANGELOG.md
+++ b/ogma-language-smv/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Revision history for ogma-language-smv
 
+## [1.X.Y] - 2026-03-21
+
+* Constrain version of `alex` in Cabal file (#370).
+
 ## [1.12.0] - 2026-01-21
 
 * Version bump 1.12.0 (#336).

--- a/ogma-language-smv/ogma-language-smv.cabal
+++ b/ogma-language-smv/ogma-language-smv.cabal
@@ -80,7 +80,7 @@ library
     , array >= 0.5.2.0  && < 0.6
 
   build-tool-depends:
-      alex:alex   >= 3
+      alex:alex   >= 3 && (< 3.5.4.1 || > 3.5.4.1)
     , BNFC:bnfc   >= 2.9.4
     , happy:happy >= 1.19
 


### PR DESCRIPTION
Restrict versions of `alex` used as a dependency during installation of Ogma and in CI, as prescribed in the solution for #370.