### PR TITLE
`ogma-core`: Bump upper version constraints on Copilot packages. Refs #377.

### DIFF
--- a/ogma-core/CHANGELOG.md
+++ b/ogma-core/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Revision history for ogma-core
 
+## [1.X.Y] - 2026-03-23
+
+* Bump upper version constraints on Copilot packages (#377).
+
 ## [1.13.0] - 2026-03-21
 
 * Version bump (1.13.0) (#373).

--- a/ogma-core/ogma-core.cabal
+++ b/ogma-core/ogma-core.cabal
@@ -133,9 +133,9 @@ library
     , aeson                   >= 2.0.0.0  && < 2.3
     , bytestring              >= 0.10.8.2 && < 0.13
     , containers              >= 0.5      && < 0.8
-    , copilot-core            >= 4.6.1    && < 4.7
-    , copilot-language        >= 4.6.1    && < 4.7
-    , copilot-theorem         >= 4.6.1    && < 4.7
+    , copilot-core            >= 4.6.1    && < 4.8
+    , copilot-language        >= 4.6.1    && < 4.8
+    , copilot-theorem         >= 4.6.1    && < 4.8
     , directory               >= 1.3.1.5  && < 1.4
     , filepath                >= 1.4.2    && < 1.6
     , graphviz                >= 2999.20  && < 2999.21


### PR DESCRIPTION
Bump upper version constraint on `copilot-core`, `copilot-language` and `copilot-theorem`, as prescribed in the solution proposed for #377 .