### PR TITLE
Provide detailed error messages when template expansion fails. Refs #390.

### DIFF
--- a/ogma-core/CHANGELOG.md
+++ b/ogma-core/CHANGELOG.md
@@ -1,10 +1,11 @@
 # Revision history for ogma-core
 
-## [1.X.Y] - 2026-05-31
+## [1.X.Y] - 2026-06-04
 
 * Remove commented code from `Data.Spec.Parser` (#430).
 * Remove redundant `where` block (#432).
 * Fix incorrect Haddock comment syntax (#434).
+* Provide detailed error messages when template expansion fails (#390).
 
 ## [1.14.0] - 2026-05-21
 

--- a/ogma-core/src/Command/CFSApp.hs
+++ b/ogma-core/src/Command/CFSApp.hs
@@ -60,6 +60,7 @@ import Command.VariableDB (Connection (..), TopicDef (..), TypeDef (..),
                            VariableDB, findConnection, findInput, findTopic,
                            findType, findTypeByType)
 import Data.Aeson.Extra   (mergeObjects)
+import Data.Either.Extra  (mapLeft)
 import Data.ExprPair      (ExprPair(..), exprPair)
 import Data.Location      (Location (..))
 import Data.Spec.Parser   (readInputExpr)
@@ -78,7 +79,7 @@ command options = processResult $ do
     let subst = mergeObjects (toJSON appData) templateVars
 
     -- Expand template
-    ExceptT $ fmap (makeLeftE cannotCopyTemplate) $ E.try $
+    ExceptT $ fmap (mapLeft cannotCopyTemplate) $ E.try $
       copyTemplate templateDir subst targetDir
 
   where

--- a/ogma-core/src/Command/Common.hs
+++ b/ogma-core/src/Command/Common.hs
@@ -48,8 +48,9 @@ import           Data.Aeson             (Value (Null, Object), eitherDecode,
 import           System.FilePath        ((</>))
 
 -- External imports: auxiliary
-import Data.ByteString.Extra as B (safeReadFile)
-import Data.String.Extra     (sanitizeLCIdentifier, sanitizeUCIdentifier)
+import Data.ByteString.Extra   as B (safeReadFile)
+import Data.String.Extra       (sanitizeLCIdentifier, sanitizeUCIdentifier)
+import System.Directory.Extra  (CopyTemplateError (..))
 
 -- External imports: ogma
 import Data.OgmaSpec (Requirement (..), Spec (..), externalVariableName,
@@ -313,15 +314,51 @@ cannotReadObjectTemplateVars file =
       "Cannot open file with additional template variables: " ++ file
 
 -- | Exception handler to deal with the case of files that cannot be
--- copied/generated due lack of space or permissions or some I/O error.
-cannotCopyTemplate :: ErrorTriplet
-cannotCopyTemplate =
-    ErrorTriplet ecCannotCopyTemplate msg LocationNothing
+-- copied/generated due to a problem with the template or the target
+-- location.
+cannotCopyTemplate :: E.SomeException -> ErrorTriplet
+cannotCopyTemplate e =
+    ErrorTriplet ecCannotCopyTemplate msg location
   where
-    msg =
-      "Generation failed during copy/write operation. Check that"
-      ++ " there's free space in the disk and that you have the necessary"
-      ++ " permissions to write in the destination directory."
+    (msg, location) = case E.fromException e of
+      Just (CopyTemplateListError dir reason) ->
+        ( "Generation failed because the template directory " ++ dir
+          ++ " cannot be read: " ++ reason
+        , LocationFile dir
+        )
+
+      Just (CopyTemplateReadError file reason) ->
+        ( "Generation failed because the template file " ++ file
+          ++ " cannot be read: " ++ reason
+        , LocationFile file
+        )
+
+      Just (CopyTemplateDecodeError file reason) ->
+        ( "Generation failed because the template file " ++ file
+          ++ " is not a valid UTF-8 text file: " ++ reason
+        , LocationFile file
+        )
+
+      Just (CopyTemplateParseError file reason) ->
+        ( "Generation failed because the template file " ++ file
+          ++ " cannot be parsed: " ++ reason
+        , LocationFile file
+        )
+
+      Just (CopyTemplateWriteError file reason) ->
+        ( "Generation failed because the file " ++ file
+          ++ " cannot be written. Check that there's free space in the disk"
+          ++ " and that you have the necessary permissions to write in the"
+          ++ " destination directory: " ++ reason
+        , LocationFile file
+        )
+
+      Nothing ->
+        ( "Generation failed during copy/write operation. Check that"
+          ++ " there's free space in the disk and that you have the necessary"
+          ++ " permissions to write in the destination directory: " ++ show e
+        , LocationNothing
+        )
 
 -- ** Error codes
 
@@ -349,8 +386,8 @@ ecCannotOpenTemplateVarsFile = 1
 ecCannotReadObjectTemplateVarsFile :: ErrorCode
 ecCannotReadObjectTemplateVarsFile = 1
 
--- | Error: the files cannot be copied/generated due lack of space or
--- permissions or some I/O error.
+-- | Error: the files cannot be copied/generated due to a problem with the
+-- template or the target location.
 ecCannotCopyTemplate :: ErrorCode
 ecCannotCopyTemplate = 1
 

--- a/ogma-core/src/Command/FPrimeApp.hs
+++ b/ogma-core/src/Command/FPrimeApp.hs
@@ -54,6 +54,7 @@ import Command.Errors     (ErrorCode, ErrorTriplet (..))
 import Command.VariableDB (InputDef (..), TypeDef (..), VariableDB, findInput,
                            findType, findTypeByType)
 import Data.Aeson.Extra   (mergeObjects)
+import Data.Either.Extra  (mapLeft)
 import Data.ExprPair      (ExprPair(..), exprPair)
 import Data.Location      (Location (..))
 import Data.Spec.Parser   (readInputExpr)
@@ -72,7 +73,7 @@ command options = processResult $ do
     let subst = mergeObjects (toJSON appData) templateVars
 
     -- Expand template
-    ExceptT $ fmap (makeLeftE cannotCopyTemplate) $ E.try $
+    ExceptT $ fmap (mapLeft cannotCopyTemplate) $ E.try $
       copyTemplate templateDir subst targetDir
 
   where

--- a/ogma-core/src/Command/ROSApp.hs
+++ b/ogma-core/src/Command/ROSApp.hs
@@ -59,6 +59,7 @@ import Command.VariableDB (Connection (..), InputDef (..), TopicDef (..),
                            TypeDef (..), VariableDB, findConnection, findInput,
                            findTopic, findType, findTypeByType)
 import Data.Aeson.Extra   (mergeObjects)
+import Data.Either.Extra  (mapLeft)
 import Data.ExprPair      (ExprPair(..), exprPair)
 import Data.Location      (Location (..))
 import Data.Spec.Parser   (readInputExpr)
@@ -77,7 +78,7 @@ command options = processResult $ do
     let subst = mergeObjects (toJSON appData) templateVars
 
     -- Expand template
-    ExceptT $ fmap (makeLeftE cannotCopyTemplate) $ E.try $
+    ExceptT $ fmap (mapLeft cannotCopyTemplate) $ E.try $
       copyTemplate templateDir subst targetDir
 
   where

--- a/ogma-core/src/Command/Report.hs
+++ b/ogma-core/src/Command/Report.hs
@@ -40,12 +40,13 @@ import System.Directory.Extra (copyTemplate)
 -- Internal imports
 import           Command.Common              (InputFile (..),
                                               cannotCopyTemplate,
-                                              locateTemplateDir, makeLeftE,
+                                              locateTemplateDir,
                                               parseInputFile, processResult)
 import           Command.Errors              (ErrorCode, ErrorTriplet (..))
 import           Command.Result              (Result (..))
 import           Data.Diagram.Analysis       (AnalysisResult (..),
                                               analyzeDiagram)
+import           Data.Either.Extra           (mapLeft)
 import           Data.ExprPair               (ExprPair (..), ExprPairT (..),
                                               exprPair)
 import           Data.Location               (Location (..))
@@ -72,7 +73,7 @@ command options = processResult $ do
     reportData <- command' options functions
 
     -- Expand template
-    ExceptT $ fmap (makeLeftE cannotCopyTemplate) $ E.try $
+    ExceptT $ fmap (mapLeft cannotCopyTemplate) $ E.try $
       copyTemplate templateDir (toJSON reportData) targetDir
 
   where

--- a/ogma-core/src/Command/Standalone.hs
+++ b/ogma-core/src/Command/Standalone.hs
@@ -76,7 +76,7 @@ command options = processResult $ do
     let subst = mergeObjects (toJSON appData) templateVars
 
     -- Expand template
-    ExceptT $ fmap (makeLeftE cannotCopyTemplate) $ E.try $
+    ExceptT $ fmap (mapLeft cannotCopyTemplate) $ E.try $
       copyTemplate templateDir subst targetDir
 
   where

--- a/ogma-extra/CHANGELOG.md
+++ b/ogma-extra/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Revision history for ogma-extra
 
+## [1.X.Y] - 2026-06-04
+
+* Distinguish causes of failure in `copyTemplate` (#390).
+
 ## [1.14.0] - 2026-05-21
 
 * Version bump (1.14.0) (#425).

--- a/ogma-extra/ogma-extra.cabal
+++ b/ogma-extra/ogma-extra.cabal
@@ -88,8 +88,14 @@ test-suite unit-tests
 
   build-depends:
       base                       >= 4.11.0.0 && < 5
+    , aeson                      >= 2.0.0.0  && < 2.3
+    , bytestring                 >= 0.10.8.2 && < 0.13
+    , directory                  >= 1.3.1.5  && < 1.4
+    , filepath                   >= 1.4.2    && < 1.6
+    , HUnit                      >= 1.2.0.0  && < 1.7
     , QuickCheck                 >= 2.8.2    && < 2.17
     , test-framework             >= 0.8.2    && < 0.9
+    , test-framework-hunit       >= 0.2.0    && < 0.4
     , test-framework-quickcheck2 >= 0.3.0.4  && < 0.4
 
     , ogma-extra

--- a/ogma-extra/src/System/Directory/Extra.hs
+++ b/ogma-extra/src/System/Directory/Extra.hs
@@ -18,64 +18,124 @@
 --
 -- | Auxiliary functions for working with directories.
 module System.Directory.Extra
-    ( copyTemplate
+    ( CopyTemplateError (..)
+    , copyTemplate
     )
   where
 
 -- External imports
+import           Control.Exception         ( Exception, IOException, handle,
+                                             throwIO )
 import           Control.Monad             ( filterM, forM_ )
 import           Data.Aeson                ( Value (..) )
 import qualified Data.ByteString.Lazy      as B
 import           Data.Text.Lazy            ( pack, unpack )
 import           Data.Text.Lazy.Encoding   ( encodeUtf8 )
 import           Distribution.Simple.Utils ( getDirectoryContentsRecursive )
+import           GHC.IO.Exception          ( IOErrorType (InvalidArgument) )
 import           System.Directory          ( createDirectoryIfMissing,
                                              doesFileExist )
 import           System.FilePath           ( makeRelative, splitFileName,
                                              takeDirectory, (</>) )
-import           Text.Microstache          ( compileMustacheFile,
+import           System.IO.Error           ( ioeGetErrorType )
+import           Text.Microstache          ( MustacheException (..), Template,
+                                             compileMustacheFile,
                                              compileMustacheText,
                                              renderMustache )
+
+-- | Exception thrown when a template cannot be expanded into a target
+-- location, indicating the reason for the failure and the file that caused
+-- it.
+data CopyTemplateError
+    = CopyTemplateListError FilePath String
+      -- ^ The template directory cannot be listed or read.
+    | CopyTemplateReadError FilePath String
+      -- ^ A file in the template cannot be opened or read.
+    | CopyTemplateDecodeError FilePath String
+      -- ^ A file in the template is not a valid UTF-8 text file.
+    | CopyTemplateParseError FilePath String
+      -- ^ A file in the template contains invalid template syntax.
+    | CopyTemplateWriteError FilePath String
+      -- ^ A file cannot be written to the target location.
+  deriving Show
+
+instance Exception CopyTemplateError
 
 -- | Copy a template directory into a target location, expanding variables
 -- provided in a map in a JSON value, both in the file contents and in the
 -- filepaths themselves.
+--
+-- This function throws a 'CopyTemplateError' if the template directory
+-- cannot be read, a file in the template cannot be read, decoded or parsed,
+-- or a file cannot be written to the target location.
 copyTemplate :: FilePath -> Value -> FilePath -> IO ()
 copyTemplate templateDir subst targetDir = do
 
-  -- Get all files (not directories) in the template dir. To keep a directory,
-  -- create an empty file in it (e.g., .keep).
-  tmplContents <- map (templateDir </>) . filter (`notElem` ["..", "."])
-                    <$> getDirectoryContentsRecursive templateDir
-  tmplFiles <- filterM doesFileExist tmplContents
+    -- Get all files (not directories) in the template dir. To keep a
+    -- directory, create an empty file in it (e.g., .keep).
+    tmplContents <- mapIOError (CopyTemplateListError templateDir) $
+                      map (templateDir </>) . filter (`notElem` ["..", "."])
+                        <$> getDirectoryContentsRecursive templateDir
+    tmplFiles <- mapIOError (CopyTemplateListError templateDir) $
+                   filterM doesFileExist tmplContents
 
-  -- Copy files to new locations, expanding their name and contents as
-  -- mustache templates.
-  forM_ tmplFiles $ \fp -> do
+    -- Copy files to new locations, expanding their name and contents as
+    -- mustache templates.
+    forM_ tmplFiles $ \fp -> do
 
-    -- New file name in target directory, treating file
-    -- name as mustache template.
-    let fullPath = targetDir </> newFP
-          where
-            -- If file name has mustache markers, expand, otherwise use
-            -- relative file path
-            newFP = either (const relFP)
-                           (unpack . (`renderMustache` subst))
-                           fpAsTemplateE
+      -- New file name in target directory, treating file
+      -- name as mustache template.
+      let fullPath = targetDir </> newFP
+            where
+              -- If file name has mustache markers, expand, otherwise use
+              -- relative file path
+              newFP = either (const relFP)
+                             (unpack . (`renderMustache` subst))
+                             fpAsTemplateE
 
-            -- Local file name within template dir
-            relFP = makeRelative templateDir fp
+              -- Local file name within template dir
+              relFP = makeRelative templateDir fp
 
-            -- Apply mustache substitutions to file name
-            fpAsTemplateE = compileMustacheText "fp" (pack relFP)
+              -- Apply mustache substitutions to file name
+              fpAsTemplateE = compileMustacheText "fp" (pack relFP)
 
-    -- File contents, treated as a mustache template.
-    contents <- encodeUtf8 <$> (`renderMustache` subst)
-                           <$> compileMustacheFile fp
+      -- File contents, treated as a mustache template.
+      template <- compileTemplateFile fp
+      let contents = encodeUtf8 $ renderMustache template subst
 
-    -- Create target directory if necessary
-    let dirName = fst $ splitFileName fullPath
-    createDirectoryIfMissing True dirName
+      mapIOError (CopyTemplateWriteError fullPath) $ do
+        -- Create target directory if necessary
+        let dirName = fst $ splitFileName fullPath
+        createDirectoryIfMissing True dirName
 
-    -- Write expanded contents to expanded file path
-    B.writeFile fullPath contents
+        -- Write expanded contents to expanded file path
+        B.writeFile fullPath contents
+
+  where
+
+    -- Run an action, turning any IO exception into a 'CopyTemplateError'
+    -- using the function provided.
+    mapIOError :: (String -> CopyTemplateError) -> IO a -> IO a
+    mapIOError mkError = handle $ \e ->
+      throwIO $ mkError $ show (e :: IOException)
+
+    -- Compile a file as a mustache template, indicating the reason for the
+    -- failure and the offending file if the file cannot be read, decoded, or
+    -- parsed.
+    compileTemplateFile :: FilePath -> IO Template
+    compileTemplateFile fp =
+        handle mapMustacheError $ handle mapIOException $
+          compileMustacheFile fp
+      where
+        mapIOException :: IOException -> IO a
+        mapIOException e
+          | ioeGetErrorType e == InvalidArgument
+          = throwIO $ CopyTemplateDecodeError fp (show e)
+          | otherwise
+          = throwIO $ CopyTemplateReadError fp (show e)
+
+        mapMustacheError :: MustacheException -> IO a
+        mapMustacheError (MustacheParserException e) =
+          throwIO $ CopyTemplateParseError fp (show e)
+        mapMustacheError e =
+          throwIO $ CopyTemplateParseError fp (show e)

--- a/ogma-extra/tests/Main.hs
+++ b/ogma-extra/tests/Main.hs
@@ -15,17 +15,30 @@
 -- License for the specific language governing permissions and limitations
 -- under the License.
 --
+{-# LANGUAGE OverloadedStrings #-}
 -- | Test ogma-extra internals.
 module Main where
 
 -- External imports
-import Data.Either                          ( isLeft, isRight )
-import Test.Framework                       ( Test, defaultMainWithOpts )
-import Test.Framework.Providers.QuickCheck2 ( testProperty )
-import Test.QuickCheck                      ( Property, (==>), Fun (Fun) )
+import           Control.Exception                    ( try )
+import           Data.Aeson                           ( object, (.=) )
+import qualified Data.ByteString                      as BS
+import           Data.Either                          ( isLeft, isRight )
+import           System.Directory                     ( createDirectoryIfMissing,
+                                                        getTemporaryDirectory,
+                                                        removePathForcibly )
+import           System.FilePath                      ( (</>) )
+import           Test.Framework                       ( Test,
+                                                        defaultMainWithOpts )
+import           Test.Framework.Providers.HUnit       ( testCase )
+import           Test.Framework.Providers.QuickCheck2 ( testProperty )
+import           Test.HUnit                           ( assertBool )
+import           Test.QuickCheck                      ( Fun (Fun), Property,
+                                                        (==>) )
 
 -- Internal imports
-import Data.List.Extra ( headEither, toHead, toTail )
+import Data.List.Extra        ( headEither, toHead, toTail )
+import System.Directory.Extra ( CopyTemplateError (..), copyTemplate )
 
 -- | Run all unit tests on Ogma's core.
 main :: IO ()
@@ -45,6 +58,14 @@ tests =
   , testProperty "Data.List.Extra.toTail (length)"             propToTailSameLength
   , testProperty "Data.List.Extra.headEither (Right case)"     propHeadEitherRight
   , testProperty "Data.List.Extra.headEither (Left case)"      propHeadEitherLeft
+  , testCase "System.Directory.Extra.copyTemplate (valid template)"
+      testCopyTemplateOk
+  , testCase "System.Directory.Extra.copyTemplate (missing template dir)"
+      testCopyTemplateMissingDir
+  , testCase "System.Directory.Extra.copyTemplate (invalid encoding)"
+      testCopyTemplateInvalidEncoding
+  , testCase "System.Directory.Extra.copyTemplate (invalid syntax)"
+      testCopyTemplateInvalidSyntax
   ]
 
 -- * Data.List.Extra
@@ -89,3 +110,87 @@ propHeadEitherRight xs = not (null xs) ==> isRight (headEither xs)
 -- | Test that 'headEither' returns a 'Left' value if applied to an empty list.
 propHeadEitherLeft :: [Int] -> Property
 propHeadEitherLeft xs = null xs ==> isLeft (headEither xs)
+
+-- * System.Directory.Extra
+
+-- | Test that 'copyTemplate' expands a valid template, substituting the
+-- variables provided in the file contents.
+testCopyTemplateOk :: IO ()
+testCopyTemplateOk = do
+    (templateDir, targetDir) <- makeTestDirs "ok"
+
+    writeFile (templateDir </> "greeting.txt") "Hello, {{name}}!"
+
+    result <- try $ copyTemplate templateDir subst targetDir
+
+    contents <- readFile (targetDir </> "greeting.txt")
+
+    let testPass = isRight (result :: Either CopyTemplateError ())
+                     && contents == "Hello, World!"
+
+    assertBool "Expansion of a valid template failed" testPass
+  where
+    subst = object [ "name" .= ("World" :: String) ]
+
+-- | Test that 'copyTemplate' reports a list error when the template
+-- directory does not exist.
+testCopyTemplateMissingDir :: IO ()
+testCopyTemplateMissingDir = do
+    (templateDir, targetDir) <- makeTestDirs "missing"
+
+    removePathForcibly templateDir
+
+    result <- try $ copyTemplate templateDir (object []) targetDir
+
+    let testPass = case result of
+                     Left (CopyTemplateListError _ _) -> True
+                     _                                -> False
+
+    assertBool "Missing template directory not reported as a list error"
+               testPass
+
+-- | Test that 'copyTemplate' reports a decode error when a file in the
+-- template is not a valid UTF-8 text file.
+testCopyTemplateInvalidEncoding :: IO ()
+testCopyTemplateInvalidEncoding = do
+    (templateDir, targetDir) <- makeTestDirs "encoding"
+
+    -- 0xC3 followed by 0x28 is an invalid UTF-8 byte sequence.
+    BS.writeFile (templateDir </> "bad.txt") (BS.pack [0x68, 0xC3, 0x28])
+
+    result <- try $ copyTemplate templateDir (object []) targetDir
+
+    let testPass = case result of
+                     Left (CopyTemplateDecodeError _ _) -> True
+                     _                                  -> False
+
+    assertBool "Invalid UTF-8 file not reported as a decode error" testPass
+
+-- | Test that 'copyTemplate' reports a parse error when a file in the
+-- template contains invalid template syntax.
+testCopyTemplateInvalidSyntax :: IO ()
+testCopyTemplateInvalidSyntax = do
+    (templateDir, targetDir) <- makeTestDirs "syntax"
+
+    writeFile (templateDir </> "bad.txt") "{{#unclosed\nsome text\n"
+
+    result <- try $ copyTemplate templateDir (object []) targetDir
+
+    let testPass = case result of
+                     Left (CopyTemplateParseError _ _) -> True
+                     _                                 -> False
+
+    assertBool "Invalid template syntax not reported as a parse error"
+               testPass
+
+-- | Create empty template and target directories for a test with the given
+-- name, removing any leftovers from prior runs.
+makeTestDirs :: String -> IO (FilePath, FilePath)
+makeTestDirs name = do
+  tmpDir <- getTemporaryDirectory
+  let templateDir = tmpDir </> ("ogma-extra-tests-template-" ++ name)
+      targetDir   = tmpDir </> ("ogma-extra-tests-target-" ++ name)
+  removePathForcibly templateDir
+  removePathForcibly targetDir
+  createDirectoryIfMissing True templateDir
+  return (templateDir, targetDir)


### PR DESCRIPTION
Closes #390.

Implements the solution proposed in #390.

**Changes**

- `ogma-extra`: `System.Directory.Extra.copyTemplate` now raises a dedicated exception type, `CopyTemplateError`, with separate constructors for each cause of failure (template directory cannot be listed, file cannot be read, file is not valid UTF-8, file contains invalid template syntax, file cannot be written), each carrying the offending file and a human-readable reason. Template syntax errors include the line and column.
- `ogma-core`: `Command.Common.cannotCopyTemplate` inspects the `CopyTemplateError` and produces a message indicating the specific cause and the offending file, which is also reported as the error location. The `cfs`, `fprime`, `ros`, `standalone` and `report` commands are adjusted accordingly. If an exception other than `CopyTemplateError` is ever raised, the prior generic message is still produced, now also including the exception details.
- `ogma-cli`: no changes needed; it already prints the message and location produced by `ogma-core`.

**Behavior, using the method to check the presence of the bug described in #390**

Before (template directory containing a file with invalid UTF-8 encoding):

```
<no location info>: error: Generation failed during copy/write operation. Check that there's free space in the disk and that you have the necessary permissions to write in the destination directory.
```

After:

```
/tmp/tmpl/bad.txt: error: Generation failed because the template file /tmp/tmpl/bad.txt is not a valid UTF-8 text file: /tmp/tmpl/bad.txt: hGetContents: invalid argument (cannot decode byte sequence starting from 195)
```

After, with invalid mustache syntax in a template file:

```
/tmp/tmpl/bad.tpl: error: Generation failed because the template file /tmp/tmpl/bad.tpl cannot be parsed: "/tmp/tmpl/bad.tpl" (line 2, column 1):
unexpected "s"
expecting space or "}}"
```

**Testing**

- New unit tests in `ogma-extra` cover `copyTemplate`: correct expansion of a valid template, and the reported error cause for a missing template directory, a template file with invalid UTF-8 encoding, and a template file with invalid template syntax.
- `cabal build` and `cabal test` pass for `ogma-extra` and `ogma-core` (GHC 9.6.7).
- Manually verified all five failure modes (unreadable template dir, unreadable file, invalid UTF-8, invalid mustache syntax, unwritable target) and that the output of a successful generation with the default cFS template is unchanged.

