### PR TITLE
Bump upper version constraint on QuickCheck. Refs #382.

### DIFF
--- a/ogma-core/CHANGELOG.md
+++ b/ogma-core/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Revision history for ogma-core
 
-## [1.X.Y] - 2026-03-29
+## [1.X.Y] - 2026-04-03
 
 * Bump upper version constraints on Copilot packages (#377).
 * Lower upper version bound on `megaparsec` (#380).
+* Bump upper version constraint on Quickcheck (#382).
 
 ## [1.13.0] - 2026-03-21
 

--- a/ogma-core/ogma-core.cabal
+++ b/ogma-core/ogma-core.cabal
@@ -176,7 +176,7 @@ test-suite unit-tests
       base                       >= 4.11.0.0 && < 5
     , directory                  >= 1.3.1.5  && < 1.4
     , HUnit                      >= 1.2.0.0  && < 1.7
-    , QuickCheck                 >= 2.8.2    && < 2.16
+    , QuickCheck                 >= 2.8.2    && < 2.17
     , test-framework             >= 0.8.2    && < 0.9
     , test-framework-hunit       >= 0.2.0    && < 0.4
     , test-framework-quickcheck2 >= 0.3.0.4  && < 0.4

--- a/ogma-extra/CHANGELOG.md
+++ b/ogma-extra/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Revision history for ogma-extra
 
+## [1.X.Y] - 2026-04-03
+
+* Bump upper version constraint on Quickcheck (#382).
+
 ## [1.13.0] - 2026-03-21
 
 * Version bump (1.13.0) (#373).

--- a/ogma-extra/ogma-extra.cabal
+++ b/ogma-extra/ogma-extra.cabal
@@ -88,7 +88,7 @@ test-suite unit-tests
 
   build-depends:
       base                       >= 4.11.0.0 && < 5
-    , QuickCheck                 >= 2.8.2    && < 2.16
+    , QuickCheck                 >= 2.8.2    && < 2.17
     , test-framework             >= 0.8.2    && < 0.9
     , test-framework-quickcheck2 >= 0.3.0.4  && < 0.4
 

--- a/ogma-language-c/CHANGELOG.md
+++ b/ogma-language-c/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Revision history for ogma-language-c
 
+## [1.X.Y] - 2026-04-03
+
+* Bump upper version constraint on Quickcheck (#382).
+
 ## [1.13.0] - 2026-03-21
 
 * Version bump (1.13.0) (#373).

--- a/ogma-language-c/ogma-language-c.cabal
+++ b/ogma-language-c/ogma-language-c.cabal
@@ -98,7 +98,7 @@ test-suite unit-tests
 
   build-depends:
       base                       >= 4.11.0.0 && < 5
-    , QuickCheck                 >= 2.8.2    && < 2.16
+    , QuickCheck                 >= 2.8.2    && < 2.17
     , test-framework             >= 0.8.2    && < 0.9
     , test-framework-quickcheck2 >= 0.3.0.4  && < 0.4
 

--- a/ogma-language-lustre/CHANGELOG.md
+++ b/ogma-language-lustre/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Revision history for ogma-language-lustre
 
+## [1.X.Y] - 2026-04-03
+
+* Bump upper version constraint on Quickcheck (#382).
+
 ## [1.13.0] - 2026-03-21
 
 * Version bump (1.13.0) (#373).

--- a/ogma-language-lustre/ogma-language-lustre.cabal
+++ b/ogma-language-lustre/ogma-language-lustre.cabal
@@ -99,7 +99,7 @@ test-suite unit-tests
 
   build-depends:
       base                       >= 4.11.0.0 && < 5
-    , QuickCheck                 >= 2.8.2    && < 2.16
+    , QuickCheck                 >= 2.8.2    && < 2.17
     , test-framework             >= 0.8.2    && < 0.9
     , test-framework-quickcheck2 >= 0.3.0.4  && < 0.4
 

--- a/ogma-language-smv/CHANGELOG.md
+++ b/ogma-language-smv/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Revision history for ogma-language-smv
 
+## [1.X.Y] - 2026-04-03
+
+* Bump upper version constraint on Quickcheck (#382).
+
 ## [1.13.0] - 2026-03-21
 
 * Version bump (1.13.0) (#373).

--- a/ogma-language-smv/ogma-language-smv.cabal
+++ b/ogma-language-smv/ogma-language-smv.cabal
@@ -99,7 +99,7 @@ test-suite unit-tests
 
   build-depends:
       base                       >= 4.11.0.0 && < 5
-    , QuickCheck                 >= 2.8.2    && < 2.16
+    , QuickCheck                 >= 2.8.2    && < 2.17
     , test-framework             >= 0.8.2    && < 0.9
     , test-framework-quickcheck2 >= 0.3.0.4  && < 0.4
 


### PR DESCRIPTION
Bump upper version constraint on `QuickCheck` across multiple packages, as prescribed in the solution proposed for #382.