### PR TITLE
`ogma-core`: Move definitions related to `ExprPair` type to dedicated module. Refs #395.

### DIFF
--- a/ogma-core/CHANGELOG.md
+++ b/ogma-core/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Revision history for ogma-core
 
-## [1.X.Y] - 2026-04-14
+## [1.X.Y] - 2026-04-15
 
 * Bump upper version constraints on Copilot packages (#377).
 * Lower upper version bound on `megaparsec` (#380).
@@ -10,6 +10,7 @@
 * Augment overview command to formally analyze diagrams (#388).
 * Move functions related to `Either` type to dedicated module (#391).
 * Move function related to JSON objects to dedicated module (#393).
+* Move definitions related to `ExprPair` type to dedicated module (#395).
 
 ## [1.13.0] - 2026-03-21
 

--- a/ogma-core/ogma-core.cabal
+++ b/ogma-core/ogma-core.cabal
@@ -126,6 +126,7 @@ library
     Command.VariableDB
     Data.Aeson.Extra
     Data.Either.Extra
+    Data.ExprPair
     Language.Trans.SpecAnalysis
 
   autogen-modules:

--- a/ogma-core/src/Command/CFSApp.hs
+++ b/ogma-core/src/Command/CFSApp.hs
@@ -60,6 +60,7 @@ import Command.VariableDB (Connection (..), TopicDef (..), TypeDef (..),
                            VariableDB, findConnection, findInput, findTopic,
                            findType, findTypeByType)
 import Data.Aeson.Extra   (mergeObjects)
+import Data.ExprPair      (ExprPair(..), exprPair)
 
 -- | Generate a new CFS application connected to Copilot.
 command :: CommandOptions

--- a/ogma-core/src/Command/Common.hs
+++ b/ogma-core/src/Command/Common.hs
@@ -31,9 +31,6 @@ module Command.Common
     , checkArguments
     , specExtractExternalVariables
     , specExtractHandlers
-    , ExprPair(..)
-    , ExprPairT(..)
-    , exprPair
     , processResult
     , cannotCopyTemplate
     , makeLeftE
@@ -67,19 +64,6 @@ import Language.JSONSpec.Parser (parseJSONSpec)
 import Language.XLSXSpec.Parser (parseXLSXSpec)
 import Language.XMLSpec.Parser  (parseXMLSpec)
 
--- External imports: language ASTs, transformers
-import qualified Language.Lustre.AbsLustre as Lustre
-import qualified Language.Lustre.ParLustre as Lustre (myLexer, pBoolSpec)
-
-import qualified Language.SMV.AbsSMV       as SMV
-import qualified Language.SMV.ParSMV       as SMV (myLexer, pBoolSpec)
-import           Language.SMV.Substitution (substituteBoolExpr)
-
-import qualified Language.Trans.Lustre2Copilot as Lustre (boolSpec2Copilot,
-                                                          boolSpecNames)
-import           Language.Trans.SMV2Copilot    as SMV (boolSpec2Copilot,
-                                                       boolSpecNames)
-
 -- Internal imports: VariableDBs
 import Command.VariableDB (VariableDB, emptyVariableDB, mergeVariableDB)
 
@@ -87,6 +71,7 @@ import Command.VariableDB (VariableDB, emptyVariableDB, mergeVariableDB)
 import Command.Errors    (ErrorTriplet(..), ErrorCode)
 import Command.Result    (Result (..))
 import Data.Either.Extra (makeLeft, mapLeft)
+import Data.ExprPair     (ExprPair (..), ExprPairT (..), exprPair)
 import Data.Location     (Location (..))
 import Paths_ogma_core   (getDataDir)
 
@@ -287,53 +272,6 @@ specExtractHandlers (Just cs) = map extractReqData
       (handlerNameF (requirementName r), requirementResultType r)
 
     handlerNameF = ("handler" ++) . sanitizeUCIdentifier
-
--- * Handler for boolean expressions
-
--- | Handler for boolean expressions that knows how to parse them, replace
--- variables in them, and convert them to Copilot.
---
--- It also contains a default value to be used whenever an expression cannot be
--- found in the input file.
-data ExprPair = forall a . ExprPair
-  { exprTPair   :: ExprPairT a
-  }
-
-data ExprPairT a = ExprPairT
-  { exprTParse   :: String -> Either String a
-  , exprTReplace :: [(String, String)] -> a -> a
-  , exprTPrint   :: a -> String
-  , exprTIdents  :: a -> [String]
-  , exprTUnknown :: a
-  }
-
-
--- | Return a handler depending on whether it should be for Lustre boolean
--- expressions or for SMV boolean expressions. We default to SMV if not format
--- is given.
-exprPair :: String -> ExprPair
-exprPair "lustre" = ExprPair $
-  ExprPairT
-    (Lustre.pBoolSpec . Lustre.myLexer)
-    (\_ -> id)
-    (Lustre.boolSpec2Copilot)
-    (Lustre.boolSpecNames)
-    (Lustre.BoolSpecSignal (Lustre.Ident "undefined"))
-exprPair "literal" = ExprPair $
-  ExprPairT
-    Right
-    (\_ -> id)
-    id
-    (const [])
-    "undefined"
-exprPair "cocospec" = exprPair "lustre"
-exprPair _ = ExprPair $
-  ExprPairT
-    (SMV.pBoolSpec . SMV.myLexer)
-    (substituteBoolExpr)
-    (SMV.boolSpec2Copilot)
-    (SMV.boolSpecNames)
-    (SMV.BoolSpecSignal (SMV.Ident "undefined"))
 
 -- * Errors
 

--- a/ogma-core/src/Command/CommonDiagram.hs
+++ b/ogma-core/src/Command/CommonDiagram.hs
@@ -62,7 +62,7 @@ import qualified Text.Megaparsec.Char.Lexer        as L
 import Data.ByteString.Extra as B (safeReadFile)
 
 -- Internal imports: auxiliary
-import Command.Common              (ExprPair (..), ExprPairT (..))
+import Data.ExprPair               (ExprPair (..), ExprPairT (..))
 import Language.Trans.SpecAnalysis (exprIsConstant, reifySpec)
 
 -- * Diagram

--- a/ogma-core/src/Command/Diagram.hs
+++ b/ogma-core/src/Command/Diagram.hs
@@ -48,9 +48,9 @@ import qualified Language.SMV.AbsSMV       as SMV
 import qualified Language.SMV.ParSMV       as SMV (myLexer, pBoolSpec)
 
 -- Internal imports: auxiliary
-import Command.Common        (ExprPair (..), ExprPairT (..))
 import Command.CommonDiagram (Diagram (..), DiagramFormat (..), readDiagram)
 import Command.Result        (Result (..))
+import Data.ExprPair         (ExprPair (..), ExprPairT (..))
 import Data.Location         (Location (..))
 import Paths_ogma_core       (getDataDir)
 

--- a/ogma-core/src/Command/FPrimeApp.hs
+++ b/ogma-core/src/Command/FPrimeApp.hs
@@ -54,6 +54,7 @@ import Command.Errors     (ErrorCode, ErrorTriplet (..))
 import Command.VariableDB (InputDef (..), TypeDef (..), VariableDB, findInput,
                            findType, findTypeByType)
 import Data.Aeson.Extra   (mergeObjects)
+import Data.ExprPair      (ExprPair(..), exprPair)
 
 -- | Generate a new FPrime component connected to Copilot.
 command :: CommandOptions -- ^ Options to the ROS backend.

--- a/ogma-core/src/Command/Overview.hs
+++ b/ogma-core/src/Command/Overview.hs
@@ -45,6 +45,8 @@ import           Command.CommonDiagram       (AnalysisResult (..),
                                               analyzeDiagram, readDiagram)
 import           Command.Errors              (ErrorCode, ErrorTriplet (..))
 import           Command.Result              (Result (..))
+import           Data.ExprPair               (ExprPair(..), ExprPairT(..),
+                                              exprPair)
 import           Data.Location               (Location (..))
 import qualified Language.Trans.Spec2Copilot as Spec2Copilot
 import qualified Language.Trans.SpecAnalysis as SpecAnalysis

--- a/ogma-core/src/Command/ROSApp.hs
+++ b/ogma-core/src/Command/ROSApp.hs
@@ -59,6 +59,7 @@ import Command.VariableDB (Connection (..), InputDef (..), TopicDef (..),
                            TypeDef (..), VariableDB, findConnection, findInput,
                            findTopic, findType, findTypeByType)
 import Data.Aeson.Extra   (mergeObjects)
+import Data.ExprPair      (ExprPair(..), exprPair)
 
 -- | Generate a new ROS application connected to Copilot.
 command :: CommandOptions -- ^ Options to the ROS backend.

--- a/ogma-core/src/Command/Standalone.hs
+++ b/ogma-core/src/Command/Standalone.hs
@@ -51,6 +51,7 @@ import Command.Errors              (ErrorCode, ErrorTriplet(..))
 import Command.Result              (Result (..))
 import Data.Aeson.Extra            (mergeObjects)
 import Data.Either.Extra           (mapLeft)
+import Data.ExprPair               (ExprPair(..), ExprPairT(..), exprPair)
 import Data.Location               (Location (..))
 import Language.Trans.Spec2Copilot (spec2Copilot, specAnalyze)
 

--- a/ogma-core/src/Data/ExprPair.hs
+++ b/ogma-core/src/Data/ExprPair.hs
@@ -1,0 +1,91 @@
+{-# LANGUAGE ExistentialQuantification #-}
+-- Copyright 2022 United States Government as represented by the Administrator
+-- of the National Aeronautics and Space Administration. All Rights Reserved.
+--
+-- Disclaimers
+--
+-- Licensed under the Apache License, Version 2.0 (the "License"); you may
+-- not use this file except in compliance with the License. You may obtain a
+-- copy of the License at
+--
+--      https://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+-- WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+-- License for the specific language governing permissions and limitations
+-- under the License.
+--
+-- | Abstraction for expressions used in specifications.
+module Data.ExprPair
+    ( ExprPair(..)
+    , ExprPairT(..)
+    , exprPair
+    )
+  where
+
+-- External imports
+import qualified Language.Lustre.AbsLustre     as Lustre
+import qualified Language.Lustre.ParLustre     as Lustre (myLexer, pBoolSpec)
+import qualified Language.SMV.AbsSMV           as SMV
+import qualified Language.SMV.ParSMV           as SMV (myLexer, pBoolSpec)
+import           Language.SMV.Substitution     (substituteBoolExpr)
+import qualified Language.Trans.Lustre2Copilot as Lustre (boolSpec2Copilot,
+                                                          boolSpecNames)
+import           Language.Trans.SMV2Copilot    as SMV (boolSpec2Copilot,
+                                                       boolSpecNames)
+
+-- | Existential wrapper over abstraction to handle expressions used in
+-- specifications.
+--
+-- The abstraction provides mechanisms to parse expressions, replace variables
+-- in them, render them in a known format or notation, and find identifiers in
+-- them, and it provides a default value to use when an expression is needed.
+data ExprPair = forall a . ExprPair
+  { exprTPair :: ExprPairT a
+  }
+
+-- | Abstraction to handle expressions used in specifications.
+--
+-- The abstraction provides mechanisms to parse expressions, replace variables
+-- in them, render them in a known format or notation, and find identifiers in
+-- them, and it provides a default value to use when an expression is needed.
+data ExprPairT a = ExprPairT
+  { exprTParse   :: String -> Either String a
+  , exprTReplace :: [(String, String)] -> a -> a
+  , exprTPrint   :: a -> String
+  , exprTIdents  :: a -> [String]
+  , exprTUnknown :: a
+  }
+
+-- | Return 'ExprPair' for a given language (e.g., Lustre, SMV).
+--
+-- The language name must be lowercase.
+--
+-- We default to SMV if no format is given.
+--
+-- The format literal returns an ExprPair that uses Strings as the base type
+-- and keeps them unchanged.
+exprPair :: String -> ExprPair
+exprPair "lustre" = ExprPair $
+  ExprPairT
+    (Lustre.pBoolSpec . Lustre.myLexer)
+    (\_ -> id)
+    (Lustre.boolSpec2Copilot)
+    (Lustre.boolSpecNames)
+    (Lustre.BoolSpecSignal (Lustre.Ident "undefined"))
+exprPair "literal" = ExprPair $
+  ExprPairT
+    Right
+    (\_ -> id)
+    id
+    (const [])
+    "undefined"
+exprPair "cocospec" = exprPair "lustre"
+exprPair _ = ExprPair $
+  ExprPairT
+    (SMV.pBoolSpec . SMV.myLexer)
+    (substituteBoolExpr)
+    (SMV.boolSpec2Copilot)
+    (SMV.boolSpecNames)
+    (SMV.BoolSpecSignal (SMV.Ident "undefined"))


### PR DESCRIPTION
Move types and functions related to the type `ExprPair` from `ogma-core:Command.Common` to a new, internal, dedicated module, adjusting imports and uses as appropriate, as prescribed in the solution proposed for #395.