### PR TITLE
`ogma-core`: Fix order of arguments in calls to internal function. Refs #419.

### DIFF
--- a/ogma-core/CHANGELOG.md
+++ b/ogma-core/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Revision history for ogma-core
 
-## [1.X.Y] - 2026-05-10
+## [1.X.Y] - 2026-05-11
 
 * Bump upper version constraints on Copilot packages (#377).
 * Lower upper version bound on `megaparsec` (#380).
@@ -22,6 +22,7 @@
 * Move functions related to reading specs to dedicated module (#413).
 * Make standalone, app backends support working directly with diagrams (#415).
 * Add support for reading specs from YAML files (#417).
+* Fix order of arguments in calls to internal function (#419).
 
 ## [1.13.0] - 2026-03-21
 

--- a/ogma-core/src/Command/CFSApp.hs
+++ b/ogma-core/src/Command/CFSApp.hs
@@ -103,7 +103,7 @@ command' options (ExprPair exprT) = do
 
     liftEither $ checkArguments spec vs rs
 
-    copilotM <- sequenceA $ (\spec' -> processSpec spec' fp cExpr) <$> spec
+    copilotM <- sequenceA $ (\spec' -> processSpec spec' cExpr fp) <$> spec
 
     let varNames = fromMaybe (defaultVarNames spec) vs
         monitors = maybe (defaultMonitors spec) (map (\x -> (x, Nothing))) rs

--- a/ogma-core/src/Command/FPrimeApp.hs
+++ b/ogma-core/src/Command/FPrimeApp.hs
@@ -97,7 +97,7 @@ command' options (ExprPair exprT) = do
 
     liftEither $ checkArguments spec vs rs
 
-    copilotM <- sequenceA $ (\spec' -> processSpec spec' fp cExpr) <$> spec
+    copilotM <- sequenceA $ (\spec' -> processSpec spec' cExpr fp) <$> spec
 
     let varNames = fromMaybe (defaultVarNames spec) vs
         monitors = maybe (defaultMonitors spec) (map (\x -> (x, Nothing))) rs

--- a/ogma-core/src/Command/ROSApp.hs
+++ b/ogma-core/src/Command/ROSApp.hs
@@ -102,7 +102,7 @@ command' options (ExprPair exprT) = do
 
     liftEither $ checkArguments spec vs rs
 
-    copilotM <- sequenceA $ (\spec' -> processSpec spec' fp cExpr) <$> spec
+    copilotM <- sequenceA $ (\spec' -> processSpec spec' cExpr fp) <$> spec
 
     let varNames = fromMaybe (defaultVarNames spec) vs
         monitors = maybe (defaultMonitors spec) (map (\x -> (x, Nothing))) rs


### PR DESCRIPTION
Adjust the order in which arguments are provided in the call to `processSpec` in the cFS, ROS and F Prime backends, as prescribed in the solution proposed for #419.