### PR TITLE
`ogma-cli`: Fix typo in README. Refs #428.

### DIFF
--- a/ogma-cli/CHANGELOG.md
+++ b/ogma-cli/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Revision history for ogma-cli
 
+## [1.X.Y] - 2026-05-28
+
+* Fix typo in README (#428).
+
 ## [1.14.0] - 2026-05-21
 
 * Version bump (1.14.0) (#425).

--- a/ogma-cli/README.md
+++ b/ogma-cli/README.md
@@ -823,7 +823,7 @@ that the state machine is in.
 
 - `safeguard`: Check whether transitioning to a given state would be safe. Under
   this mode, the monitor always fires, and it provides as arguments booleans
-indicating whether transitioning to each state would be allowed or note.  For
+indicating whether transitioning to each state would be allowed or not.  For
 example, for the diagram above, the arguments passed to the external handler
 would be three booleans, indicating, respectively, if transitioning to state 0
 would be legal, if transitioning to state 1 would be legal, and if


### PR DESCRIPTION
Fix the incorrect spelling of "not" in the README, as prescribed in the solution proposed for #428.