### PR TITLE
`ogma-core`: Fix indentation of record fields in multiple backends. Refs #442.

### DIFF
--- a/ogma-core/CHANGELOG.md
+++ b/ogma-core/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Remove redundant `where` block (#432).
 * Fix incorrect Haddock comment syntax (#434).
 * Remove redundant occurrences of `MultiWayIf` pragma (#440).
+* Fix indentation of record fields in multiple backends (#442).
 
 ## [1.14.0] - 2026-05-21
 

--- a/ogma-core/src/Command/CFSApp.hs
+++ b/ogma-core/src/Command/CFSApp.hs
@@ -285,13 +285,13 @@ instance ToJSON Trigger
 
 -- | Data that may be relevant to generate a cFS monitoring application.
 data AppData = AppData
-  { variables   :: [VarDecl]
-  , msgIds      :: [MsgInfoId]
-  , msgCases    :: [MsgInfo]
-  , msgHandlers :: [MsgData]
-  , triggers    :: [Trigger]
-  , copilot     :: Maybe Command.Standalone.AppData
-  }
+    { variables   :: [VarDecl]
+    , msgIds      :: [MsgInfoId]
+    , msgCases    :: [MsgInfo]
+    , msgHandlers :: [MsgData]
+    , triggers    :: [Trigger]
+    , copilot     :: Maybe Command.Standalone.AppData
+    }
   deriving (Generic)
 
 instance ToJSON AppData

--- a/ogma-core/src/Command/FPrimeApp.hs
+++ b/ogma-core/src/Command/FPrimeApp.hs
@@ -224,10 +224,10 @@ instance ToJSON Monitor
 
 -- | Data that may be relevant to generate a ROS application.
 data AppData = AppData
-  { variables :: [VarDecl]
-  , monitors  :: [Monitor]
-  , copilot   :: Maybe Command.Standalone.AppData
-  }
+    { variables :: [VarDecl]
+    , monitors  :: [Monitor]
+    , copilot   :: Maybe Command.Standalone.AppData
+    }
   deriving (Generic)
 
 instance ToJSON AppData

--- a/ogma-core/src/Command/ROSApp.hs
+++ b/ogma-core/src/Command/ROSApp.hs
@@ -261,12 +261,12 @@ instance ToJSON Node
 
 -- | Data that may be relevant to generate a ROS application.
 data AppData = AppData
-  { variables        :: [VarDecl]
-  , monitors         :: [Monitor]
-  , copilot          :: Maybe Command.Standalone.AppData
-  , testingApps      :: [Node]
-  , testingVariables :: [VarDecl]
-  }
+    { variables        :: [VarDecl]
+    , monitors         :: [Monitor]
+    , copilot          :: Maybe Command.Standalone.AppData
+    , testingApps      :: [Node]
+    , testingVariables :: [VarDecl]
+    }
   deriving (Generic)
 
 instance ToJSON AppData


### PR DESCRIPTION
Increase the indentation of record fields for the type `AppData` in the cFS, ROS and F Prime backends, as prescribed in the solution proposed for #442.