### PR TITLE
`ogma-cli`: Adjust `overview` command to accept multiple input files. Refs #456.

### DIFF
--- a/ogma-cli/CHANGELOG.md
+++ b/ogma-cli/CHANGELOG.md
@@ -1,10 +1,11 @@
 # Revision history for ogma-cli
 
-## [1.X.Y] - 2026-06-23
+## [1.X.Y] - 2026-06-25
 
 * Fix typo in README (#428).
 * Update CI job to install Copilot 4.7.1 by default (#446).
 * Fix style of record definitions, constructions in multiple commands (#454).
+* Adjust `overview` command to accept multiple input files (#456).
 
 ## [1.14.0] - 2026-05-21
 

--- a/ogma-cli/src/CLI/CommandOverview.hs
+++ b/ogma-cli/src/CLI/CommandOverview.hs
@@ -32,10 +32,12 @@ module CLI.CommandOverview
 
 -- External imports
 import           Data.Aeson          (toJSON)
+import           Data.List           (dropWhileEnd)
 import qualified Data.Text.Lazy      as T
 import qualified Data.Text.Lazy.IO   as T
 import           Options.Applicative (Parser, help, long, metavar, optional,
-                                      short, showDefault, strOption, value)
+                                      short, showDefault, some, strOption,
+                                      value)
 import           Text.Microstache
 
 -- External imports: command results
@@ -49,37 +51,52 @@ import qualified Command.Overview
 
 -- | Options to generate an overview from the input specification(s).
 data CommandOpts = CommandOpts
-  { overviewInputFile  :: FilePath
-  , overviewFormat     :: String
-  , overviewPropFormat :: String
-  , overviewPropVia    :: Maybe String
+  { overviewInputFiles :: [OverviewFile]
+  }
+
+-- | Options associated to a specific input file.
+data OverviewFile = OverviewFile
+  { overviewFilePath       :: FilePath
+  , overviewFileFormat     :: String
+  , overviewFilePropFormat :: String
+  , overviewFilePropVia    :: Maybe String
   }
 
 -- | Print an overview of the input specification(s).
 command :: CommandOpts -> IO (Result ErrorCode)
 command c = do
     (mOutput, result) <-
-      Command.Overview.command (overviewInputFile c) internalCommandOpts
+      Command.Overview.command internalCommandOpts
 
     case mOutput of
       Just output ->
-        case outputString output of
-          Right template -> T.putStr $ renderMustache template (toJSON output)
+        case outputString of
+          Right template ->
+            T.putStr $ trimEnd $ renderMustache template (toJSON output)
           _              -> putStrLn "Error"
       _ -> putStrLn "Error"
     return result
 
   where
+
+    trimEnd :: T.Text -> T.Text
+    trimEnd = T.unlines . dropWhileEnd T.null . T.lines
+
     internalCommandOpts :: Command.Overview.CommandOptions
-    internalCommandOpts = Command.Overview.CommandOptions
-      { Command.Overview.commandFormat     = overviewFormat c
-      , Command.Overview.commandPropFormat = overviewPropFormat c
-      , Command.Overview.commandPropVia    = overviewPropVia c
+    internalCommandOpts = Command.Overview.CommandOptions $
+      map fileInfo (overviewInputFiles c)
+
+    fileInfo f = Command.Overview.OverviewFile
+      { Command.Overview.overviewFilePath       = overviewFilePath   f
+      , Command.Overview.overviewFileFormat     = overviewFileFormat f
+      , Command.Overview.overviewFilePropFormat = overviewFilePropFormat f
+      , Command.Overview.overviewFilePropVia    = overviewFilePropVia f
       }
 
-    outputString (Command.Overview.CommandSummaryRequirement {}) =
+    outputString =
       compileMustacheText "output" $ T.unlines
-        [ "The requirements file has:"
+        [ "{{#commandSummaryRequirements}}"
+        , "The requirements file {{commandRequirementsFile}} has:"
         , " - {{commandExternalVariables}} external variables."
         , " - {{commandInternalVariables}} internal variables."
         , " - {{commandRequirements}} requirements."
@@ -91,17 +108,19 @@ command c = do
         , "{{^commandRequirementsConsistent}}"
         , "   - The requirements are not mutually consistent."
         , "{{/commandRequirementsConsistent}}"
-        ]
-    outputString (Command.Overview.CommandSummaryDiagram {}) =
-      compileMustacheText "output" $ T.unlines
-        [ "The diagram file:"
-        , " - Has {{commandNumStates}} states."
-        , "{{#commandDeterministic}}"
+        , ""
+        , "{{/commandSummaryRequirements}}"
+        , "{{#commandSummaryDiagrams}}"
+        , "The diagram file {{commandDiagramFile}}:"
+        , " - Has {{commandDiagramNumStates}} states."
+        , "{{#commandDiagramDeterministic}}"
         , " - Is deterministic."
-        , "{{/commandDeterministic}}"
-        , "{{^commandDeterministic}}"
+        , "{{/commandDiagramDeterministic}}"
+        , "{{^commandDiagramDeterministic}}"
         , " - Is not deterministic."
-        , "{{/commandDeterministic}}"
+        , "{{/commandDiagramDeterministic}}"
+        , ""
+        , "{{/commandSummaryDiagrams}}"
         ]
 
 -- * CLI
@@ -113,7 +132,12 @@ commandDesc = "Generate an overview of the input specification(s)"
 -- | Subparser for the @overview@ command, used to generate an overview
 -- of the input specifications.
 commandOptsParser :: Parser CommandOpts
-commandOptsParser = CommandOpts
+commandOptsParser = CommandOpts <$> some overviewFileOptsParser
+
+-- | Subparser for information on one input file to be used with the @overview@
+-- command.
+overviewFileOptsParser :: Parser OverviewFile
+overviewFileOptsParser = OverviewFile
   <$> strOption
         (  long "input-file"
         <> metavar "FILENAME"

--- a/ogma-core/CHANGELOG.md
+++ b/ogma-core/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Leverage `Data.ExprPair.exprPair` in `Command.Diagram.exprPair` (#448).
 * Remove empty Haddock section heading from `Command.Diagram` (#450).
 * Add missing dependency to Cabal file (#458).
+* Adjust overview command to accept multiple input files (#456).
 
 ## [1.14.0] - 2026-05-21
 

--- a/ogma-core/src/Command/Overview.hs
+++ b/ogma-core/src/Command/Overview.hs
@@ -23,12 +23,16 @@
 module Command.Overview
     ( command
     , CommandOptions(..)
+    , OverviewFile(..)
     , CommandSummary(..)
+    , CommandSummaryRequirements(..)
+    , CommandSummaryDiagram(..)
     , ErrorCode
     )
   where
 
 -- External imports
+import Control.Monad        (foldM)
 import Control.Monad.Except (runExceptT)
 import Data.Aeson           (ToJSON (..))
 import GHC.Generics         (Generic)
@@ -57,15 +61,29 @@ import qualified Language.Trans.Spec2Copilot as Spec2Copilot
 -- used are valid C99 identifiers. The template, if provided, exists and uses
 -- the variables needed by the overview application generator. The target
 -- directory is writable and there's enough disk space to copy the files over.
-command :: FilePath        -- ^ Path to a file containing a specification
-        -> CommandOptions -- ^ Customization options
+command :: CommandOptions -- ^ Customization options
         -> IO (Maybe CommandSummary, Result ErrorCode)
-command fp options = do
-  let functions = exprPair (commandPropFormat options)
+command options = do
+    fs <- foldM
+            processFile
+            (Right emptyCommandSummary)
+            (commandInputFiles options)
 
-  copilot <- command' fp options functions
+    return $ commandResult options fs
 
-  return $ commandResult options fp copilot
+  where
+
+    processFile :: Either (FilePath, String) CommandSummary
+                -> OverviewFile
+                -> IO (Either (FilePath, String) CommandSummary)
+    processFile acc file = case acc of
+      Left _     -> return acc
+      Right acc' -> do
+        let functions = exprPair (overviewFilePropFormat file)
+        c <- command' (overviewFilePath file) file functions
+        case c of
+          Left msg -> return $ Left (overviewFilePath file, msg)
+          Right s  -> return $ Right $ mergeCommandSummary acc' s
 
 -- | Generate overview of a spec given in an input file.
 --
@@ -76,7 +94,7 @@ command fp options = do
 -- the variables needed by the overview application generator. The target
 -- directory is writable and there's enough disk space to copy the files over.
 command' :: FilePath
-          -> CommandOptions
+          -> OverviewFile
           -> ExprPair
           -> IO (Either String CommandSummary)
 command' fp options (ExprPair exprT) = do
@@ -87,10 +105,14 @@ command' fp options (ExprPair exprT) = do
 
       Right (InputFileDiagram diagramR) -> do
         analysisResult <- analyzeDiagram diagramR
-        pure $ Right $
-          CommandSummaryDiagram
-            (numStates analysisResult)
-            (deterministic analysisResult)
+        pure $ Right $ emptyCommandSummary
+                         { commandSummaryDiagrams =
+                             [ CommandSummaryDiagram
+                                 fp
+                                 (numStates analysisResult)
+                                 (deterministic analysisResult)
+                             ]
+                         }
 
       Right (InputFileSpec spec') -> do
         let specCompleted = addMissingIdentifiers ids spec'
@@ -107,40 +129,89 @@ command' fp options (ExprPair exprT) = do
           numFalses   <- SpecAnalysis.numAlwaysFalse <$> specFormalAnalysis
           consistent  <- SpecAnalysis.consistent     <$> specFormalAnalysis
 
-          pure $
-            CommandSummaryRequirement
-              numExterns numInternal numReqs numTrues numFalses consistent
+          pure $ emptyCommandSummary
+                   { commandSummaryRequirements =
+                       [ CommandSummaryRequirements
+                           fp
+                           numExterns
+                           numInternal
+                           numReqs
+                           numTrues
+                           numFalses
+                           consistent
+                      ]
+                   }
 
   where
 
-    formatName     = commandFormat options
-    propFormatName = commandPropFormat options
-    propVia        = commandPropVia options
+    formatName     = overviewFileFormat options
+    propFormatName = overviewFilePropFormat options
+    propVia        = overviewFilePropVia options
 
     ExprPairT _parse replace printExpr ids _def = exprT
 
-data CommandSummary
-    = CommandSummaryRequirement
-        { commandExternalVariables      :: Int
-        , commandInternalVariables      :: Int
-        , commandRequirements           :: Int
-        , commandRequirementsTrue       :: Int
-        , commandRequirementsFalse      :: Int
-        , commandRequirementsConsistent :: Bool
-        }
-    | CommandSummaryDiagram
-        { commandNumStates     :: Int
-        , commandDeterministic :: Bool
-        }
+data CommandSummary = CommandSummary
+    { commandSummaryRequirements :: [CommandSummaryRequirements]
+    , commandSummaryDiagrams     :: [CommandSummaryDiagram]
+    }
   deriving (Generic, Show)
 
 instance ToJSON CommandSummary
 
+-- | Summary with empty data.
+emptyCommandSummary :: CommandSummary
+emptyCommandSummary = CommandSummary [] []
+
+-- | Merge two summaries.
+mergeCommandSummary :: CommandSummary -> CommandSummary -> CommandSummary
+mergeCommandSummary c1 c2 = CommandSummary
+  { commandSummaryRequirements =
+      commandSummaryRequirements c1 ++ commandSummaryRequirements c2
+  , commandSummaryDiagrams =
+      commandSummaryDiagrams c1 ++ commandSummaryDiagrams c2
+  }
+
+instance Semigroup CommandSummary where
+  (<>) = mergeCommandSummary
+
+instance Monoid CommandSummary where
+  mempty  = emptyCommandSummary
+
+-- | Requirement data for inclusion in the summary.
+data CommandSummaryRequirements = CommandSummaryRequirements
+    { commandRequirementsFile       :: FilePath
+    , commandExternalVariables      :: Int
+    , commandInternalVariables      :: Int
+    , commandRequirements           :: Int
+    , commandRequirementsTrue       :: Int
+    , commandRequirementsFalse      :: Int
+    , commandRequirementsConsistent :: Bool
+    }
+  deriving (Generic, Show)
+
+instance ToJSON CommandSummaryRequirements
+
+-- | Diagram Data for inclusion in the summary.
+data CommandSummaryDiagram = CommandSummaryDiagram
+    { commandDiagramFile          :: FilePath
+    , commandDiagramNumStates     :: Int
+    , commandDiagramDeterministic :: Bool
+    }
+  deriving (Generic, Show)
+
+instance ToJSON CommandSummaryDiagram
+
 -- | Options used to customize the interpretation of input specifications.
 data CommandOptions = CommandOptions
-  { commandFormat     :: String
-  , commandPropFormat :: String
-  , commandPropVia    :: Maybe String
+  { commandInputFiles :: [ OverviewFile ]
+  }
+
+-- | Information about one file in the command options.
+data OverviewFile = OverviewFile
+  { overviewFilePath       :: FilePath
+  , overviewFileFormat     :: String
+  , overviewFilePropFormat :: String
+  , overviewFilePropVia    :: Maybe String
   }
 
 -- * Error codes
@@ -154,9 +225,8 @@ ecOverviewError = 1
 
 -- | Process the result of the transformation function.
 commandResult :: CommandOptions
-              -> FilePath
-              -> Either String a
+              -> Either (FilePath, String) a
               -> (Maybe a, Result ErrorCode)
-commandResult _options fp result = case result of
-  Left msg -> (Nothing, Error ecOverviewError msg (LocationFile fp))
-  Right t  -> (Just t,  Success)
+commandResult _options result = case result of
+  Left (fp, msg) -> (Nothing, Error ecOverviewError msg (LocationFile fp))
+  Right t        -> (Just t,  Success)


### PR DESCRIPTION
Adjust `overview` command in `ogma-cli` to accept multiple input files and present information on all of them, making the necessary changes in the internal implementation of the command in `ogma-core`, as prescribed in the solution proposed for #456.