### PR TITLE
`ogma-core`: Rename module to more accurately reflect intent. Refs #399.

### DIFF
--- a/ogma-core/CHANGELOG.md
+++ b/ogma-core/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Revision history for ogma-core
 
-## [1.X.Y] - 2026-04-17
+## [1.X.Y] - 2026-04-18
 
 * Bump upper version constraints on Copilot packages (#377).
 * Lower upper version bound on `megaparsec` (#380).
@@ -12,6 +12,7 @@
 * Move function related to JSON objects to dedicated module (#393).
 * Move definitions related to `ExprPair` type to dedicated module (#395).
 * Move functions related to Copilot specs to dedicated modules (#397).
+* Rename module to more accurately reflect intent (#399).
 
 ## [1.13.0] - 2026-03-21
 

--- a/ogma-core/ogma-core.cabal
+++ b/ogma-core/ogma-core.cabal
@@ -129,7 +129,7 @@ library
     Data.Aeson.Extra
     Data.Either.Extra
     Data.ExprPair
-    Language.Trans.SpecAnalysis
+    Data.Spec.Analysis
 
   autogen-modules:
     Paths_ogma_core

--- a/ogma-core/src/Command/Overview.hs
+++ b/ogma-core/src/Command/Overview.hs
@@ -48,8 +48,8 @@ import           Command.Result              (Result (..))
 import           Data.ExprPair               (ExprPair(..), ExprPairT(..),
                                               exprPair)
 import           Data.Location               (Location (..))
+import qualified Data.Spec.Analysis          as SpecAnalysis
 import qualified Language.Trans.Spec2Copilot as Spec2Copilot
-import qualified Language.Trans.SpecAnalysis as SpecAnalysis
 
 -- | Generate overview of a spec given in an input file.
 --

--- a/ogma-core/src/Data/Spec/Analysis.hs
+++ b/ogma-core/src/Data/Spec/Analysis.hs
@@ -16,7 +16,7 @@
 -- under the License.
 
 -- | Formally analyze specifications and provide information about them.
-module Language.Trans.SpecAnalysis
+module Data.Spec.Analysis
     ( AnalysisResult(..)
     , specAnalyze
     )


### PR DESCRIPTION
Rename module `Language.Trans.SpecAnalysis` to `Data.Spec.Analysis` to better communicate intent, adjusting the Cabal file and imports as needed, as prescribed in the solution proposed for #399.