### PR TITLE
`ogma-core`: Remove redundant `where` block. Refs #432.

### DIFF
--- a/ogma-core/CHANGELOG.md
+++ b/ogma-core/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Revision history for ogma-core
 
-## [1.X.Y] - 2026-05-30
+## [1.X.Y] - 2026-05-31
 
 * Remove commented code from `Data.Spec.Parser` (#430).
+* Remove redundant `where` block (#432).
 
 ## [1.14.0] - 2026-05-21
 

--- a/ogma-core/src/Command/CFSApp.hs
+++ b/ogma-core/src/Command/CFSApp.hs
@@ -208,27 +208,25 @@ variableMap :: VariableDB
             -> String
             -> Maybe (VarDecl, MsgInfoId, MsgInfo, MsgData)
 variableMap varDB varName = do
-    inputDef  <- findInput varDB varName
-    mid       <- connectionTopic <$> findConnection inputDef "cfs"
-    topicDef  <- findTopic varDB "cfs" mid
+  inputDef  <- findInput varDB varName
+  mid       <- connectionTopic <$> findConnection inputDef "cfs"
+  topicDef  <- findTopic varDB "cfs" mid
 
-    let typeDef = findType varDB varName "cfs" "C"
+  let typeDef = findType varDB varName "cfs" "C"
 
-    let typeMsgFromType  = typeFromType <$> typeDef
-        typeMsgFromField = typeFromField =<< typeDef
+  let typeMsgFromType  = typeFromType <$> typeDef
+      typeMsgFromField = typeFromField =<< typeDef
 
-    let typeVar' = fromMaybe (topicType topicDef) (typeToType <$> typeDef)
+  let typeVar' = fromMaybe (topicType topicDef) (typeToType <$> typeDef)
 
-    -- Pick name for the function to process a message ID.
-    let mn = pascalCase $ stripSuffix "_MID" mid
+  -- Pick name for the function to process a message ID.
+  let mn = pascalCase $ stripSuffix "_MID" mid
 
-    return ( VarDecl varName typeVar'
-           , mid
-           , MsgInfo mid mn
-           , MsgData mn typeMsgFromType typeMsgFromField varName typeVar'
-           )
-
-  where
+  return ( VarDecl varName typeVar'
+         , mid
+         , MsgInfo mid mn
+         , MsgData mn typeMsgFromType typeMsgFromField varName typeVar'
+         )
 
 -- | Return the monitor information needed to generate declarations and
 -- publishers for the given monitor info, and variable database.


### PR DESCRIPTION
Remove the redundant `where` keyword and indent the surrounding code, as prescribed in the solution proposed for #432.
