### PR TITLE
`ogma-core`:  Add diagram query functions to `Data.Diagram`. Refs #407.

### DIFF
--- a/ogma-core/CHANGELOG.md
+++ b/ogma-core/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Revision history for ogma-core
 
-## [1.X.Y] - 2026-04-24
+## [1.X.Y] - 2026-04-25
 
 * Bump upper version constraints on Copilot packages (#377).
 * Lower upper version bound on `megaparsec` (#380).
@@ -16,6 +16,7 @@
 * Move auxiliary function into new auxiliary module (#401).
 * Split `Command.CommonDiagram` into smaller, more cohesive modules (#403).
 * Simplify internal definition `showTransitions` (#405).
+* Add diagram query functions to `Data.Diagram` (#407).
 
 ## [1.13.0] - 2026-03-21
 

--- a/ogma-core/src/Command/Diagram.hs
+++ b/ogma-core/src/Command/Diagram.hs
@@ -49,7 +49,8 @@ import qualified Language.SMV.ParSMV       as SMV (myLexer, pBoolSpec)
 
 -- Internal imports: auxiliary
 import Command.Result      (Result (..))
-import Data.Diagram        (Diagram (..))
+import Data.Diagram        (Diagram (..), diagramBadState, diagramFinalState,
+                            diagramInitialState)
 import Data.Diagram.Parser (DiagramFormat (..), readDiagram)
 import Data.ExprPair       (ExprPair (..), ExprPairT (..))
 import Data.Location       (Location (..))
@@ -264,9 +265,9 @@ diagramToCopilot diag mode = (machine, arguments)
                      CheckState   -> "stateMachine1 /= externalState"
                      ComputeState -> "true"
                      CheckMoves   -> "true"
-    initialState = minimum states
-    finalState   = maximum states
-    badState     = maximum states + 1
+    initialState = diagramInitialState diag
+    finalState   = diagramFinalState diag
+    badState     = diagramBadState diag
 
     -- Arguments for the handler.
     arguments = "[ " ++ intercalate ", " (map ("arg " ++) argExprs) ++ " ]"

--- a/ogma-core/src/Data/Diagram.hs
+++ b/ogma-core/src/Data/Diagram.hs
@@ -20,6 +20,9 @@ module Data.Diagram
     ( Diagram(..)
     , diagramStates
     , diagramNumStates
+    , diagramInitialState
+    , diagramFinalState
+    , diagramBadState
     )
   where
 
@@ -40,3 +43,17 @@ diagramStates diagram = nub $ sort $ concat
 -- | Number of states in a diagram.
 diagramNumStates :: Diagram -> Int
 diagramNumStates = length . diagramStates
+
+-- | Initial state of a diagram.
+diagramInitialState :: Diagram -> Int
+diagramInitialState = minimum . diagramStates
+
+-- | Final state of a diagram.
+--
+-- PRE: The diagram obtains one and only one final state.
+diagramFinalState :: Diagram -> Int
+diagramFinalState = maximum . diagramStates
+
+-- | Return a state value that does not represent any state in the diagram.
+diagramBadState :: Diagram -> Int
+diagramBadState diag = maximum (diagramStates diag) + 1

--- a/ogma-core/src/Data/Diagram/Analysis.hs
+++ b/ogma-core/src/Data/Diagram/Analysis.hs
@@ -29,8 +29,9 @@ import           Data.List    (intercalate)
 -- Internal imports: auxiliary
 import Copilot.Core.Analysis        (exprIsConstant)
 import Copilot.Language.Reify.Extra (reifySpec)
-import Data.Diagram                 (Diagram (..), diagramNumStates,
-                                     diagramStates)
+import Data.Diagram                 (Diagram (..), diagramBadState,
+                                     diagramFinalState, diagramInitialState,
+                                     diagramNumStates)
 
 -- * Analysis of Specs
 
@@ -167,12 +168,11 @@ showDiagram diagram = unlines
   where
 
     -- Elements of the spec.
-    initialState = minimum states
-    finalState   = maximum states
-    badState     = maximum states + 1
+    initialState = diagramInitialState diagram
+    finalState   = diagramFinalState diagram
+    badState     = diagramBadState diagram
 
-    -- States and transitions from the diagram.
-    states      = diagramStates diagram
+    -- Transitions from the diagram.
     transitions = diagramTransitions diagram
 
     showTransitions :: String


### PR DESCRIPTION
Introduce new functions to obtain information on initial, final and invalid states in diagrams, and use the functions in other modules, as prescribed in the solution proposed for #407.