### PR TITLE
`ogma-core`: Add missing dependency to Cabal file. Refs #458.

### DIFF
--- a/ogma-core/CHANGELOG.md
+++ b/ogma-core/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Revision history for ogma-core
 
-## [1.X.Y] - 2026-06-13
+## [1.X.Y] - 2026-06-26
 
 * Remove commented code from `Data.Spec.Parser` (#430).
 * Remove redundant `where` block (#432).
@@ -11,6 +11,7 @@
 * Update backends to use state machine module from `copilot-libraries` (#446).
 * Leverage `Data.ExprPair.exprPair` in `Command.Diagram.exprPair` (#448).
 * Remove empty Haddock section heading from `Command.Diagram` (#450).
+* Add missing dependency to Cabal file (#458).
 
 ## [1.14.0] - 2026-05-21
 

--- a/ogma-core/ogma-core.cabal
+++ b/ogma-core/ogma-core.cabal
@@ -151,6 +151,7 @@ library
     , containers              >= 0.5      && < 0.8
     , copilot-core            >= 4.7.1    && < 4.8
     , copilot-language        >= 4.7.1    && < 4.8
+    , copilot-libraries       >= 4.7.1    && < 4.8
     , copilot-theorem         >= 4.7.1    && < 4.8
     , directory               >= 1.3.1.5  && < 1.4
     , filepath                >= 1.4.2    && < 1.6


### PR DESCRIPTION
Add missing dependency on `copilot-libraries` to `ogma-core`'s Cabal file, as prescribed in the solution proposed for #458.