### PR TITLE
`ogma-core`: Fix incorrect Haddock comment syntax. Refs #434.

### DIFF
--- a/ogma-core/CHANGELOG.md
+++ b/ogma-core/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Remove commented code from `Data.Spec.Parser` (#430).
 * Remove redundant `where` block (#432).
+* Fix incorrect Haddock comment syntax (#434).
 
 ## [1.14.0] - 2026-05-21
 

--- a/ogma-core/src/Command/Standalone.hs
+++ b/ogma-core/src/Command/Standalone.hs
@@ -195,7 +195,7 @@ data CommandOptions = CommandOptions
                                          -- template.
   }
 
--- * Mapping of types from input format to Copilot
+-- | Mapping of types from input format to Copilot.
 typeToCopilotTypeMapping :: [(String, String)] -> [(String, String)]
 typeToCopilotTypeMapping types =
     [ ("bool",    "Bool")


### PR DESCRIPTION
Change a Haddock comment from a section heading to a function comment, as prescribed in the solution proposed for #434.