### PR TITLE
`ogma-cli`: Fix style of record definitions, constructions in multiple commands. Refs #454.

### DIFF
--- a/ogma-cli/CHANGELOG.md
+++ b/ogma-cli/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Revision history for ogma-cli
 
-## [1.X.Y] - 2026-05-31
+## [1.X.Y] - 2026-06-23
 
 * Fix typo in README (#428).
 * Update CI job to install Copilot 4.7.1 by default (#446).
+* Fix style of record definitions, constructions in multiple commands (#454).
 
 ## [1.14.0] - 2026-05-21
 

--- a/ogma-cli/src/CLI/CommandCFSApp.hs
+++ b/ogma-cli/src/CLI/CommandCFSApp.hs
@@ -45,16 +45,16 @@ import qualified Command.CFSApp
 -- | Options needed to generate the cFS application.
 data CommandOpts = CommandOpts
   { cFSAppConditionExpr :: Maybe String
-  , cFSAppInputFiles   :: [String]
-  , cFSAppTarget       :: String
-  , cFSAppTemplateDir  :: Maybe String
-  , cFSAppVarNames     :: Maybe String
-  , cFSAppVarDB        :: Maybe String
-  , cFSAppHandlers     :: Maybe String
-  , cFSAppFormat       :: String
-  , cFSAppPropFormat   :: String
-  , cFSAppPropVia      :: Maybe String
-  , cFSAppTemplateVars :: Maybe String
+  , cFSAppInputFiles    :: [String]
+  , cFSAppTarget        :: String
+  , cFSAppTemplateDir   :: Maybe String
+  , cFSAppVarNames      :: Maybe String
+  , cFSAppVarDB         :: Maybe String
+  , cFSAppHandlers      :: Maybe String
+  , cFSAppFormat        :: String
+  , cFSAppPropFormat    :: String
+  , cFSAppPropVia       :: Maybe String
+  , cFSAppTemplateVars  :: Maybe String
   }
 
 -- | Create <https://cfs.gsfc.nasa.gov/ NASA core Flight System> (cFS)
@@ -67,16 +67,16 @@ command c = Command.CFSApp.command options
   where
     options = Command.CFSApp.CommandOptions
                 { Command.CFSApp.commandConditionExpr = cFSAppConditionExpr c
-                , Command.CFSApp.commandInputFiles  = cFSAppInputFiles c
-                , Command.CFSApp.commandTargetDir   = cFSAppTarget c
-                , Command.CFSApp.commandTemplateDir = cFSAppTemplateDir c
-                , Command.CFSApp.commandVariables   = cFSAppVarNames c
-                , Command.CFSApp.commandVariableDB  = cFSAppVarDB c
-                , Command.CFSApp.commandHandlers    = cFSAppHandlers c
-                , Command.CFSApp.commandFormat      = cFSAppFormat c
-                , Command.CFSApp.commandPropFormat  = cFSAppPropFormat c
-                , Command.CFSApp.commandPropVia     = cFSAppPropVia c
-                , Command.CFSApp.commandExtraVars   = cFSAppTemplateVars c
+                , Command.CFSApp.commandInputFiles    = cFSAppInputFiles c
+                , Command.CFSApp.commandTargetDir     = cFSAppTarget c
+                , Command.CFSApp.commandTemplateDir   = cFSAppTemplateDir c
+                , Command.CFSApp.commandVariables     = cFSAppVarNames c
+                , Command.CFSApp.commandVariableDB    = cFSAppVarDB c
+                , Command.CFSApp.commandHandlers      = cFSAppHandlers c
+                , Command.CFSApp.commandFormat        = cFSAppFormat c
+                , Command.CFSApp.commandPropFormat    = cFSAppPropFormat c
+                , Command.CFSApp.commandPropVia       = cFSAppPropVia c
+                , Command.CFSApp.commandExtraVars     = cFSAppTemplateVars c
                 }
 
 -- * CLI

--- a/ogma-cli/src/CLI/CommandCFSApp.hs
+++ b/ogma-cli/src/CLI/CommandCFSApp.hs
@@ -44,7 +44,7 @@ import qualified Command.CFSApp
 
 -- | Options needed to generate the cFS application.
 data CommandOpts = CommandOpts
-  { cFSAppConditionExpr  :: Maybe String
+  { cFSAppConditionExpr :: Maybe String
   , cFSAppInputFiles   :: [String]
   , cFSAppTarget       :: String
   , cFSAppTemplateDir  :: Maybe String

--- a/ogma-cli/src/CLI/CommandFPrimeApp.hs
+++ b/ogma-cli/src/CLI/CommandFPrimeApp.hs
@@ -45,16 +45,16 @@ import qualified Command.FPrimeApp
 -- | Options needed to generate the FPrime component.
 data CommandOpts = CommandOpts
   { fprimeAppConditionExpr :: Maybe String
-  , fprimeAppInputFiles   :: [String]
-  , fprimeAppTarget       :: String
-  , fprimeAppTemplateDir  :: Maybe String
-  , fprimeAppVariables    :: Maybe String
-  , fprimeAppVarDB        :: Maybe String
-  , fprimeAppHandlers     :: Maybe String
-  , fprimeAppFormat       :: String
-  , fprimeAppPropFormat   :: String
-  , fprimeAppPropVia      :: Maybe String
-  , fprimeAppTemplateVars :: Maybe String
+  , fprimeAppInputFiles    :: [String]
+  , fprimeAppTarget        :: String
+  , fprimeAppTemplateDir   :: Maybe String
+  , fprimeAppVariables     :: Maybe String
+  , fprimeAppVarDB         :: Maybe String
+  , fprimeAppHandlers      :: Maybe String
+  , fprimeAppFormat        :: String
+  , fprimeAppPropFormat    :: String
+  , fprimeAppPropVia       :: Maybe String
+  , fprimeAppTemplateVars  :: Maybe String
   }
 
 -- | Create <https://github.com/nasa/fprime FPrime> component that subscribe
@@ -68,16 +68,16 @@ command c = Command.FPrimeApp.command options
     options =
       Command.FPrimeApp.CommandOptions
         { Command.FPrimeApp.commandConditionExpr = fprimeAppConditionExpr c
-        , Command.FPrimeApp.commandInputFiles  = fprimeAppInputFiles c
-        , Command.FPrimeApp.commandTargetDir   = fprimeAppTarget c
-        , Command.FPrimeApp.commandTemplateDir = fprimeAppTemplateDir c
-        , Command.FPrimeApp.commandVariables   = fprimeAppVariables c
-        , Command.FPrimeApp.commandVariableDB  = fprimeAppVarDB c
-        , Command.FPrimeApp.commandHandlers    = fprimeAppHandlers c
-        , Command.FPrimeApp.commandFormat      = fprimeAppFormat c
-        , Command.FPrimeApp.commandPropFormat  = fprimeAppPropFormat c
-        , Command.FPrimeApp.commandPropVia     = fprimeAppPropVia c
-        , Command.FPrimeApp.commandExtraVars   = fprimeAppTemplateVars c
+        , Command.FPrimeApp.commandInputFiles    = fprimeAppInputFiles c
+        , Command.FPrimeApp.commandTargetDir     = fprimeAppTarget c
+        , Command.FPrimeApp.commandTemplateDir   = fprimeAppTemplateDir c
+        , Command.FPrimeApp.commandVariables     = fprimeAppVariables c
+        , Command.FPrimeApp.commandVariableDB    = fprimeAppVarDB c
+        , Command.FPrimeApp.commandHandlers      = fprimeAppHandlers c
+        , Command.FPrimeApp.commandFormat        = fprimeAppFormat c
+        , Command.FPrimeApp.commandPropFormat    = fprimeAppPropFormat c
+        , Command.FPrimeApp.commandPropVia       = fprimeAppPropVia c
+        , Command.FPrimeApp.commandExtraVars     = fprimeAppTemplateVars c
         }
 
 -- * CLI

--- a/ogma-cli/src/CLI/CommandFPrimeApp.hs
+++ b/ogma-cli/src/CLI/CommandFPrimeApp.hs
@@ -44,7 +44,7 @@ import qualified Command.FPrimeApp
 
 -- | Options needed to generate the FPrime component.
 data CommandOpts = CommandOpts
-  { fprimeAppConditionExpr  :: Maybe String
+  { fprimeAppConditionExpr :: Maybe String
   , fprimeAppInputFiles   :: [String]
   , fprimeAppTarget       :: String
   , fprimeAppTemplateDir  :: Maybe String

--- a/ogma-cli/src/CLI/CommandOverview.hs
+++ b/ogma-cli/src/CLI/CommandOverview.hs
@@ -49,10 +49,10 @@ import qualified Command.Overview
 
 -- | Options to generate an overview from the input specification(s).
 data CommandOpts = CommandOpts
-  { overviewInputFile   :: FilePath
-  , overviewFormat      :: String
-  , overviewPropFormat  :: String
-  , overviewPropVia     :: Maybe String
+  { overviewInputFile  :: FilePath
+  , overviewFormat     :: String
+  , overviewPropFormat :: String
+  , overviewPropVia    :: Maybe String
   }
 
 -- | Print an overview of the input specification(s).
@@ -72,9 +72,9 @@ command c = do
   where
     internalCommandOpts :: Command.Overview.CommandOptions
     internalCommandOpts = Command.Overview.CommandOptions
-      { Command.Overview.commandFormat      = overviewFormat c
-      , Command.Overview.commandPropFormat  = overviewPropFormat c
-      , Command.Overview.commandPropVia     = overviewPropVia c
+      { Command.Overview.commandFormat     = overviewFormat c
+      , Command.Overview.commandPropFormat = overviewPropFormat c
+      , Command.Overview.commandPropVia    = overviewPropVia c
       }
 
     outputString (Command.Overview.CommandSummaryRequirement {}) =

--- a/ogma-cli/src/CLI/CommandROSApp.hs
+++ b/ogma-cli/src/CLI/CommandROSApp.hs
@@ -44,7 +44,7 @@ import qualified Command.ROSApp
 
 -- | Options needed to generate the ROS application.
 data CommandOpts = CommandOpts
-  { rosAppConditionExpr  :: Maybe String
+  { rosAppConditionExpr :: Maybe String
   , rosAppInputFiles   :: [String]
   , rosAppTarget       :: String
   , rosAppTemplateDir  :: Maybe String

--- a/ogma-cli/src/CLI/CommandROSApp.hs
+++ b/ogma-cli/src/CLI/CommandROSApp.hs
@@ -45,18 +45,18 @@ import qualified Command.ROSApp
 -- | Options needed to generate the ROS application.
 data CommandOpts = CommandOpts
   { rosAppConditionExpr :: Maybe String
-  , rosAppInputFiles   :: [String]
-  , rosAppTarget       :: String
-  , rosAppTemplateDir  :: Maybe String
-  , rosAppVarNames     :: Maybe String
-  , rosAppVarDB        :: Maybe String
-  , rosAppHandlers     :: Maybe String
-  , rosAppFormat       :: String
-  , rosAppPropFormat   :: String
-  , rosAppPropVia      :: Maybe String
-  , rosAppTemplateVars :: Maybe String
-  , rosAppTestingApps  :: [String]
-  , rosAppTestingVars  :: [String]
+  , rosAppInputFiles    :: [String]
+  , rosAppTarget        :: String
+  , rosAppTemplateDir   :: Maybe String
+  , rosAppVarNames      :: Maybe String
+  , rosAppVarDB         :: Maybe String
+  , rosAppHandlers      :: Maybe String
+  , rosAppFormat        :: String
+  , rosAppPropFormat    :: String
+  , rosAppPropVia       :: Maybe String
+  , rosAppTemplateVars  :: Maybe String
+  , rosAppTestingApps   :: [String]
+  , rosAppTestingVars   :: [String]
   }
 
 -- | Create <https://www.ros.org/ Robot Operating System> (ROS) applications
@@ -69,18 +69,18 @@ command c = Command.ROSApp.command options
   where
     options = Command.ROSApp.CommandOptions
                 { Command.ROSApp.commandConditionExpr = rosAppConditionExpr c
-                , Command.ROSApp.commandInputFiles  = rosAppInputFiles c
-                , Command.ROSApp.commandTargetDir   = rosAppTarget c
-                , Command.ROSApp.commandTemplateDir = rosAppTemplateDir c
-                , Command.ROSApp.commandVariables   = rosAppVarNames c
-                , Command.ROSApp.commandVariableDB  = rosAppVarDB c
-                , Command.ROSApp.commandHandlers    = rosAppHandlers c
-                , Command.ROSApp.commandFormat      = rosAppFormat c
-                , Command.ROSApp.commandPropFormat  = rosAppPropFormat c
-                , Command.ROSApp.commandPropVia     = rosAppPropVia c
-                , Command.ROSApp.commandExtraVars   = rosAppTemplateVars c
-                , Command.ROSApp.commandTestingApps = appNames
-                , Command.ROSApp.commandTestingVars = rosAppTestingVars c
+                , Command.ROSApp.commandInputFiles    = rosAppInputFiles c
+                , Command.ROSApp.commandTargetDir     = rosAppTarget c
+                , Command.ROSApp.commandTemplateDir   = rosAppTemplateDir c
+                , Command.ROSApp.commandVariables     = rosAppVarNames c
+                , Command.ROSApp.commandVariableDB    = rosAppVarDB c
+                , Command.ROSApp.commandHandlers      = rosAppHandlers c
+                , Command.ROSApp.commandFormat        = rosAppFormat c
+                , Command.ROSApp.commandPropFormat    = rosAppPropFormat c
+                , Command.ROSApp.commandPropVia       = rosAppPropVia c
+                , Command.ROSApp.commandExtraVars     = rosAppTemplateVars c
+                , Command.ROSApp.commandTestingApps   = appNames
+                , Command.ROSApp.commandTestingVars   = rosAppTestingVars c
                 }
 
     -- Turn the qualified app names into tuples of package and node name.

--- a/ogma-cli/src/CLI/CommandStandalone.hs
+++ b/ogma-cli/src/CLI/CommandStandalone.hs
@@ -45,16 +45,16 @@ import qualified Command.Standalone
 
 -- | Options to generate Copilot from specification.
 data CommandOpts = CommandOpts
-  { standaloneTargetDir    :: FilePath
-  , standaloneTemplateDir  :: Maybe FilePath
+  { standaloneTargetDir     :: FilePath
+  , standaloneTemplateDir   :: Maybe FilePath
   , standaloneConditionExpr :: Maybe String
-  , standaloneInputFiles   :: [FilePath]
-  , standaloneFormat       :: String
-  , standalonePropFormat   :: String
-  , standaloneTypes        :: [String]
-  , standaloneTarget       :: String
-  , standalonePropVia      :: Maybe String
-  , standaloneTemplateVars :: Maybe String
+  , standaloneInputFiles    :: [FilePath]
+  , standaloneFormat        :: String
+  , standalonePropFormat    :: String
+  , standaloneTypes         :: [String]
+  , standaloneTarget        :: String
+  , standalonePropVia       :: Maybe String
+  , standaloneTemplateVars  :: Maybe String
   }
 
 -- | Transform an input specification into a Copilot specification.
@@ -65,15 +65,15 @@ command c =
     internalCommandOpts :: Command.Standalone.CommandOptions
     internalCommandOpts = Command.Standalone.CommandOptions
       { Command.Standalone.commandConditionExpr = standaloneConditionExpr c
-      , Command.Standalone.commandInputFiles  = standaloneInputFiles c
-      , Command.Standalone.commandTargetDir   = standaloneTargetDir c
-      , Command.Standalone.commandTemplateDir = standaloneTemplateDir c
-      , Command.Standalone.commandFormat      = standaloneFormat c
-      , Command.Standalone.commandPropFormat  = standalonePropFormat c
-      , Command.Standalone.commandTypeMapping = types
-      , Command.Standalone.commandFilename    = standaloneTarget c
-      , Command.Standalone.commandPropVia     = standalonePropVia c
-      , Command.Standalone.commandExtraVars   = standaloneTemplateVars c
+      , Command.Standalone.commandInputFiles    = standaloneInputFiles c
+      , Command.Standalone.commandTargetDir     = standaloneTargetDir c
+      , Command.Standalone.commandTemplateDir   = standaloneTemplateDir c
+      , Command.Standalone.commandFormat        = standaloneFormat c
+      , Command.Standalone.commandPropFormat    = standalonePropFormat c
+      , Command.Standalone.commandTypeMapping   = types
+      , Command.Standalone.commandFilename      = standaloneTarget c
+      , Command.Standalone.commandPropVia       = standalonePropVia c
+      , Command.Standalone.commandExtraVars     = standaloneTemplateVars c
       }
 
     types :: [(String, String)]

--- a/ogma-cli/src/CLI/CommandStandalone.hs
+++ b/ogma-cli/src/CLI/CommandStandalone.hs
@@ -47,7 +47,7 @@ import qualified Command.Standalone
 data CommandOpts = CommandOpts
   { standaloneTargetDir    :: FilePath
   , standaloneTemplateDir  :: Maybe FilePath
-  , standaloneConditionExpr  :: Maybe String
+  , standaloneConditionExpr :: Maybe String
   , standaloneInputFiles   :: [FilePath]
   , standaloneFormat       :: String
   , standalonePropFormat   :: String


### PR DESCRIPTION
Remove extra horizontal space and align record fields in the definitions and construction of command options in multilple commands, as prescribed in the solution proposed for #454.