### PR TITLE
`ogma-core`: Move functions related to Copilot specs to dedicated modules. Refs #397.

### DIFF
--- a/ogma-core/CHANGELOG.md
+++ b/ogma-core/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Revision history for ogma-core
 
-## [1.X.Y] - 2026-04-15
+## [1.X.Y] - 2026-04-17
 
 * Bump upper version constraints on Copilot packages (#377).
 * Lower upper version bound on `megaparsec` (#380).
@@ -11,6 +11,7 @@
 * Move functions related to `Either` type to dedicated module (#391).
 * Move function related to JSON objects to dedicated module (#393).
 * Move definitions related to `ExprPair` type to dedicated module (#395).
+* Move functions related to Copilot specs to dedicated modules (#397).
 
 ## [1.13.0] - 2026-03-21
 

--- a/ogma-core/ogma-core.cabal
+++ b/ogma-core/ogma-core.cabal
@@ -124,6 +124,7 @@ library
     Command.CommonDiagram
     Command.Errors
     Command.VariableDB
+    Copilot.Core.Analysis
     Data.Aeson.Extra
     Data.Either.Extra
     Data.ExprPair

--- a/ogma-core/ogma-core.cabal
+++ b/ogma-core/ogma-core.cabal
@@ -125,6 +125,7 @@ library
     Command.Errors
     Command.VariableDB
     Copilot.Core.Analysis
+    Copilot.Language.Reify.Extra
     Data.Aeson.Extra
     Data.Either.Extra
     Data.ExprPair

--- a/ogma-core/src/Command/CommonDiagram.hs
+++ b/ogma-core/src/Command/CommonDiagram.hs
@@ -62,8 +62,9 @@ import qualified Text.Megaparsec.Char.Lexer        as L
 import Data.ByteString.Extra as B (safeReadFile)
 
 -- Internal imports: auxiliary
+import Copilot.Core.Analysis       (exprIsConstant)
 import Data.ExprPair               (ExprPair (..), ExprPairT (..))
-import Language.Trans.SpecAnalysis (exprIsConstant, reifySpec)
+import Language.Trans.SpecAnalysis (reifySpec)
 
 -- * Diagram
 

--- a/ogma-core/src/Command/CommonDiagram.hs
+++ b/ogma-core/src/Command/CommonDiagram.hs
@@ -62,9 +62,9 @@ import qualified Text.Megaparsec.Char.Lexer        as L
 import Data.ByteString.Extra as B (safeReadFile)
 
 -- Internal imports: auxiliary
-import Copilot.Core.Analysis       (exprIsConstant)
-import Data.ExprPair               (ExprPair (..), ExprPairT (..))
-import Language.Trans.SpecAnalysis (reifySpec)
+import Copilot.Core.Analysis        (exprIsConstant)
+import Copilot.Language.Reify.Extra (reifySpec)
+import Data.ExprPair                (ExprPair (..), ExprPairT (..))
 
 -- * Diagram
 

--- a/ogma-core/src/Copilot/Core/Analysis.hs
+++ b/ogma-core/src/Copilot/Core/Analysis.hs
@@ -1,0 +1,59 @@
+-- Copyright 2024 United States Government as represented by the Administrator
+-- of the National Aeronautics and Space Administration. All Rights Reserved.
+--
+-- Disclaimers
+--
+-- Licensed under the Apache License, Version 2.0 (the "License"); you may
+-- not use this file except in compliance with the License. You may obtain a
+-- copy of the License at
+--
+--      https://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+-- WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+-- License for the specific language governing permissions and limitations
+-- under the License.
+
+-- | Formally analyze Copilot Core specifications.
+module Copilot.Core.Analysis
+    ( exprIsConstant )
+  where
+
+-- External imports
+import qualified Copilot.Core          as Core
+import           Copilot.Theorem.What4 (SatResult (..), Solver (Z3), prove)
+import           Data.List             (lookup)
+
+-- | Determine if a boolean expression is always 'True' or always 'False'.
+--
+-- The first boolean in the result is 'True' if the expression can be proven
+-- always 'True'. The second boolean in the expression is 'True' is the
+-- expression can be proven always 'False'.
+--
+-- They values in the tuple cannot both 'True' at the same time.
+exprIsConstant :: Core.Spec
+               -> Core.Name
+               -> Core.Expr Bool
+               -> IO (Bool, Bool)
+exprIsConstant spec name expr = do
+  r1 <- propIsValid spec name (Core.Forall expr)
+  r2 <- propIsValid spec name (Core.Forall (Core.Op1 Core.Not expr))
+  pure (r1, r2)
+
+-- | 'True' if the Copilot 'Prop' with the given name and expression is
+-- constantly 'True', or valid, and 'False' otherwise (not always 'True' or
+-- unknown).
+propIsValid :: Core.Spec
+            -> Core.Name
+            -> Core.Prop
+            -> IO Bool
+propIsValid spec name expr =
+    maybe False isValid . lookup name <$> prove Z3 spec'
+  where
+    spec' = spec { Core.specProperties = prop' : Core.specProperties spec }
+    prop' = Core.Property name expr
+
+    isValid :: SatResult -> Bool
+    isValid Valid = True
+    isValid _     = False

--- a/ogma-core/src/Copilot/Language/Reify/Extra.hs
+++ b/ogma-core/src/Copilot/Language/Reify/Extra.hs
@@ -1,0 +1,43 @@
+-- Copyright 2024 United States Government as represented by the Administrator
+-- of the National Aeronautics and Space Administration. All Rights Reserved.
+--
+-- Disclaimers
+--
+-- Licensed under the Apache License, Version 2.0 (the "License"); you may
+-- not use this file except in compliance with the License. You may obtain a
+-- copy of the License at
+--
+--      https://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+-- WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+-- License for the specific language governing permissions and limitations
+-- under the License.
+
+-- | Typechecking of Copilot specs.
+module Copilot.Language.Reify.Extra
+    ( reifySpec )
+  where
+
+-- External imports
+import qualified Copilot.Core                 as Core
+import qualified Copilot.Language             as Copilot
+import qualified Copilot.Language.Reify       as Copilot
+import qualified Language.Haskell.Interpreter as HI
+
+-- | Read a specification from a 'String' and reify it.
+--
+-- This function receives a list of possibly qualified imports.
+reifySpec :: [(String, Maybe String)] -> String -> IO Core.Spec
+reifySpec imports specText = do
+  coreSpecE <- HI.runInterpreter $ do
+                 HI.setImportsQ imports
+                 copilotSpec <- HI.interpret specText (HI.as :: Copilot.Spec)
+                 HI.liftIO $ Copilot.reify copilotSpec
+
+  case coreSpecE of
+    Left err -> do putStrLn $ "Error: " ++ show err
+                   error $ show err
+
+    Right coreSpec -> return coreSpec

--- a/ogma-core/src/Language/Trans/SpecAnalysis.hs
+++ b/ogma-core/src/Language/Trans/SpecAnalysis.hs
@@ -19,17 +19,13 @@
 module Language.Trans.SpecAnalysis
     ( AnalysisResult(..)
     , specAnalyze
-    , reifySpec
     )
   where
 
 -- External imports
-import qualified Copilot.Core                 as Core
-import qualified Copilot.Language             as Copilot
-import qualified Copilot.Language.Reify       as Copilot
-import           Data.List                    (intercalate, lookup)
-import           Data.Maybe                   (fromMaybe)
-import qualified Language.Haskell.Interpreter as HI
+import qualified Copilot.Core as Core
+import           Data.List    (intercalate, lookup)
+import           Data.Maybe   (fromMaybe)
 
 -- External imports: auxiliary
 import Data.String.Extra (sanitizeLCIdentifier, sanitizeUCIdentifier)
@@ -39,7 +35,8 @@ import Data.OgmaSpec (ExternalVariableDef (..), InternalVariableDef (..),
                       Requirement (..), Spec (..))
 
 -- Internal imports
-import Copilot.Core.Analysis (exprIsConstant)
+import Copilot.Core.Analysis        (exprIsConstant)
+import Copilot.Language.Reify.Extra (reifySpec)
 
 -- * Analysis of Specs
 
@@ -250,24 +247,6 @@ defaultSpecImports =
   , ("Copilot.Library.PTLTL", Just "PTLTL")
   , ("Prelude",               Just "P")
   ]
-
--- ** Typechecking of Copilot specs
-
--- | Read a specification from a 'String' and reify it.
---
--- This function receives a list of possibly qualified imports.
-reifySpec :: [(String, Maybe String)] -> String -> IO Core.Spec
-reifySpec imports specText = do
-  coreSpecE <- HI.runInterpreter $ do
-                 HI.setImportsQ imports
-                 copilotSpec <- HI.interpret specText (HI.as :: Copilot.Spec)
-                 HI.liftIO $ Copilot.reify copilotSpec
-
-  case coreSpecE of
-    Left err -> do putStrLn $ "Error: " ++ show err
-                   error $ show err
-
-    Right coreSpec -> return coreSpec
 
 -- ** Auxiliary list functions
 

--- a/ogma-core/src/Language/Trans/SpecAnalysis.hs
+++ b/ogma-core/src/Language/Trans/SpecAnalysis.hs
@@ -20,7 +20,6 @@ module Language.Trans.SpecAnalysis
     ( AnalysisResult(..)
     , specAnalyze
     , reifySpec
-    , exprIsConstant
     )
   where
 
@@ -28,8 +27,6 @@ module Language.Trans.SpecAnalysis
 import qualified Copilot.Core                 as Core
 import qualified Copilot.Language             as Copilot
 import qualified Copilot.Language.Reify       as Copilot
-import           Copilot.Theorem.What4        (SatResult (..), Solver (Z3),
-                                               prove)
 import           Data.List                    (intercalate, lookup)
 import           Data.Maybe                   (fromMaybe)
 import qualified Language.Haskell.Interpreter as HI
@@ -40,6 +37,9 @@ import Data.String.Extra (sanitizeLCIdentifier, sanitizeUCIdentifier)
 -- External imports: ogma-spec
 import Data.OgmaSpec (ExternalVariableDef (..), InternalVariableDef (..),
                       Requirement (..), Spec (..))
+
+-- Internal imports
+import Copilot.Core.Analysis (exprIsConstant)
 
 -- * Analysis of Specs
 
@@ -268,41 +268,6 @@ reifySpec imports specText = do
                    error $ show err
 
     Right coreSpec -> return coreSpec
-
--- ** Analysis of Copilot specs
-
--- | Determine if a boolean expression is always 'True' or always 'False'.
---
--- The first boolean in the result is 'True' if the expression can be proven
--- always 'True'. The second boolean in the expression is 'True' is the
--- expression can be proven always 'False'.
---
--- They values in the tuple cannot both 'True' at the same time.
-exprIsConstant :: Core.Spec
-               -> Core.Name
-               -> Core.Expr Bool
-               -> IO (Bool, Bool)
-exprIsConstant spec name expr = do
-  r1 <- propIsValid spec name (Core.Forall expr)
-  r2 <- propIsValid spec name (Core.Forall (Core.Op1 Core.Not expr))
-  pure (r1, r2)
-
--- | 'True' if the Copilot 'Prop' with the given name and expression is
--- constantly 'True', or valid, and 'False' otherwise (not always 'True' or
--- unknown).
-propIsValid :: Core.Spec
-            -> Core.Name
-            -> Core.Prop
-            -> IO Bool
-propIsValid spec name expr =
-    maybe False isValid . lookup name <$> prove Z3 spec'
-  where
-    spec' = spec { Core.specProperties = prop' : Core.specProperties spec }
-    prop' = Core.Property name expr
-
-    isValid :: SatResult -> Bool
-    isValid Valid = True
-    isValid _     = False
 
 -- ** Auxiliary list functions
 


### PR DESCRIPTION
Move functions related to reading, reification and formal analysis of Copilot specs from `ogma-core:Language.Trans.SpecAnalysis` to a new, internal, dedicated module, adjusting imports and uses as appropriate, as prescribed in the solution proposed for #397.