### PR TITLE
`ogma-core`: Move expressions from `let` block into `where` clause. Refs #444.

### DIFF
--- a/ogma-core/CHANGELOG.md
+++ b/ogma-core/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Fix incorrect Haddock comment syntax (#434).
 * Remove redundant occurrences of `MultiWayIf` pragma (#440).
 * Fix indentation of record fields in multiple backends (#442).
+* Move expressions from `let` block into `where` clause (#444).
 
 ## [1.14.0] - 2026-05-21
 

--- a/ogma-core/src/Command/Standalone.hs
+++ b/ogma-core/src/Command/Standalone.hs
@@ -147,27 +147,29 @@ commandLogic expr fps name typeMaps exprT (InputFileDiagram d) =
   where
     (int, trigs) = diagram2CopilotSpec d ComputeState
 
-commandLogic expr fps name typeMaps exprT (InputFileSpec input) = do
-    let spec = addMissingIdentifiers ids input
-    -- Analyze the spec for incorrect identifiers and convert it to Copilot.
-    -- If there is an error, we change the error to a message we control.
-    let appData = mapLeft commandIncorrectSpec' $ do
-          spec' <- specAnalyze spec
-          res   <- spec2Copilot name typeMaps replace print spec'
-
-          -- Pack the results
-          let (ext, int, reqs, trigs, specN) = res
-
-          return $ AppData ext int reqs trigs specN
+commandLogic expr fps name typeMaps exprT (InputFileSpec input) =
 
     liftEither appData
 
   where
 
+    -- Analyze the spec for incorrect identifiers and convert it to Copilot.
+    -- If there is an error, we change the error to a message we control.
+    appData = mapLeft commandIncorrectSpec' $ do
+      spec' <- specAnalyze spec
+      res   <- spec2Copilot name typeMaps replace print spec'
+
+      -- Pack the results
+      let (ext, int, reqs, trigs, specN) = res
+
+      return $ AppData ext int reqs trigs specN
+
     commandIncorrectSpec' = case (expr, fps) of
       (Nothing,    [])   -> error "Both expression and file are missing"
       (Nothing,    fps') -> commandIncorrectSpecF
       (Just expr', _)    -> commandIncorrectSpecE expr'
+
+    spec = addMissingIdentifiers ids input
 
     ExprPairT parse replace print ids def = exprT
 


### PR DESCRIPTION
Move definitions of local variables in `ogma-core:Command.Standalone.commandLogic` from `let` block into `where` clause, as prescribed in the solution proposed for #444.