### PR TITLE
Translate diagrams to Copilot using state machine function from `copilot-libraries`. Refs #446.

### DIFF
--- a/.github/workflows/repo-ghc-8.6-cabal-2.4-csv.yml
+++ b/.github/workflows/repo-ghc-8.6-cabal-2.4-csv.yml
@@ -44,7 +44,7 @@ jobs:
 
     - name: Install ogma
       run: |
-        cabal v1-install ogma-**/ copilot --constraint="aeson >= 2.0.3.0" --constraint="copilot>=4.6.1"
+        cabal v1-install ogma-**/ copilot --constraint="aeson >= 2.0.3.0" --constraint="copilot>=4.7.1"
 
     - name: Generate Copilot module
       run: |

--- a/.github/workflows/repo-ghc-8.6-cabal-2.4-diagram.yml
+++ b/.github/workflows/repo-ghc-8.6-cabal-2.4-diagram.yml
@@ -44,7 +44,7 @@ jobs:
 
     - name: Install ogma
       run: |
-        cabal v1-install copilot-4.6 ogma-**/ --constraint="aeson >= 2.0.3.0"
+        cabal v1-install copilot-4.7.1 ogma-**/ --constraint="aeson >= 2.0.3.0"
 
     - name: Generate and enable app from diagram
       run: |

--- a/.github/workflows/repo-ghc-8.6-cabal-2.4-xlsx.yml
+++ b/.github/workflows/repo-ghc-8.6-cabal-2.4-xlsx.yml
@@ -44,7 +44,7 @@ jobs:
 
     - name: Install ogma
       run: |
-        cabal v1-install ogma-**/ copilot --constraint="aeson >= 2.0.3.0" --constraint="copilot>=4.6.1"
+        cabal v1-install ogma-**/ copilot --constraint="aeson >= 2.0.3.0" --constraint="copilot>=4.7.1"
 
     - name: Generate Copilot module
       run: |

--- a/ogma-cli/CHANGELOG.md
+++ b/ogma-cli/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Revision history for ogma-cli
 
