### PR TITLE
`ogma-core`: Simplify internal definition `showTransitions`. Refs #405.

### DIFF
--- a/ogma-core/CHANGELOG.md
+++ b/ogma-core/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Revision history for ogma-core
 
-## [1.X.Y] - 2026-04-19
+## [1.X.Y] - 2026-04-24
 
 * Bump upper version constraints on Copilot packages (#377).
 * Lower upper version bound on `megaparsec` (#380).
@@ -15,6 +15,7 @@
 * Rename module to more accurately reflect intent (#399).
 * Move auxiliary function into new auxiliary module (#401).
 * Split `Command.CommonDiagram` into smaller, more cohesive modules (#403).
+* Simplify internal definition `showTransitions` (#405).
 
 ## [1.13.0] - 2026-03-21
 

--- a/ogma-core/src/Command/Diagram.hs
+++ b/ogma-core/src/Command/Diagram.hs
@@ -284,13 +284,8 @@ diagramToCopilot diag mode = (machine, arguments)
     states      = nub $ sort $ concat [ [x, y] | (x, _, y) <- transitions ]
 
     showTransitions :: String
-    showTransitions = "[" ++ showTransitions' transitions
-
-    showTransitions' :: [(Int, String, Int)] -> String
-    showTransitions' []         = "]"
-    showTransitions' (x1:x2:xs) =
-      showTransition x1 ++ ", " ++ showTransitions' (x2:xs)
-    showTransitions' (x2:[])    = showTransition x2 ++ "]"
+    showTransitions =
+      "[" ++ intercalate ", " (map showTransition transitions) ++ "]"
 
     showTransition :: (Int, String, Int) -> String
     showTransition (a, b, c) =


### PR DESCRIPTION
Simplify the internal definition `Command.Diagram.diagramToCopilot.showTransitions` by copying the version defined in `Data.Diagram.Analysis.showDiagram`, as prescribed in the solution proposed for #405.