### PR TITLE
`ogma-core`: Remove commented code from `Data.Spec.Parser`. Refs #430.

### DIFF
--- a/ogma-core/CHANGELOG.md
+++ b/ogma-core/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Revision history for ogma-core
 
+## [1.X.Y] - 2026-05-30
+
+* Remove commented code from `Data.Spec.Parser` (#430).
+
 ## [1.14.0] - 2026-05-21
 
 * Version bump (1.14.0) (#425).

--- a/ogma-core/src/Data/Spec/Parser.hs
+++ b/ogma-core/src/Data/Spec/Parser.hs
@@ -125,7 +125,6 @@ readInputFile fp formatName propFormatName propVia exprT =
                    content <- readFile fp
                    parseXMLSpec
                      (wrapper) (def) xmlFormat content
-                     -- (fmap (fmap print) . wrapper) (print def) xmlFormat content
              | isPrefixOf "CSVFormat" format
              -> do let csvFormat = read format
                    content <- readFile fp


### PR DESCRIPTION
Remove line that contains commented code from `Data.Spec.Parser.readInputFile`, as prescribed in the solution proposed for #430.