### PR TITLE
`ogma-core`: Move auxiliary function into new auxiliary module. Refs #401.

### DIFF
--- a/ogma-core/CHANGELOG.md
+++ b/ogma-core/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Move definitions related to `ExprPair` type to dedicated module (#395).
 * Move functions related to Copilot specs to dedicated modules (#397).
 * Rename module to more accurately reflect intent (#399).
+* Move auxiliary function into new auxiliary module (#401).
 
 ## [1.13.0] - 2026-03-21
 

--- a/ogma-core/ogma-core.cabal
+++ b/ogma-core/ogma-core.cabal
@@ -130,6 +130,7 @@ library
     Data.Either.Extra
     Data.ExprPair
     Data.Spec.Analysis
+    Data.Spec.Extra
 
   autogen-modules:
     Paths_ogma_core

--- a/ogma-core/src/Command/Overview.hs
+++ b/ogma-core/src/Command/Overview.hs
@@ -31,12 +31,10 @@ module Command.Overview
 -- External imports
 import Control.Monad.Except (runExceptT)
 import Data.Aeson           (ToJSON (..))
-import Data.List            (nub, (\\))
 import GHC.Generics         (Generic)
 
 -- External imports: Ogma
-import Data.OgmaSpec (ExternalVariableDef (..), InternalVariableDef (..),
-                      Requirement (..), Spec (..))
+import Data.OgmaSpec (Spec (..))
 
 -- Internal imports
 import           Command.Common
@@ -49,6 +47,7 @@ import           Data.ExprPair               (ExprPair(..), ExprPairT(..),
                                               exprPair)
 import           Data.Location               (Location (..))
 import qualified Data.Spec.Analysis          as SpecAnalysis
+import           Data.Spec.Extra             (addMissingIdentifiers)
 import qualified Language.Trans.Spec2Copilot as Spec2Copilot
 
 -- | Generate overview of a spec given in an input file.
@@ -177,21 +176,3 @@ commandResult :: CommandOptions
 commandResult _options fp result = case result of
   Left msg -> (Nothing, Error ecOverviewError msg (LocationFile fp))
   Right t  -> (Just t,  Success)
-
--- | Add to a spec external variables for all identifiers mentioned in
--- expressions that are not defined anywhere.
-addMissingIdentifiers :: (a -> [String]) -> Spec a -> Spec a
-addMissingIdentifiers f s = s { externalVariables = vars' }
-  where
-    vars'   = externalVariables s ++ newVars
-    newVars = map (\n -> ExternalVariableDef n "") newVarNames
-
-    -- Names that are not defined anywhere
-    newVarNames = identifiers \\ existingNames
-
-    -- Identifiers being mentioned in the requirements.
-    identifiers = nub $ concatMap (f . requirementExpr) (requirements s)
-
-    -- Names that are defined in variables.
-    existingNames = map externalVariableName (externalVariables s)
-                 ++ map internalVariableName (internalVariables s)

--- a/ogma-core/src/Command/Standalone.hs
+++ b/ogma-core/src/Command/Standalone.hs
@@ -35,14 +35,11 @@ import Control.Applicative  ((<|>))
 import Control.Exception    as E
 import Control.Monad.Except (ExceptT (..), liftEither)
 import Data.Aeson           (ToJSON (..))
-import Data.List            (nub, (\\))
 import Data.Maybe           (fromMaybe)
 import GHC.Generics         (Generic)
 
 -- External imports: Ogma
-import Data.OgmaSpec          (ExternalVariableDef (..),
-                               InternalVariableDef (..), Requirement (..),
-                               Spec (..))
+import Data.OgmaSpec          (Spec)
 import System.Directory.Extra (copyTemplate)
 
 -- Internal imports
@@ -53,6 +50,7 @@ import Data.Aeson.Extra            (mergeObjects)
 import Data.Either.Extra           (mapLeft)
 import Data.ExprPair               (ExprPair(..), ExprPairT(..), exprPair)
 import Data.Location               (Location (..))
+import Data.Spec.Extra             (addMissingIdentifiers)
 import Language.Trans.Spec2Copilot (spec2Copilot, specAnalyze)
 
 -- | Generate a new standalone Copilot monitor that implements the spec in an
@@ -242,21 +240,3 @@ ecMissingSpec = 1
 -- | Error: the input specification cannot be formalized.
 ecIncorrectSpec :: ErrorCode
 ecIncorrectSpec = 1
-
--- | Add to a spec external variables for all identifiers mentioned in
--- expressions that are not defined anywhere.
-addMissingIdentifiers :: (a -> [String]) -> Spec a -> Spec a
-addMissingIdentifiers f s = s { externalVariables = vars' }
-  where
-    vars'   = externalVariables s ++ newVars
-    newVars = map (\n -> ExternalVariableDef n "") newVarNames
-
-    -- Names that are not defined anywhere
-    newVarNames = identifiers \\ existingNames
-
-    -- Identifiers being mentioned in the requirements.
-    identifiers = nub $ concatMap (f . requirementExpr) (requirements s)
-
-    -- Names that are defined in variables.
-    existingNames = map externalVariableName (externalVariables s)
-                 ++ map internalVariableName (internalVariables s)

--- a/ogma-core/src/Data/Spec/Extra.hs
+++ b/ogma-core/src/Data/Spec/Extra.hs
@@ -1,0 +1,46 @@
+-- Copyright 2022 United States Government as represented by the Administrator
+-- of the National Aeronautics and Space Administration. All Rights Reserved.
+--
+-- Disclaimers
+--
+-- Licensed under the Apache License, Version 2.0 (the "License"); you may
+-- not use this file except in compliance with the License. You may obtain a
+-- copy of the License at
+--
+--      https://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+-- WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+-- License for the specific language governing permissions and limitations
+-- under the License.
+--
+-- | Auxiliary functions for working with values of type 'Spec'.
+module Data.Spec.Extra
+    ( addMissingIdentifiers )
+  where
+
+-- External imports
+import Data.List (nub, (\\))
+
+-- External imports: ogma
+import Data.OgmaSpec (ExternalVariableDef (..), InternalVariableDef (..),
+                      Requirement (..), Spec (..))
+
+-- | Add to a spec external variables for all identifiers mentioned in
+-- expressions that are not defined anywhere.
+addMissingIdentifiers :: (a -> [String]) -> Spec a -> Spec a
+addMissingIdentifiers f s = s { externalVariables = vars' }
+  where
+    vars'   = externalVariables s ++ newVars
+    newVars = map (\n -> ExternalVariableDef n "") newVarNames
+
+    -- Names that are not defined anywhere
+    newVarNames = identifiers \\ existingNames
+
+    -- Identifiers being mentioned in the requirements.
+    identifiers = nub $ concatMap (f . requirementExpr) (requirements s)
+
+    -- Names that are defined in variables.
+    existingNames = map externalVariableName (externalVariables s)
+                 ++ map internalVariableName (internalVariables s)


### PR DESCRIPTION
Move the duplicate function `addMissingIdentifiers` into a new internal auxiliary module, removing other instantiations of the same function and adjusting imports to make use of this new module, as prescribed in the solution proposed for #401.