### PR TITLE
`ogma-core`: Move function related to JSON objects to dedicated module. Refs #393.

### DIFF
--- a/ogma-core/CHANGELOG.md
+++ b/ogma-core/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Revision history for ogma-core
 
-## [1.X.Y] - 2026-04-13
+## [1.X.Y] - 2026-04-14
 
 * Bump upper version constraints on Copilot packages (#377).
 * Lower upper version bound on `megaparsec` (#380).
@@ -9,6 +9,7 @@
 * Add support for reading diagrams to overview command (#386).
 * Augment overview command to formally analyze diagrams (#388).
 * Move functions related to `Either` type to dedicated module (#391).
+* Move function related to JSON objects to dedicated module (#393).
 
 ## [1.13.0] - 2026-03-21
 

--- a/ogma-core/ogma-core.cabal
+++ b/ogma-core/ogma-core.cabal
@@ -124,6 +124,7 @@ library
     Command.CommonDiagram
     Command.Errors
     Command.VariableDB
+    Data.Aeson.Extra
     Data.Either.Extra
     Language.Trans.SpecAnalysis
 

--- a/ogma-core/src/Command/CFSApp.hs
+++ b/ogma-core/src/Command/CFSApp.hs
@@ -59,6 +59,7 @@ import Command.Errors     (ErrorCode, ErrorTriplet (..))
 import Command.VariableDB (Connection (..), TopicDef (..), TypeDef (..),
                            VariableDB, findConnection, findInput, findTopic,
                            findType, findTypeByType)
+import Data.Aeson.Extra   (mergeObjects)
 
 -- | Generate a new CFS application connected to Copilot.
 command :: CommandOptions

--- a/ogma-core/src/Command/Common.hs
+++ b/ogma-core/src/Command/Common.hs
@@ -37,7 +37,6 @@ module Command.Common
     , processResult
     , cannotCopyTemplate
     , makeLeftE
-    , mergeObjects
     , locateTemplateDir
     )
   where
@@ -48,7 +47,6 @@ import           Control.Monad.Except   (ExceptT (..), runExceptT, throwError)
 import           Control.Monad.IO.Class (liftIO)
 import           Data.Aeson             (Value (Null, Object), eitherDecode,
                                          eitherDecodeFileStrict, object)
-import           Data.Aeson.KeyMap      (union)
 import qualified Data.ByteString.Lazy   as L
 import           Data.List              (isInfixOf, isPrefixOf)
 import           System.Directory       (doesFileExist)
@@ -517,15 +515,6 @@ wrapVia (Just f) parse s =
   E.handle (\(e :: E.IOException) -> return $ Left $ show e) $ do
     out <- readProcess f [] s
     return $ parse out
-
--- | Merge two JSON objects.
---
--- Fails if the values are not objects or null.
-mergeObjects :: Value -> Value -> Value
-mergeObjects (Object m1) (Object m2) = Object (union m1 m2)
-mergeObjects obj         Null        = obj
-mergeObjects Null        obj         = obj
-mergeObjects _           _           = error "The values passed are not objects"
 
 -- | Replace the left Exception in an Either.
 makeLeftE :: c -> Either E.SomeException b -> Either c b

--- a/ogma-core/src/Command/FPrimeApp.hs
+++ b/ogma-core/src/Command/FPrimeApp.hs
@@ -53,6 +53,7 @@ import Command.Common
 import Command.Errors     (ErrorCode, ErrorTriplet (..))
 import Command.VariableDB (InputDef (..), TypeDef (..), VariableDB, findInput,
                            findType, findTypeByType)
+import Data.Aeson.Extra   (mergeObjects)
 
 -- | Generate a new FPrime component connected to Copilot.
 command :: CommandOptions -- ^ Options to the ROS backend.

--- a/ogma-core/src/Command/ROSApp.hs
+++ b/ogma-core/src/Command/ROSApp.hs
@@ -58,6 +58,7 @@ import Command.Errors     (ErrorCode, ErrorTriplet (..))
 import Command.VariableDB (Connection (..), InputDef (..), TopicDef (..),
                            TypeDef (..), VariableDB, findConnection, findInput,
                            findTopic, findType, findTypeByType)
+import Data.Aeson.Extra   (mergeObjects)
 
 -- | Generate a new ROS application connected to Copilot.
 command :: CommandOptions -- ^ Options to the ROS backend.

--- a/ogma-core/src/Command/Standalone.hs
+++ b/ogma-core/src/Command/Standalone.hs
@@ -49,6 +49,7 @@ import System.Directory.Extra (copyTemplate)
 import Command.Common
 import Command.Errors              (ErrorCode, ErrorTriplet(..))
 import Command.Result              (Result (..))
+import Data.Aeson.Extra            (mergeObjects)
 import Data.Either.Extra           (mapLeft)
 import Data.Location               (Location (..))
 import Language.Trans.Spec2Copilot (spec2Copilot, specAnalyze)

--- a/ogma-core/src/Data/Aeson/Extra.hs
+++ b/ogma-core/src/Data/Aeson/Extra.hs
@@ -1,0 +1,34 @@
+-- Copyright 2022 United States Government as represented by the Administrator
+-- of the National Aeronautics and Space Administration. All Rights Reserved.
+--
+-- Disclaimers
+--
+-- Licensed under the Apache License, Version 2.0 (the "License"); you may
+-- not use this file except in compliance with the License. You may obtain a
+-- copy of the License at
+--
+--      https://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+-- WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+-- License for the specific language governing permissions and limitations
+-- under the License.
+--
+-- | Auxiliary functions for working with JSON values.
+module Data.Aeson.Extra
+    ( mergeObjects )
+  where
+
+-- External imports
+import Data.Aeson        (Value (Null, Object))
+import Data.Aeson.KeyMap (union)
+
+-- | Merge two JSON values.
+--
+-- Fails if the values are not objects or null.
+mergeObjects :: Value -> Value -> Value
+mergeObjects (Object m1) (Object m2) = Object (union m1 m2)
+mergeObjects obj         Null        = obj
+mergeObjects Null        obj         = obj
+mergeObjects _           _           = error "The values passed are not objects"


### PR DESCRIPTION
Move function for manipulating JSON values to new internal dedicated module, adjusting imports and uses as appropriate, as prescribed in the solution proposed for #393.