-## [1.X.Y] - 2026-05-28
+## [1.X.Y] - 2026-05-31
 
 * Fix typo in README (#428).
+* Update CI job to install Copilot 4.7.1 by default (#446).
 
 ## [1.14.0] - 2026-05-21
 

--- a/ogma-core/CHANGELOG.md
+++ b/ogma-core/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Remove redundant occurrences of `MultiWayIf` pragma (#440).
 * Fix indentation of record fields in multiple backends (#442).
 * Move expressions from `let` block into `where` clause (#444).
+* Update backends to use state machine module from `copilot-libraries` (#446).
 
 ## [1.14.0] - 2026-05-21
 

--- a/ogma-core/ogma-core.cabal
+++ b/ogma-core/ogma-core.cabal
@@ -149,9 +149,9 @@ library
     , aeson                   >= 2.0.0.0  && < 2.3
     , bytestring              >= 0.10.8.2 && < 0.13
     , containers              >= 0.5      && < 0.8
-    , copilot-core            >= 4.6.1    && < 4.8
-    , copilot-language        >= 4.6.1    && < 4.8
-    , copilot-theorem         >= 4.6.1    && < 4.8
+    , copilot-core            >= 4.7.1    && < 4.8
+    , copilot-language        >= 4.7.1    && < 4.8
+    , copilot-theorem         >= 4.7.1    && < 4.8
     , directory               >= 1.3.1.5  && < 1.4
     , filepath                >= 1.4.2    && < 1.6
     , graphviz                >= 2999.20  && < 2999.21

--- a/ogma-core/src/Data/Diagram/Analysis.hs
+++ b/ogma-core/src/Data/Diagram/Analysis.hs
@@ -62,12 +62,13 @@ analyzeDiagram diagram = do
 -- | Default imports for a 'Spec' that was converted into a 'Copilot.Spec'.
 defaultSpecImports :: [(String, Maybe String)]
 defaultSpecImports =
-  [ ("Control.Monad.Writer",  Nothing)
-  , ("Copilot.Language",      Nothing)
-  , ("Copilot.Language.Spec", Nothing)
-  , ("Data.Functor.Identity", Nothing)
-  , ("Data.List",             Just "L")
-  , ("Prelude",               Just "P")
+  [ ("Control.Monad.Writer",          Nothing)
+  , ("Copilot.Language",              Nothing)
+  , ("Copilot.Language.Spec",         Nothing)
+  , ("Copilot.Library.StateMachines", Nothing)
+  , ("Data.Functor.Identity",         Nothing)
+  , ("Data.List",                     Just "L")
+  , ("Prelude",                       Just "P")
   ]
 
 -- | Render a 'Diagram' as a Haskell definition of a 'Copilot.Spec'.
@@ -94,29 +95,7 @@ showDiagram diagram = unlines $
 -- | Auxiliary definitions needed in the spec.
 auxiliaryDefinitions :: String
 auxiliaryDefinitions = unlines
-  [ "stateMachine :: (Eq a, Typed a)"
-  , "             => (a, a, Stream Bool, [(a, Stream Bool, a)], a)"
-  , "             -> Stream a"
-  , "stateMachine (initial, final, noInputData, transitions, bad) ="
-  , "    state"
-  , "  where"
-  , "    state         = ifThenElses transitions"
-  , "    previousState = [initial] ++ state"
-  , ""
-  , "    -- ifThenElses :: [(a, Stream Bool, a)] -> Stream a"
-  , "    ifThenElses [] ="
-  , "      ifThenElse"
-  , "        (previousState == constant final && noInputData)"
-  , "        (constant final)"
-  , "        (constant bad)"
-  , ""
-  , "    ifThenElses ((s1, i, s2):ss) ="
-  , "      ifThenElse"
-  , "        (previousState == constant s1 && i)"
-  , "        (constant s2)"
-  , "        (ifThenElses ss)"
-  , ""
-  , "isDeterministic :: (Ord a, Eq a, Typed a)"
+  [ "isDeterministic :: (Ord a, Eq a, Typed a)"
   , "                => (a, a, Stream Bool, [(a, Stream Bool, a)], a)"
   , "                -> Stream Bool"
   , "isDeterministic (_, _, _, ts, _) = all $"

--- a/ogma-core/src/Language/Trans/Diagram2Copilot.hs
+++ b/ogma-core/src/Language/Trans/Diagram2Copilot.hs
@@ -44,7 +44,7 @@ diagram2CopilotSpec diag mode = (machine, triggers)
   where
     machine = unlines
       [ "stateMachineS :: Stream Word8"
-      , "stateMachineS = stateMachineGF stateMachine1"
+      , "stateMachineS = stateMachine stateMachine1"
       , ""
       , "stateMachineProp :: Stream Bool"
       , "stateMachineProp = " ++ propExpr

--- a/ogma-core/templates/cfs/copilot/fsw/src/Properties.hs
+++ b/ogma-core/templates/cfs/copilot/fsw/src/Properties.hs
@@ -1,14 +1,15 @@
 {{#copilot}}
 import           Copilot.Compile.C99
-import           Copilot.Language          hiding (prop)
+import           Copilot.Language              hiding (prop)
 import           Copilot.Language.Prelude
-import           Copilot.Library.LTL       (next)
-import           Copilot.Library.MTL       hiding (since, alwaysBeen, trigger)
-import           Copilot.Library.PTLTL     (since, previous, alwaysBeen)
-import qualified Copilot.Library.PTLTL     as PTLTL
-import qualified Copilot.Library.MTL       as MTL
-import           Language.Copilot          (reify)
-import           Prelude                   hiding ((&&), (||), (++), (<=), (>=), (<), (>), (==), (/=), not)
+import           Copilot.Library.LTL           (next)
+import           Copilot.Library.MTL           hiding (since, alwaysBeen, trigger)
+import           Copilot.Library.PTLTL         (since, previous, alwaysBeen)
+import qualified Copilot.Library.PTLTL         as PTLTL
+import qualified Copilot.Library.MTL           as MTL
+import           Copilot.Library.StateMachines (stateMachine)
+import           Language.Copilot              (reify)
+import           Prelude                       hiding ((&&), (||), (++), (<=), (>=), (<), (>), (==), (/=), not)
 
 {{#copilot_extra_defs}}
 {{{.}}}
@@ -33,31 +34,6 @@ tpre = ([True] ++)
 
 notPreviousNot :: Stream Bool -> Stream Bool
 notPreviousNot = not . PTLTL.previous . not
-
--- Initial state, final state, no transition signal, transitions, bad state
-type StateMachineGF a = (a, a, Stream Bool, [(a, Stream Bool, a)], a)
-
-stateMachineGF :: (Eq a, Typed a)
-               => StateMachineGF a
-               -> Stream a
-stateMachineGF (initial, final, noInputData, transitions, bad) =
-    state
-  where
-    state         = ifThenElses transitions
-    previousState = [initial] ++ state
-
-    -- ifThenElses :: [(a, Stream Bool, a)] -> Stream a
-    ifThenElses [] =
-      ifThenElse
-        (previousState == constant final && noInputData)
-        (constant final)
-        (constant bad)
-
-    ifThenElses ((s1, i, s2):ss) =
-      ifThenElse
-        (previousState == constant s1 && i)
-        (constant s2)
-        (ifThenElses ss)
 
 -- | Complete specification. Calls C handler functions when properties are
 -- violated.

--- a/ogma-core/templates/diagram/Copilot.hs
+++ b/ogma-core/templates/diagram/Copilot.hs
@@ -1,16 +1,18 @@
 import           Copilot.Compile.C99
-import           Copilot.Language         hiding (max, min, prop)
+import           Copilot.Language              hiding (max, min, prop)
 import           Copilot.Language.Prelude
-import           Copilot.Library.LTL      (next)
-import           Copilot.Library.MTL      hiding (alwaysBeen, since, trigger)
-import qualified Copilot.Library.MTL      as MTL
-import           Copilot.Library.PTLTL    (alwaysBeen, previous, since)
-import qualified Copilot.Library.PTLTL    as PTLTL
-import           Language.Copilot         (reify)
-import           Language.Copilot         hiding (max, min)
-import           Prelude                  hiding (max, min, mod, not, until,
-                                           (&&), (++), (/=), (<), (<=), (==),
-                                           (>), (>=), (||))
+import           Copilot.Library.LTL           (next)
+import           Copilot.Library.MTL           hiding (alwaysBeen, since,
+                                                trigger)
+import qualified Copilot.Library.MTL           as MTL
+import           Copilot.Library.PTLTL         (alwaysBeen, previous, since)
+import qualified Copilot.Library.PTLTL         as PTLTL
+import           Copilot.Library.StateMachines (stateMachine)
+import           Language.Copilot              (reify)
+import           Language.Copilot              hiding (max, min)
+import           Prelude                       hiding (max, min, mod, not,
+                                                until, (&&), (++), (/=), (<),
+                                                (<=), (==), (>), (>=), (||))
 
 externalState :: Stream Word8
 externalState = extern "{{{state}}}" Nothing
@@ -28,21 +30,3 @@ spec = do
 
 main :: IO ()
 main = reify spec >>= compile "{{{specName}}}"
-
--- Initial state, final state, no transition signal, transitions, bad state
-type StateMachineGF = ( Word8, Word8, Stream Bool, [(Word8, Stream Bool, Word8)], Word8)
-
-stateMachineGF :: StateMachineGF -> Stream Word8
-stateMachineGF (initialState, finalState, noInputData, transitions, badState) = state
-  where
-    state         = ifThenElses transitions
-    previousState = [initialState] ++ state
-
-    ifThenElses :: [(Word8, Stream Bool, Word8)] -> Stream Word8
-    ifThenElses [] =
-      ifThenElse (previousState == constant finalState && noInputData)
-        (constant finalState)
-        (constant badState)
-
-    ifThenElses ((s1,i,s2):ss) =
-      ifThenElse (previousState == constant s1 && i) (constant s2) (ifThenElses ss)

--- a/ogma-core/templates/fprime/Copilot.hs
+++ b/ogma-core/templates/fprime/Copilot.hs
@@ -1,14 +1,15 @@
 {{#copilot}}
 import           Copilot.Compile.C99
-import           Copilot.Language          hiding (prop)
+import           Copilot.Language              hiding (prop)
 import           Copilot.Language.Prelude
-import           Copilot.Library.LTL       (next)
-import           Copilot.Library.MTL       hiding (since, alwaysBeen, trigger)
-import           Copilot.Library.PTLTL     (since, previous, alwaysBeen)
-import qualified Copilot.Library.PTLTL     as PTLTL
-import qualified Copilot.Library.MTL       as MTL
-import           Language.Copilot          (reify)
-import           Prelude                   hiding ((&&), (||), (++), (<=), (>=), (<), (>), (==), (/=), not)
+import           Copilot.Library.LTL           (next)
+import           Copilot.Library.MTL           hiding (since, alwaysBeen, trigger)
+import           Copilot.Library.PTLTL         (since, previous, alwaysBeen)
+import qualified Copilot.Library.PTLTL         as PTLTL
+import qualified Copilot.Library.MTL           as MTL
+import           Copilot.Library.StateMachines (stateMachine)
+import           Language.Copilot              (reify)
+import           Prelude                       hiding ((&&), (||), (++), (<=), (>=), (<), (>), (==), (/=), not)
 
 {{#copilot_extra_defs}}
 {{{.}}}
@@ -33,31 +34,6 @@ tpre = ([True] ++)
 
 notPreviousNot :: Stream Bool -> Stream Bool
 notPreviousNot = not . PTLTL.previous . not
-
--- Initial state, final state, no transition signal, transitions, bad state
-type StateMachineGF a = (a, a, Stream Bool, [(a, Stream Bool, a)], a)
-
-stateMachineGF :: (Eq a, Typed a)
-               => StateMachineGF a
-               -> Stream a
-stateMachineGF (initial, final, noInputData, transitions, bad) =
-    state
-  where
-    state         = ifThenElses transitions
-    previousState = [initial] ++ state
-
-    -- ifThenElses :: [(a, Stream Bool, a)] -> Stream a
-    ifThenElses [] =
-      ifThenElse
-        (previousState == constant final && noInputData)
-        (constant final)
-        (constant bad)
-
-    ifThenElses ((s1, i, s2):ss) =
-      ifThenElse
-        (previousState == constant s1 && i)
-        (constant s2)
-        (ifThenElses ss)
 
 -- | Complete specification. Calls C handler functions when properties are
 -- violated.

--- a/ogma-core/templates/ros/copilot/src/Copilot.hs
+++ b/ogma-core/templates/ros/copilot/src/Copilot.hs
@@ -1,14 +1,15 @@
 {{#copilot}}
 import           Copilot.Compile.C99
-import           Copilot.Language          hiding (prop)
+import           Copilot.Language              hiding (prop)
 import           Copilot.Language.Prelude
-import           Copilot.Library.LTL       (next)
-import           Copilot.Library.MTL       hiding (since, alwaysBeen, trigger)
-import           Copilot.Library.PTLTL     (since, previous, alwaysBeen)
-import qualified Copilot.Library.PTLTL     as PTLTL
-import qualified Copilot.Library.MTL       as MTL
-import           Language.Copilot          (reify)
-import           Prelude                   hiding ((&&), (||), (++), (<=), (>=), (<), (>), (==), (/=), not)
+import           Copilot.Library.LTL           (next)
+import           Copilot.Library.MTL           hiding (since, alwaysBeen, trigger)
+import           Copilot.Library.PTLTL         (since, previous, alwaysBeen)
+import qualified Copilot.Library.PTLTL         as PTLTL
+import qualified Copilot.Library.MTL           as MTL
+import           Copilot.Library.StateMachines (stateMachine)
+import           Language.Copilot              (reify)
+import           Prelude                       hiding ((&&), (||), (++), (<=), (>=), (<), (>), (==), (/=), not)
 
 {{#copilot_extra_defs}}
 {{{.}}}
@@ -33,31 +34,6 @@ tpre = ([True] ++)
 
 notPreviousNot :: Stream Bool -> Stream Bool
 notPreviousNot = not . PTLTL.previous . not
-
--- Initial state, final state, no transition signal, transitions, bad state
-type StateMachineGF a = (a, a, Stream Bool, [(a, Stream Bool, a)], a)
-
-stateMachineGF :: (Eq a, Typed a)
-               => StateMachineGF a
-               -> Stream a
-stateMachineGF (initial, final, noInputData, transitions, bad) =
-    state
-  where
-    state         = ifThenElses transitions
-    previousState = [initial] ++ state
-
-    -- ifThenElses :: [(a, Stream Bool, a)] -> Stream a
-    ifThenElses [] =
-      ifThenElse
-        (previousState == constant final && noInputData)
-        (constant final)
-        (constant bad)
-
-    ifThenElses ((s1, i, s2):ss) =
-      ifThenElse
-        (previousState == constant s1 && i)
-        (constant s2)
-        (ifThenElses ss)
 
 -- | Complete specification. Calls C handler functions when properties are
 -- violated.

--- a/ogma-core/templates/standalone/Copilot.hs
+++ b/ogma-core/templates/standalone/Copilot.hs
@@ -1,13 +1,14 @@
 import           Copilot.Compile.C99
-import           Copilot.Language          hiding (prop)
+import           Copilot.Language              hiding (prop)
 import           Copilot.Language.Prelude
-import           Copilot.Library.LTL       (next)
-import           Copilot.Library.MTL       hiding (since, alwaysBeen, trigger)
-import           Copilot.Library.PTLTL     (since, previous, alwaysBeen)
-import qualified Copilot.Library.PTLTL     as PTLTL
-import qualified Copilot.Library.MTL       as MTL
-import           Language.Copilot          (reify)
-import           Prelude                   hiding ((&&), (||), (++), (<=), (>=), (<), (>), (==), (/=), not)
+import           Copilot.Library.LTL           (next)
+import           Copilot.Library.MTL           hiding (since, alwaysBeen, trigger)
+import           Copilot.Library.PTLTL         (since, previous, alwaysBeen)
+import qualified Copilot.Library.PTLTL         as PTLTL
+import qualified Copilot.Library.MTL           as MTL
+import           Copilot.Library.StateMachines (stateMachine)
+import           Language.Copilot              (reify)
+import           Prelude                       hiding ((&&), (||), (++), (<=), (>=), (<), (>), (==), (/=), not)
 
 {{#copilot_extra_defs}}
 {{{.}}}
@@ -32,31 +33,6 @@ tpre = ([True] ++)
 
 notPreviousNot :: Stream Bool -> Stream Bool
 notPreviousNot = not . PTLTL.previous . not
-
--- Initial state, final state, no transition signal, transitions, bad state
-type StateMachineGF a = (a, a, Stream Bool, [(a, Stream Bool, a)], a)
-
-stateMachineGF :: (Eq a, Typed a)
-               => StateMachineGF a
-               -> Stream a
-stateMachineGF (initial, final, noInputData, transitions, bad) =
-    state
-  where
-    state         = ifThenElses transitions
-    previousState = [initial] ++ state
-
-    -- ifThenElses :: [(a, Stream Bool, a)] -> Stream a
-    ifThenElses [] =
-      ifThenElse
-        (previousState == constant final && noInputData)
-        (constant final)
-        (constant bad)
-
-    ifThenElses ((s1, i, s2):ss) =
-      ifThenElse
-        (previousState == constant s1 && i)
-        (constant s2)
-        (ifThenElses ss)
 
 -- | Complete specification. Calls C handler functions when properties are
 -- violated.


### PR DESCRIPTION
Update translation functions in Ogma to use the version of state machines available in Copilot 4.7.1, update templates as necessary, and update CI jobs and Cabal files to require a version of Copilot that provides the necessary module, as prescribed in the solution proposed for #446.