### PR TITLE
`ogma-language-xmlspec`: Remove redundant `where` block. Refs #452.

### DIFF
--- a/ogma-language-xmlspec/CHANGELOG.md
+++ b/ogma-language-xmlspec/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Revision history for ogma-language-xmlspec
 
+## [1.X.Y] - 2026-06-14
+
+* Remove redundant `where` block (#452).
+
 ## [1.14.0] - 2026-05-21
 
 * Version bump (1.14.0) (#425).

--- a/ogma-language-xmlspec/src/Language/XMLSpec/PrintTrees.hs
+++ b/ogma-language-xmlspec/src/Language/XMLSpec/PrintTrees.hs
@@ -288,9 +288,8 @@ prettyValue attributeList children
       | otherwise                 = text attrType
 
     prettyAttrEnum =
-        parens $ sepBy (text " | ") $
-          map (prettyEnum . fromMaybe [] . getDTDAttrl) children
-      where
+      parens $ sepBy (text " | ") $
+        map (prettyEnum . fromMaybe [] . getDTDAttrl) children
 
     prettyAttrKind kind
       | kind == k_default


### PR DESCRIPTION
Remove the redundant `where` keyword and indent the surrounding code, as prescribed in the solution proposed for #452.