### PR TITLE
`ogma-core`: Move functions related to `Either` type to dedicated module. Refs #391.

### DIFF
--- a/ogma-core/CHANGELOG.md
+++ b/ogma-core/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Revision history for ogma-core
 
-## [1.X.Y] - 2026-04-09
+## [1.X.Y] - 2026-04-13
 
 * Bump upper version constraints on Copilot packages (#377).
 * Lower upper version bound on `megaparsec` (#380).
@@ -8,6 +8,7 @@
 * Adjust `Common.Diagram` module to use `Command.Common.ExprPair` (#384).
 * Add support for reading diagrams to overview command (#386).
 * Augment overview command to formally analyze diagrams (#388).
+* Move functions related to `Either` type to dedicated module (#391).
 
 ## [1.13.0] - 2026-03-21
 

--- a/ogma-core/ogma-core.cabal
+++ b/ogma-core/ogma-core.cabal
@@ -124,6 +124,7 @@ library
     Command.CommonDiagram
     Command.Errors
     Command.VariableDB
+    Data.Either.Extra
     Language.Trans.SpecAnalysis
 
   autogen-modules:

--- a/ogma-core/src/Command/Common.hs
+++ b/ogma-core/src/Command/Common.hs
@@ -86,10 +86,11 @@ import           Language.Trans.SMV2Copilot    as SMV (boolSpec2Copilot,
 import Command.VariableDB (VariableDB, emptyVariableDB, mergeVariableDB)
 
 -- Internal imports: auxiliary
-import Command.Errors  (ErrorTriplet(..), ErrorCode)
-import Command.Result  (Result (..))
-import Data.Location   (Location (..))
-import Paths_ogma_core (getDataDir)
+import Command.Errors    (ErrorTriplet(..), ErrorCode)
+import Command.Result    (Result (..))
+import Data.Either.Extra (makeLeft)
+import Data.Location     (Location (..))
+import Paths_ogma_core   (getDataDir)
 
 -- | Process input specification from a single expression and return its
 -- abstract representation.
@@ -224,7 +225,7 @@ openVarDBFiles acc (x:xs) = do
                    -> ExceptT ErrorTriplet IO VariableDB
     parseVarDBFile Nothing   = return emptyVariableDB
     parseVarDBFile (Just fn) =
-      ExceptT $ makeLeftE' (cannotOpenDB fn) <$>
+      ExceptT $ makeLeft (cannotOpenDB fn) <$>
         eitherDecodeFileStrict fn
 
 -- | Read a list of variable DBs, as well as the default variable DB.
@@ -529,9 +530,4 @@ mergeObjects _           _           = error "The values passed are not objects"
 
 -- | Replace the left Exception in an Either.
 makeLeftE :: c -> Either E.SomeException b -> Either c b
-makeLeftE = makeLeftE'
-
--- | Replace the left value in an @Either@.
-makeLeftE' :: c -> Either a b -> Either c b
-makeLeftE' c (Left _)  = Left c
-makeLeftE' _ (Right x) = Right x
+makeLeftE = makeLeft

--- a/ogma-core/src/Command/Common.hs
+++ b/ogma-core/src/Command/Common.hs
@@ -88,7 +88,7 @@ import Command.VariableDB (VariableDB, emptyVariableDB, mergeVariableDB)
 -- Internal imports: auxiliary
 import Command.Errors    (ErrorTriplet(..), ErrorCode)
 import Command.Result    (Result (..))
-import Data.Either.Extra (makeLeft)
+import Data.Either.Extra (makeLeft, mapLeft)
 import Data.Location     (Location (..))
 import Paths_ogma_core   (getDataDir)
 
@@ -112,9 +112,8 @@ parseInputExpr expr propFormatName propVia exprT =
           let req = Requirement "triggerCondition" expr' "" Nothing Nothing
           return $ Spec [] [] [ req ]
 
-    case spec of
-      Left e  -> return $ Left $ cannotReadConditionExpr expr e
-      Right s -> return $ Right s
+    -- Return the spec, transforming the error message if applicable.
+    pure $ mapLeft (cannotReadConditionExpr expr) spec
 
 -- | Process input specification, if available, and return its abstract
 -- representation.

--- a/ogma-core/src/Command/Standalone.hs
+++ b/ogma-core/src/Command/Standalone.hs
@@ -49,6 +49,7 @@ import System.Directory.Extra (copyTemplate)
 import Command.Common
 import Command.Errors              (ErrorCode, ErrorTriplet(..))
 import Command.Result              (Result (..))
+import Data.Either.Extra           (mapLeft)
 import Data.Location               (Location (..))
 import Language.Trans.Spec2Copilot (spec2Copilot, specAnalyze)
 
@@ -257,7 +258,3 @@ addMissingIdentifiers f s = s { externalVariables = vars' }
     -- Names that are defined in variables.
     existingNames = map externalVariableName (externalVariables s)
                  ++ map internalVariableName (internalVariables s)
-
-mapLeft :: (a -> c) -> Either a b -> Either c b
-mapLeft f (Left x)  = Left (f x)
-mapLeft _ (Right x) = Right x

--- a/ogma-core/src/Data/Either/Extra.hs
+++ b/ogma-core/src/Data/Either/Extra.hs
@@ -17,10 +17,19 @@
 --
 -- | Auxiliary functions for working with values of type 'Either'.
 module Data.Either.Extra
-    ( makeLeft )
+    ( makeLeft
+    , mapLeft
+    )
   where
 
 -- | Replace the left value in an @Either@.
 makeLeft :: c -> Either a b -> Either c b
 makeLeft c (Left _)  = Left c
 makeLeft _ (Right x) = Right x
+
+-- | Apply a transformation only to the 'Left' values of an 'Either'.
+--
+-- Left counterpart of 'fmap'.
+mapLeft :: (a -> c) -> Either a b -> Either c b
+mapLeft f (Left x)  = Left (f x)
+mapLeft _ (Right x) = Right x

--- a/ogma-core/src/Data/Either/Extra.hs
+++ b/ogma-core/src/Data/Either/Extra.hs
@@ -1,0 +1,26 @@
+-- Copyright 2022 United States Government as represented by the Administrator
+-- of the National Aeronautics and Space Administration. All Rights Reserved.
+--
+-- Disclaimers
+--
+-- Licensed under the Apache License, Version 2.0 (the "License"); you may
+-- not use this file except in compliance with the License. You may obtain a
+-- copy of the License at
+--
+--      https://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+-- WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+-- License for the specific language governing permissions and limitations
+-- under the License.
+--
+-- | Auxiliary functions for working with values of type 'Either'.
+module Data.Either.Extra
+    ( makeLeft )
+  where
+
+-- | Replace the left value in an @Either@.
+makeLeft :: c -> Either a b -> Either c b
+makeLeft c (Left _)  = Left c
+makeLeft _ (Right x) = Right x


### PR DESCRIPTION
Move functions related to `Either` type to new internal dedicated module, adjusting imports and uses as appropriate, as prescribed in the solution proposed for #391.