### PR TITLE
`ogma-core`: Factorize translation of diagrams to Copilot into separate module. Refs #409.

### DIFF
--- a/ogma-core/CHANGELOG.md
+++ b/ogma-core/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Revision history for ogma-core
 
-## [1.X.Y] - 2026-04-25
+## [1.X.Y] - 2026-04-26
 
 * Bump upper version constraints on Copilot packages (#377).
 * Lower upper version bound on `megaparsec` (#380).
@@ -17,6 +17,7 @@
 * Split `Command.CommonDiagram` into smaller, more cohesive modules (#403).
 * Simplify internal definition `showTransitions` (#405).
 * Add diagram query functions to `Data.Diagram` (#407).
+* Factorize translation of diagrams to Copilot into separate module (#409).
 
 ## [1.13.0] - 2026-03-21
 

--- a/ogma-core/ogma-core.cabal
+++ b/ogma-core/ogma-core.cabal
@@ -114,6 +114,7 @@ library
     Language.Trans.CStruct2CopilotStruct
     Language.Trans.CStructs2Copilot
     Language.Trans.CStructs2MsgHandlers
+    Language.Trans.Diagram2Copilot
     Language.Trans.Lustre2Copilot
     Language.Trans.Spec2Copilot
     Language.Trans.SMV2Copilot

--- a/ogma-core/src/Command/Diagram.hs
+++ b/ogma-core/src/Command/Diagram.hs
@@ -49,19 +49,19 @@ import qualified Language.SMV.ParSMV       as SMV (myLexer, pBoolSpec)
 
 -- Internal imports: auxiliary
 import Command.Result      (Result (..))
-import Data.Diagram        (Diagram (..), diagramBadState, diagramFinalState,
-                            diagramInitialState)
+import Data.Diagram        (Diagram (..))
 import Data.Diagram.Parser (DiagramFormat (..), readDiagram)
 import Data.ExprPair       (ExprPair (..), ExprPairT (..))
 import Data.Location       (Location (..))
 import Paths_ogma_core     (getDataDir)
 
 -- Internal imports: language ASTs, transformers
-import           Language.SMV.Substitution     (substituteBoolExpr)
-import qualified Language.Trans.Lustre2Copilot as Lustre (boolSpec2Copilot,
-                                                          boolSpecNames)
-import           Language.Trans.SMV2Copilot    as SMV (boolSpec2Copilot,
-                                                       boolSpecNames)
+import           Language.SMV.Substitution      (substituteBoolExpr)
+import qualified Language.Trans.Diagram2Copilot as Diagram2Copilot
+import qualified Language.Trans.Lustre2Copilot  as Lustre (boolSpec2Copilot,
+                                                           boolSpecNames)
+import           Language.Trans.SMV2Copilot     as SMV (boolSpec2Copilot,
+                                                        boolSpecNames)
 
 -- | Generate a new Copilot monitor that implements a state machine described
 -- in a diagram given as an input file.
@@ -236,45 +236,27 @@ diagramToCopilot :: Diagram -> DiagramMode -> (String, String)
 diagramToCopilot diag mode = (machine, arguments)
   where
     machine = unlines
-      [ "stateMachineProp :: Stream Bool"
+      [ "stateMachineS :: Stream Word8"
+      , "stateMachineS = stateMachineGF stateMachine1"
+      , ""
+      , "stateMachineProp :: Stream Bool"
       , "stateMachineProp = " ++ propExpr
       , ""
-      , "stateMachine1 :: Stream Word8"
-      , "stateMachine1 = stateMachineGF (initialState, finalState, noInput, "
-        ++ "transitions, badState)"
-      , ""
-      , "-- Check"
-      , "initialState :: Word8"
-      , "initialState = " ++ show initialState
-      , ""
-      , "-- Check"
-      , "finalState :: Word8"
-      , "finalState = " ++ show finalState
-      , ""
-      , "noInput :: Stream Bool"
-      , "noInput = false"
-      , ""
-      , "badState :: Word8"
-      , "badState = " ++ show badState
-      , ""
-      , "transitions = " ++ showTransitions
       ]
+      ++ Diagram2Copilot.diagram2Copilot diag
 
     -- Elements of the spec.
-    propExpr     = case mode of
-                     CheckState   -> "stateMachine1 /= externalState"
-                     ComputeState -> "true"
-                     CheckMoves   -> "true"
-    initialState = diagramInitialState diag
-    finalState   = diagramFinalState diag
-    badState     = diagramBadState diag
+    propExpr = case mode of
+                 CheckState   -> "stateMachineS /= externalState"
+                 ComputeState -> "true"
+                 CheckMoves   -> "true"
 
     -- Arguments for the handler.
     arguments = "[ " ++ intercalate ", " (map ("arg " ++) argExprs) ++ " ]"
 
     argExprs = case mode of
-      CheckState   -> [ "stateMachine1", "externalState", "input" ]
-      ComputeState -> [ "stateMachine1", "externalState", "input" ]
+      CheckState   -> [ "stateMachineS", "externalState", "input" ]
+      ComputeState -> [ "stateMachineS", "externalState", "input" ]
       CheckMoves   -> map stateCheckExpr states
 
     stateCheckExpr stateId =
@@ -283,11 +265,3 @@ diagramToCopilot diag mode = (machine, arguments)
     -- States and transitions from the diagram.
     transitions = diagramTransitions diag
     states      = nub $ sort $ concat [ [x, y] | (x, _, y) <- transitions ]
-
-    showTransitions :: String
-    showTransitions =
-      "[" ++ intercalate ", " (map showTransition transitions) ++ "]"
-
-    showTransition :: (Int, String, Int) -> String
-    showTransition (a, b, c) =
-      "(" ++ show a ++ ", " ++ b ++ ", " ++ show c ++ ")"

--- a/ogma-core/src/Data/Diagram/Analysis.hs
+++ b/ogma-core/src/Data/Diagram/Analysis.hs
@@ -24,14 +24,13 @@ module Data.Diagram.Analysis
 
 -- External imports
 import qualified Copilot.Core as Core
-import           Data.List    (intercalate)
 
 -- Internal imports: auxiliary
-import Copilot.Core.Analysis        (exprIsConstant)
-import Copilot.Language.Reify.Extra (reifySpec)
-import Data.Diagram                 (Diagram (..), diagramBadState,
-                                     diagramFinalState, diagramInitialState,
-                                     diagramNumStates)
+import Copilot.Core.Analysis          (exprIsConstant)
+import Copilot.Language.Reify.Extra   (reifySpec)
+import Data.Diagram                   (Diagram (..),
+                                       diagramNumStates)
+import Language.Trans.Diagram2Copilot (diagram2Copilot)
 
 -- * Analysis of Specs
 
@@ -76,109 +75,79 @@ defaultSpecImports =
 -- The shown 'Copilot.Spec' has a top-level triggers for the properties we are
 -- interested in, as well as several auxiliary definitions.
 showDiagram :: Diagram -> String
-showDiagram diagram = unlines
-    [ "do let"
-    , ""
-    , "       stateMachine :: (Eq a, Typed a)"
-    , "                    => (a, a, Stream Bool, [(a, Stream Bool, a)], a)"
-    , "                    -> Stream a"
-    , "       stateMachine (initial, final, noInputData, transitions, bad) ="
-    , "           state"
-    , "         where"
-    , "           state         = ifThenElses transitions"
-    , "           previousState = [initial] ++ state"
-    , ""
-    , "           -- ifThenElses :: [(a, Stream Bool, a)] -> Stream a"
-    , "           ifThenElses [] ="
-    , "             ifThenElse"
-    , "               (previousState == constant final && noInputData)"
-    , "               (constant final)"
-    , "               (constant bad)"
-    , ""
-    , "           ifThenElses ((s1, i, s2):ss) ="
-    , "             ifThenElse"
-    , "               (previousState == constant s1 && i)"
-    , "               (constant s2)"
-    , "               (ifThenElses ss)"
-    , ""
-    , "       isDeterministic :: (Ord a, Eq a, Typed a)"
-    , "                       => (a, a, Stream Bool, [(a, Stream Bool, a)], a)"
-    , "                       -> Stream Bool"
-    , "       isDeterministic (_, _, _, ts, _) = all $"
-    , "           map"
-    , "             (\\s -> all (map not $ pairwise $ transitionsFrom s))"
-    , "             states"
-    , "         where"
-    , "           states = L.nub $ L.sort $ concat $"
-    , "             map (\\(s1, _, s2) -> [s1, s2]) ts"
-    , ""
-    , "           transitionsFrom s = [ t | (s1, t, _) <- ts, s P.== s1 ]"
-    , ""
-    , "       completeMachine :: (Ord a, Eq a, Typed a)"
-    , "                       => (a, a, Stream Bool, [(a, Stream Bool, a)], a)"
-    , "                       -> Stream Bool"
-    , "       completeMachine (_, _, _, ts, _) = all $"
-    , "           map (\\s -> or $ transitionsFrom s) states"
-    , "         where"
-    , "           states = L.nub $ L.sort $ concat $"
-    , "             map (\\(s1, _, s2) -> [s1, s2]) ts"
-    , "           transitionsFrom s = [ t | (s1, t, _) <- ts, s P.== s1 ]"
-    , ""
-    , "       all [] = true"
-    , "       all (x:xs) = x && all xs"
-    , ""
-    , "       or [] = false"
-    , "       or (x:xs) = x || or xs"
-    , ""
-    , "       pairwise :: [ Stream Bool ] -> [ Stream Bool ]"
-    , "       pairwise []      = []"
-    , "       pairwise (x:[])  = []"
-    , "       pairwise (x1:xs) ="
-    , "         (map (\\x2 -> (x1 && x2)) xs) P.++ pairwise xs"
-    , ""
-    , "       stateMachine1 :: ( Word8"
-    , "                        , Word8"
-    , "                        , Stream Bool"
-    , "                        , [(Word8, Stream Bool, Word8)]"
-    , "                        , Word8"
-    , "                        )"
-    , "       stateMachine1 ="
-    , "         (initialState, finalState, noInput, transitions, badState)"
-    , ""
-    , "       initialState :: Word8"
-    , "       initialState = " ++ show initialState
-    , ""
-    , "       finalState :: Word8"
-    , "       finalState = " ++ show finalState
-    , ""
-    , "       noInput :: Stream Bool"
-    , "       noInput = false"
-    , ""
-    , "       input :: Stream Word8"
-    , "       input = extern \"input\" Nothing"
-    , ""
-    , "       badState :: Word8"
-    , "       badState = " ++ show badState
-    , ""
-    , "       transitions = " ++ showTransitions
-    , ""
-    , "   trigger \"deterministic\" (isDeterministic stateMachine1) []"
-    ]
+showDiagram diagram = unlines $
+       [ "do let" ]
+    ++ map ("       " ++) (lines auxiliaryDefinitions)
+    ++ map ("       " ++) (lines input)
+    ++ map ("       " ++) (lines diagramDefinitions)
+    ++ [ "   trigger \"deterministic\" (isDeterministic stateMachine1) []" ]
 
   where
 
-    -- Elements of the spec.
-    initialState = diagramInitialState diagram
-    finalState   = diagramFinalState diagram
-    badState     = diagramBadState diagram
+    input = unlines
+      [ "input :: Stream Word8"
+      , "input = extern \"input\" Nothing"
+      ]
 
-    -- Transitions from the diagram.
-    transitions = diagramTransitions diagram
+    diagramDefinitions = diagram2Copilot diagram
 
-    showTransitions :: String
-    showTransitions =
-      "[" ++ intercalate ", " (map showTransition transitions) ++ "]"
-
-    showTransition :: (Int, String, Int) -> String
-    showTransition (a, b, c) =
-      "(" ++ show a ++ ", " ++ b ++ ", " ++ show c ++ ")"
+-- | Auxiliary definitions needed in the spec.
+auxiliaryDefinitions :: String
+auxiliaryDefinitions = unlines
+  [ "stateMachine :: (Eq a, Typed a)"
+  , "             => (a, a, Stream Bool, [(a, Stream Bool, a)], a)"
+  , "             -> Stream a"
+  , "stateMachine (initial, final, noInputData, transitions, bad) ="
+  , "    state"
+  , "  where"
+  , "    state         = ifThenElses transitions"
+  , "    previousState = [initial] ++ state"
+  , ""
+  , "    -- ifThenElses :: [(a, Stream Bool, a)] -> Stream a"
+  , "    ifThenElses [] ="
+  , "      ifThenElse"
+  , "        (previousState == constant final && noInputData)"
+  , "        (constant final)"
+  , "        (constant bad)"
+  , ""
+  , "    ifThenElses ((s1, i, s2):ss) ="
+  , "      ifThenElse"
+  , "        (previousState == constant s1 && i)"
+  , "        (constant s2)"
+  , "        (ifThenElses ss)"
+  , ""
+  , "isDeterministic :: (Ord a, Eq a, Typed a)"
+  , "                => (a, a, Stream Bool, [(a, Stream Bool, a)], a)"
+  , "                -> Stream Bool"
+  , "isDeterministic (_, _, _, ts, _) = all $"
+  , "    map"
+  , "      (\\s -> all (map not $ pairwise $ transitionsFrom s))"
+  , "      states"
+  , "  where"
+  , "    states = L.nub $ L.sort $ concat $"
+  , "      map (\\(s1, _, s2) -> [s1, s2]) ts"
+  , ""
+  , "    transitionsFrom s = [ t | (s1, t, _) <- ts, s P.== s1 ]"
+  , ""
+  , "completeMachine :: (Ord a, Eq a, Typed a)"
+  , "                => (a, a, Stream Bool, [(a, Stream Bool, a)], a)"
+  , "                -> Stream Bool"
+  , "completeMachine (_, _, _, ts, _) = all $"
+  , "    map (\\s -> or $ transitionsFrom s) states"
+  , "  where"
+  , "    states = L.nub $ L.sort $ concat $"
+  , "      map (\\(s1, _, s2) -> [s1, s2]) ts"
+  , "    transitionsFrom s = [ t | (s1, t, _) <- ts, s P.== s1 ]"
+  , ""
+  , "all [] = true"
+  , "all (x:xs) = x && all xs"
+  , ""
+  , "or [] = false"
+  , "or (x:xs) = x || or xs"
+  , ""
+  , "pairwise :: [ Stream Bool ] -> [ Stream Bool ]"
+  , "pairwise []      = []"
+  , "pairwise (x:[])  = []"
+  , "pairwise (x1:xs) ="
+  , "  (map (\\x2 -> (x1 && x2)) xs) P.++ pairwise xs"
+  ]

--- a/ogma-core/src/Language/Trans/Diagram2Copilot.hs
+++ b/ogma-core/src/Language/Trans/Diagram2Copilot.hs
@@ -1,0 +1,74 @@
+-- Copyright 2024 United States Government as represented by the Administrator
+-- of the National Aeronautics and Space Administration. All Rights Reserved.
+--
+-- Disclaimers
+--
+-- Licensed under the Apache License, Version 2.0 (the "License"); you may
+-- not use this file except in compliance with the License. You may obtain a
+-- copy of the License at
+--
+--      https://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+-- WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+-- License for the specific language governing permissions and limitations
+-- under the License.
+--
+-- | Transform a state diagram into a Copilot specification.
+module Language.Trans.Diagram2Copilot
+    ( diagram2Copilot
+    )
+  where
+
+-- External imports
+import Data.List (intercalate)
+
+-- Internal imports: auxiliary
+import Data.Diagram (Diagram (..), diagramBadState, diagramFinalState,
+                     diagramInitialState)
+
+-- | Convert the diagram into a set of Copilot definitions.
+diagram2Copilot :: Diagram -> String
+diagram2Copilot diag = unlines
+    [ "stateMachine1 :: ( Word8"
+    , "                 , Word8"
+    , "                 , Stream Bool"
+    , "                 , [(Word8, Stream Bool, Word8)]"
+    , "                 , Word8"
+    , "                 )"
+    , "stateMachine1 ="
+    , "  (initialState, finalState, noInput, transitions, badState)"
+    , ""
+    , "-- Check"
+    , "initialState :: Word8"
+    , "initialState = " ++ show initialState
+    , ""
+    , "-- Check"
+    , "finalState :: Word8"
+    , "finalState = " ++ show finalState
+    , ""
+    , "noInput :: Stream Bool"
+    , "noInput = false"
+    , ""
+    , "badState :: Word8"
+    , "badState = " ++ show badState
+    , ""
+    , "transitions = " ++ showTransitions
+    ]
+
+  where
+
+    initialState = diagramInitialState diag
+    finalState   = diagramFinalState diag
+    badState     = diagramBadState diag
+
+    transitions = diagramTransitions diag
+
+    showTransitions :: String
+    showTransitions =
+      "[" ++ intercalate ", " (map showTransition transitions) ++ "]"
+
+    showTransition :: (Int, String, Int) -> String
+    showTransition (a, b, c) =
+      "(" ++ show a ++ ", " ++ b ++ ", " ++ show c ++ ")"


### PR DESCRIPTION
Move translation of digrams to Copilot into its own module and adjust `Command.Diagram` and `Data.Diagram.Analysis` to leverage the shared capability, as prescribed in the solution proposed for #409.