### PR TITLE
Lower upper version bound on `megaparsec`. Refs #380.

### DIFF
--- a/ogma-core/CHANGELOG.md
+++ b/ogma-core/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Revision history for ogma-core
 
-## [1.X.Y] - 2026-03-23
+## [1.X.Y] - 2026-03-29
 
 * Bump upper version constraints on Copilot packages (#377).
+* Lower upper version bound on `megaparsec` (#380).
 
 ## [1.13.0] - 2026-03-21
 

--- a/ogma-core/ogma-core.cabal
+++ b/ogma-core/ogma-core.cabal
@@ -140,7 +140,7 @@ library
     , filepath                >= 1.4.2    && < 1.6
     , graphviz                >= 2999.20  && < 2999.21
     , hint                    >= 0.9.0    && < 1.10
-    , megaparsec              >= 8.0.0    && < 9.10
+    , megaparsec              >= 8.0.0    && < 9.8
     , mtl                     >= 2.2.2    && < 2.4
     , process                 >= 1.6      && < 1.7
     , text                    >= 1.2.3.1  && < 2.2

--- a/ogma-language-jsonspec/CHANGELOG.md
+++ b/ogma-language-jsonspec/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Revision history for ogma-language-jsonspec
 
+## [1.X.Y] - 2026-03-29
+
+* Lower upper version bound on `megaparsec` (#380).
+
 ## [1.13.0] - 2026-03-21
 
 * Version bump (1.13.0) (#373).

--- a/ogma-language-jsonspec/ogma-language-jsonspec.cabal
+++ b/ogma-language-jsonspec/ogma-language-jsonspec.cabal
@@ -60,7 +60,7 @@ library
     , aeson                  >= 2.0.0.0  && < 2.3
     , jsonpath               >= 0.3      && < 0.4
     , text                   >= 1.2.3.1  && < 2.2
-    , megaparsec             >= 8.0.0    && < 9.10
+    , megaparsec             >= 8.0.0    && < 9.8
     , mtl                    >= 2.2.2    && < 2.4
     , bytestring             >= 0.10.8.2 && < 0.13
 


### PR DESCRIPTION
Lower the upper version bound applicable to `megaparsec` to 9.8 in the two packages that depend on it, as prescribed in the solution proposed for #380.