### PR TITLE
`ogma-cli`: Adjust `overview`, `standalone`, app commands to support projects. Refs #460.

### DIFF
--- a/ogma-cli/CHANGELOG.md
+++ b/ogma-cli/CHANGELOG.md
@@ -1,11 +1,12 @@
 # Revision history for ogma-cli
 
-## [1.X.Y] - 2026-06-25
+## [1.X.Y] - 2026-06-27
 
 * Fix typo in README (#428).
 * Update CI job to install Copilot 4.7.1 by default (#446).
 * Fix style of record definitions, constructions in multiple commands (#454).
 * Adjust `overview` command to accept multiple input files (#456).
+* Adjust `overview`, `standalone`, app commands to support projects (#460).
 
 ## [1.14.0] - 2026-05-21
 

--- a/ogma-cli/src/CLI/CommandCFSApp.hs
+++ b/ogma-cli/src/CLI/CommandCFSApp.hs
@@ -30,6 +30,9 @@ module CLI.CommandCFSApp
   where
 
 -- External imports
+import Control.Applicative ( (<|>) )
+import Data.Functor        ( (<&>) )
+import Data.Maybe          ( fromMaybe )
 import Options.Applicative ( Parser, help, long, many, metavar, optional,
                              short, showDefault, strOption, value )
 
@@ -39,12 +42,16 @@ import Command.Result ( Result )
 -- External imports: actions or commands supported
 import           Command.CFSApp ( ErrorCode )
 import qualified Command.CFSApp
+import           Command.Result ( Result (..) )
+import           Data.Location  ( Location ( LocationFile ) )
+import           Data.Project   ( Project (..), readProject )
 
 -- * Command
 
 -- | Options needed to generate the cFS application.
 data CommandOpts = CommandOpts
-  { cFSAppConditionExpr :: Maybe String
+  { cFSAppProject       :: Maybe String
+  , cFSAppConditionExpr :: Maybe String
   , cFSAppInputFiles    :: [String]
   , cFSAppTarget        :: String
   , cFSAppTemplateDir   :: Maybe String
@@ -63,21 +70,74 @@ data CommandOpts = CommandOpts
 --
 -- This is just an uncurried version of "Command.CFSApp".
 command :: CommandOpts -> IO (Result ErrorCode)
-command c = Command.CFSApp.command options
-  where
-    options = Command.CFSApp.CommandOptions
-                { Command.CFSApp.commandConditionExpr = cFSAppConditionExpr c
-                , Command.CFSApp.commandInputFiles    = cFSAppInputFiles c
-                , Command.CFSApp.commandTargetDir     = cFSAppTarget c
-                , Command.CFSApp.commandTemplateDir   = cFSAppTemplateDir c
-                , Command.CFSApp.commandVariables     = cFSAppVarNames c
-                , Command.CFSApp.commandVariableDB    = cFSAppVarDB c
-                , Command.CFSApp.commandHandlers      = cFSAppHandlers c
-                , Command.CFSApp.commandFormat        = cFSAppFormat c
-                , Command.CFSApp.commandPropFormat    = cFSAppPropFormat c
-                , Command.CFSApp.commandPropVia       = cFSAppPropVia c
-                , Command.CFSApp.commandExtraVars     = cFSAppTemplateVars c
-                }
+command c
+  | Just p <- cFSAppProject c
+  = do optE <- commandProjectOptions p c
+       case optE of
+         Left msg  -> return $ Error cannotReadProject msg (LocationFile p)
+         Right opt -> Command.CFSApp.command opt
+
+  | otherwise
+  = Command.CFSApp.command $
+      Command.CFSApp.CommandOptions
+        { Command.CFSApp.commandConditionExpr = cFSAppConditionExpr c
+        , Command.CFSApp.commandInputFiles    = cFSAppInputFiles c
+        , Command.CFSApp.commandTargetDir     = cFSAppTarget c
+        , Command.CFSApp.commandTemplateDir   = cFSAppTemplateDir c
+        , Command.CFSApp.commandVariables     = cFSAppVarNames c
+        , Command.CFSApp.commandVariableDB    = cFSAppVarDB c
+        , Command.CFSApp.commandHandlers      = cFSAppHandlers c
+        , Command.CFSApp.commandFormat        = cFSAppFormat c
+        , Command.CFSApp.commandPropFormat    = cFSAppPropFormat c
+        , Command.CFSApp.commandPropVia       = cFSAppPropVia c
+        , Command.CFSApp.commandExtraVars     = cFSAppTemplateVars c
+        }
+
+-- | Produce default command options based on project settings.
+commandProjectOptions :: FilePath
+                      -> CommandOpts
+                      -> IO (Either String Command.CFSApp.CommandOptions)
+commandProjectOptions projectFile c = do
+  projectE <- readProject projectFile
+  return $ projectE <&> \project ->
+    Command.CFSApp.CommandOptions
+      { Command.CFSApp.commandConditionExpr = cFSAppConditionExpr c
+
+      , Command.CFSApp.commandInputFiles = concat
+          [ map (\(f, _, _) -> f) $ projectInputFiles project
+          , cFSAppInputFiles c
+          ]
+
+      , Command.CFSApp.commandTargetDir =
+          fromMaybe (cFSAppTarget c) (projectTargetDir project)
+
+      , Command.CFSApp.commandTemplateDir =
+          projectTemplateDir project <|> cFSAppTemplateDir c
+
+      , Command.CFSApp.commandVariables =
+          projectVariableFiles project <|> cFSAppVarNames c
+
+      , Command.CFSApp.commandVariableDB =
+          projectVariableDBFile project <|> cFSAppVarDB c
+
+      , Command.CFSApp.commandHandlers =
+          projectHandlerFile project <|> cFSAppHandlers c
+
+      , Command.CFSApp.commandFormat = case projectInputFiles project of
+          []            -> cFSAppFormat c
+          ((_, f, _):_) -> f
+
+      , Command.CFSApp.commandPropFormat = case projectInputFiles project of
+          []            -> cFSAppPropFormat c
+          ((_, _, f):_) -> f
+
+      , Command.CFSApp.commandPropVia =
+          projectCommandPropVia project <|> cFSAppPropVia c
+
+      , Command.CFSApp.commandExtraVars =
+          projectExtraJSONFile project <|> cFSAppTemplateVars c
+
+      }
 
 -- * CLI
 
@@ -90,6 +150,13 @@ commandDesc = "Generate a complete cFS/Copilot application"
 commandOptsParser :: Parser CommandOpts
 commandOptsParser = CommandOpts
   <$> optional
+        ( strOption
+            (  long "project"
+            <> metavar "FILENAME"
+            <> help strCFSAppProjectArgDesc
+            )
+        )
+  <*> optional
         ( strOption
             (  long "condition-expr"
             <> metavar "EXPRESSION"
@@ -169,6 +236,10 @@ commandOptsParser = CommandOpts
             )
         )
 
+-- | Argument project to cFS app generation command.
+strCFSAppProjectArgDesc :: String
+strCFSAppProjectArgDesc = "Project file"
+
 -- | Argument target directory to cFS app generation command
 strCFSAppDirArgDesc :: String
 strCFSAppDirArgDesc = "Target directory"
@@ -221,3 +292,7 @@ strCFSAppPropViaDesc =
 strCFSAppTemplateVarsArgDesc :: String
 strCFSAppTemplateVarsArgDesc =
   "JSON file containing additional variables to expand in template"
+
+-- | Error code for when a project cannot be read.
+cannotReadProject :: ErrorCode
+cannotReadProject = 1

--- a/ogma-cli/src/CLI/CommandFPrimeApp.hs
+++ b/ogma-cli/src/CLI/CommandFPrimeApp.hs
@@ -30,6 +30,9 @@ module CLI.CommandFPrimeApp
   where
 
 -- External imports
+import Control.Applicative ( (<|>) )
+import Data.Functor        ( (<&>) )
+import Data.Maybe          ( fromMaybe )
 import Options.Applicative ( Parser, help, long, many, metavar, optional,
                              short, showDefault, strOption, value )
 
@@ -39,12 +42,16 @@ import Command.Result ( Result )
 -- External imports: actions or commands supported
 import           Command.FPrimeApp (ErrorCode)
 import qualified Command.FPrimeApp
+import           Command.Result    (Result (..))
+import           Data.Location     (Location (LocationFile))
+import           Data.Project      (Project (..), readProject)
 
 -- * Command
 
 -- | Options needed to generate the FPrime component.
 data CommandOpts = CommandOpts
-  { fprimeAppConditionExpr :: Maybe String
+  { fprimeAppProject       :: Maybe String
+  , fprimeAppConditionExpr :: Maybe String
   , fprimeAppInputFiles    :: [String]
   , fprimeAppTarget        :: String
   , fprimeAppTemplateDir   :: Maybe String
@@ -63,7 +70,15 @@ data CommandOpts = CommandOpts
 --
 -- This is just a wrapper around "Command.fprimeApp".
 command :: CommandOpts -> IO (Result ErrorCode)
-command c = Command.FPrimeApp.command options
+command c
+    | Just p <- fprimeAppProject c
+    = do optE <- commandProjectOptions p c
+         case optE of
+           Left msg  -> return $ Error cannotReadProject msg (LocationFile p)
+           Right opt -> Command.FPrimeApp.command opt
+
+    | otherwise
+    = Command.FPrimeApp.command options
   where
     options =
       Command.FPrimeApp.CommandOptions
@@ -80,6 +95,52 @@ command c = Command.FPrimeApp.command options
         , Command.FPrimeApp.commandExtraVars     = fprimeAppTemplateVars c
         }
 
+-- | Produce default command options based on project settings.
+commandProjectOptions :: FilePath
+                      -> CommandOpts
+                      -> IO (Either String Command.FPrimeApp.CommandOptions)
+commandProjectOptions projectFile c = do
+  projectE <- readProject projectFile
+  return $ projectE <&> \project ->
+    Command.FPrimeApp.CommandOptions
+      { Command.FPrimeApp.commandConditionExpr = fprimeAppConditionExpr c
+
+      , Command.FPrimeApp.commandInputFiles = concat
+          [ map (\(f, _, _) -> f) $ projectInputFiles project
+          , fprimeAppInputFiles c
+          ]
+
+      , Command.FPrimeApp.commandTargetDir =
+          fromMaybe (fprimeAppTarget c) (projectTargetDir project)
+
+      , Command.FPrimeApp.commandTemplateDir =
+          maybe (fprimeAppTemplateDir c) Just (projectTemplateDir project)
+
+      , Command.FPrimeApp.commandVariables =
+          projectVariableFiles project <|> fprimeAppVariables c
+
+      , Command.FPrimeApp.commandVariableDB =
+          projectVariableDBFile project <|> fprimeAppVarDB c
+
+      , Command.FPrimeApp.commandHandlers =
+          projectHandlerFile project <|> fprimeAppHandlers c
+
+      , Command.FPrimeApp.commandFormat = case projectInputFiles project of
+          []            -> fprimeAppFormat c
+          ((_, f, _):_) -> f
+
+      , Command.FPrimeApp.commandPropFormat = case projectInputFiles project of
+          []            -> fprimeAppPropFormat c
+          ((_, _, f):_) -> f
+
+      , Command.FPrimeApp.commandPropVia =
+          projectCommandPropVia project <|> fprimeAppPropVia c
+
+      , Command.FPrimeApp.commandExtraVars =
+          projectExtraJSONFile project <|> fprimeAppTemplateVars c
+
+      }
+
 -- * CLI
 
 -- | FPrime command description
@@ -91,6 +152,13 @@ commandDesc = "Generate a complete F' monitoring component"
 commandOptsParser :: Parser CommandOpts
 commandOptsParser = CommandOpts
   <$> optional
+        ( strOption
+            (  long "project"
+            <> metavar "FILENAME"
+            <> help strFPrimeAppProjectArgDesc
+            )
+        )
+  <*> optional
         ( strOption
             (  long "condition-expr"
             <> metavar "EXPRESSION"
@@ -170,6 +238,10 @@ commandOptsParser = CommandOpts
             )
         )
 
+-- | Argument project to FPrime app generation command.
+strFPrimeAppProjectArgDesc :: String
+strFPrimeAppProjectArgDesc = "Project file"
+
 -- | Argument target directory to FPrime component generation command
 strFPrimeAppDirArgDesc :: String
 strFPrimeAppDirArgDesc = "Target directory"
@@ -220,3 +292,7 @@ strFPrimeAppPropViaDesc =
 strFPrimeAppTemplateVarsArgDesc :: String
 strFPrimeAppTemplateVarsArgDesc =
   "JSON file containing additional variables to expand in template"
+
+-- | Error code for when a project cannot be read.
+cannotReadProject :: ErrorCode
+cannotReadProject = 1

--- a/ogma-cli/src/CLI/CommandOverview.hs
+++ b/ogma-cli/src/CLI/CommandOverview.hs
@@ -32,26 +32,30 @@ module CLI.CommandOverview
 
 -- External imports
 import           Data.Aeson          (toJSON)
+import           Data.Functor        ((<&>))
 import           Data.List           (dropWhileEnd)
 import qualified Data.Text.Lazy      as T
 import qualified Data.Text.Lazy.IO   as T
-import           Options.Applicative (Parser, help, long, metavar, optional,
-                                      short, showDefault, some, strOption,
+import           Options.Applicative (Parser, help, long, many, metavar,
+                                      optional, short, showDefault, strOption,
                                       value)
 import           Text.Microstache
 
 -- External imports: command results
 import Command.Result ( Result(..) )
+import Data.Location  ( Location(..) )
 
 -- External imports: actions or commands supported
 import           Command.Overview (ErrorCode)
 import qualified Command.Overview
+import           Data.Project       (Project (..), readProject)
 
 -- * Command
 
 -- | Options to generate an overview from the input specification(s).
 data CommandOpts = CommandOpts
-  { overviewInputFiles :: [OverviewFile]
+  { overviewProject    :: Maybe String
+  , overviewInputFiles :: [OverviewFile]
   }
 
 -- | Options associated to a specific input file.
@@ -64,18 +68,34 @@ data OverviewFile = OverviewFile
 
 -- | Print an overview of the input specification(s).
 command :: CommandOpts -> IO (Result ErrorCode)
-command c = do
-    (mOutput, result) <-
-      Command.Overview.command internalCommandOpts
+command c
+    | Just p <- overviewProject c
+    = do optE <- commandProjectOptions p c
+         case optE of
+           Left msg  -> return $ Error cannotReadProject msg (LocationFile p)
+           Right opt -> do
+             (mOutput, result) <- Command.Overview.command opt
+             case mOutput of
+               Just output ->
+                 case outputString of
+                   Right template ->
+                     T.putStr $ trimEnd $ renderMustache template (toJSON output)
+                   _              -> putStrLn "Error"
+               _ -> putStrLn "Error"
+             return result
 
-    case mOutput of
-      Just output ->
-        case outputString of
-          Right template ->
-            T.putStr $ trimEnd $ renderMustache template (toJSON output)
-          _              -> putStrLn "Error"
-      _ -> putStrLn "Error"
-    return result
+     | otherwise
+     = do (mOutput, result) <-
+            Command.Overview.command internalCommandOpts
+
+          case mOutput of
+            Just output ->
+              case outputString of
+                Right template ->
+                  T.putStr $ trimEnd $ renderMustache template (toJSON output)
+                _              -> putStrLn "Error"
+            _ -> putStrLn "Error"
+          return result
 
   where
 
@@ -123,6 +143,39 @@ command c = do
         , "{{/commandSummaryDiagrams}}"
         ]
 
+-- | Produce command options based on project settings and user-provided
+-- command options.
+commandProjectOptions :: FilePath
+                      -> CommandOpts
+                      -> IO (Either String Command.Overview.CommandOptions)
+commandProjectOptions projectFile c = do
+    projectE <- readProject projectFile
+    return $ projectE <&> \project ->
+      Command.Overview.CommandOptions
+        { Command.Overview.commandInputFiles = concat
+            [ map (convertProjectFile project) $ projectInputFiles project
+            , map convertInputFile $ overviewInputFiles c
+            ]
+
+        }
+
+  where
+
+    convertProjectFile project (fp, format, propFormat) =
+      Command.Overview.OverviewFile
+        { Command.Overview.overviewFilePath       = fp
+        , Command.Overview.overviewFileFormat     = format
+        , Command.Overview.overviewFilePropFormat = propFormat
+        , Command.Overview.overviewFilePropVia    =
+            projectCommandPropVia project
+        }
+    convertInputFile f = Command.Overview.OverviewFile
+      { Command.Overview.overviewFilePath       = overviewFilePath   f
+      , Command.Overview.overviewFileFormat     = overviewFileFormat f
+      , Command.Overview.overviewFilePropFormat = overviewFilePropFormat f
+      , Command.Overview.overviewFilePropVia    = overviewFilePropVia f
+      }
+
 -- * CLI
 
 -- | Command description for CLI help.
@@ -132,7 +185,15 @@ commandDesc = "Generate an overview of the input specification(s)"
 -- | Subparser for the @overview@ command, used to generate an overview
 -- of the input specifications.
 commandOptsParser :: Parser CommandOpts
-commandOptsParser = CommandOpts <$> some overviewFileOptsParser
+commandOptsParser = CommandOpts
+  <$> optional
+        ( strOption
+            (  long "project"
+            <> metavar "FILENAME"
+            <> help strOverviewProjectArgDesc
+            )
+        )
+   <*> many overviewFileOptsParser
 
 -- | Subparser for information on one input file to be used with the @overview@
 -- command.
@@ -167,6 +228,10 @@ overviewFileOptsParser = OverviewFile
             )
         )
 
+-- | Project flag description.
+strOverviewProjectArgDesc :: String
+strOverviewProjectArgDesc = "Project file"
+
 -- | Input file flag description.
 strOverviewInputFileDesc :: String
 strOverviewInputFileDesc = "File with properties or requirements"
@@ -183,3 +248,7 @@ strOverviewPropFormatDesc = "Format of temporal or boolean properties"
 strOverviewPropViaDesc :: String
 strOverviewPropViaDesc =
   "Command to pre-process individual properties"
+
+-- | Error code for when a project cannot be read.
+cannotReadProject :: ErrorCode
+cannotReadProject = 1

--- a/ogma-cli/src/CLI/CommandROSApp.hs
+++ b/ogma-cli/src/CLI/CommandROSApp.hs
@@ -30,6 +30,9 @@ module CLI.CommandROSApp
   where
 
 -- External imports
+import Control.Applicative ( (<|>) )
+import Data.Functor        ( (<&>) )
+import Data.Maybe          ( fromMaybe )
 import Options.Applicative ( Parser, help, long, metavar, many, optional, short,
                              showDefault, strOption, value )
 
@@ -37,14 +40,18 @@ import Options.Applicative ( Parser, help, long, metavar, many, optional, short,
 import Command.Result ( Result )
 
 -- External imports: actions or commands supported
+import           Command.Result (Result (..))
 import           Command.ROSApp (ErrorCode)
 import qualified Command.ROSApp
+import           Data.Location  (Location (LocationFile))
+import           Data.Project   (Project (..), readProject)
 
 -- * Command
 
 -- | Options needed to generate the ROS application.
 data CommandOpts = CommandOpts
-  { rosAppConditionExpr :: Maybe String
+  { rosAppProject       :: Maybe String
+  , rosAppConditionExpr :: Maybe String
   , rosAppInputFiles    :: [String]
   , rosAppTarget        :: String
   , rosAppTemplateDir   :: Maybe String
@@ -65,7 +72,15 @@ data CommandOpts = CommandOpts
 --
 -- This is just a wrapper around "Command.ROSApp".
 command :: CommandOpts -> IO (Result ErrorCode)
-command c = Command.ROSApp.command options
+command c
+    | Just p <- rosAppProject c
+    = do optE <- commandProjectOptions p c
+         case optE of
+           Left msg  -> return $ Error cannotReadProject msg (LocationFile p)
+           Right opt -> Command.ROSApp.command opt
+
+    | otherwise
+    = Command.ROSApp.command options
   where
     options = Command.ROSApp.CommandOptions
                 { Command.ROSApp.commandConditionExpr = rosAppConditionExpr c
@@ -90,6 +105,66 @@ command c = Command.ROSApp.command options
       where
         (package, nodeT) = break (== ':') name
 
+-- | Produce default command options based on project settings.
+commandProjectOptions :: FilePath
+                      -> CommandOpts
+                      -> IO (Either String Command.ROSApp.CommandOptions)
+commandProjectOptions projectFile c = do
+    projectE <- readProject projectFile
+    return $ projectE <&> \project ->
+      Command.ROSApp.CommandOptions
+        { Command.ROSApp.commandConditionExpr = rosAppConditionExpr c
+
+        , Command.ROSApp.commandInputFiles = concat
+            [ map (\(f, _, _) -> f) $ projectInputFiles project
+            , rosAppInputFiles c
+            ]
+
+        , Command.ROSApp.commandTargetDir =
+            fromMaybe (rosAppTarget c) (projectTargetDir project)
+
+        , Command.ROSApp.commandTemplateDir =
+            projectTemplateDir project <|> rosAppTemplateDir c
+
+        , Command.ROSApp.commandVariables =
+            projectVariableFiles project <|> rosAppVarNames c
+
+        , Command.ROSApp.commandVariableDB =
+            projectVariableDBFile project <|> rosAppVarDB c
+
+        , Command.ROSApp.commandHandlers =
+            projectHandlerFile project <|> rosAppHandlers c
+
+        , Command.ROSApp.commandFormat = case projectInputFiles project of
+            []            -> rosAppFormat c
+            ((_, f, _):_) -> f
+
+        , Command.ROSApp.commandPropFormat =
+            case projectInputFiles project of
+              []            -> rosAppPropFormat c
+              ((_, _, f):_) -> f
+
+        , Command.ROSApp.commandPropVia =
+            projectCommandPropVia project <|> rosAppPropVia c
+
+        , Command.ROSApp.commandExtraVars =
+            projectExtraJSONFile project <|> rosAppTemplateVars c
+
+        , Command.ROSApp.commandTestingApps = appNames
+
+        , Command.ROSApp.commandTestingVars = rosAppTestingVars c
+
+        }
+
+  where
+
+    -- Turn the qualified app names into tuples of package and node name.
+    appNames = map splitAppName $ rosAppTestingApps c
+
+    splitAppName name = Command.ROSApp.Node package (drop 1 nodeT)
+      where
+        (package, nodeT) = break (== ':') name
+
 -- * CLI
 
 -- | ROS command description
@@ -101,6 +176,13 @@ commandDesc = "Generate a ROS 2 monitoring package"
 commandOptsParser :: Parser CommandOpts
 commandOptsParser = CommandOpts
   <$> optional
+        ( strOption
+            (  long "project"
+            <> metavar "FILENAME"
+            <> help strROSAppProjectArgDesc
+            )
+        )
+  <*> optional
         ( strOption
             (  long "condition-expr"
             <> metavar "EXPRESSION"
@@ -193,6 +275,10 @@ commandOptsParser = CommandOpts
               )
            )
 
+-- | Argument project to ROS app generation command.
+strROSAppProjectArgDesc :: String
+strROSAppProjectArgDesc = "Project file"
+
 -- | Argument target directory to ROS app generation command
 strROSAppDirArgDesc :: String
 strROSAppDirArgDesc = "Target directory"
@@ -253,3 +339,7 @@ strROSAppROSNodesTestingListArgDesc =
 strROSAppVarsTestingListArgDesc :: String
 strROSAppVarsTestingListArgDesc =
   "Limit random input generation to these variables"
+
+-- | Error code for when a project cannot be read.
+cannotReadProject :: ErrorCode
+cannotReadProject = 1

--- a/ogma-cli/src/CLI/CommandStandalone.hs
+++ b/ogma-cli/src/CLI/CommandStandalone.hs
@@ -30,6 +30,9 @@ module CLI.CommandStandalone
   where
 
 -- External imports
+import Control.Applicative ((<|>))
+import Data.Functor        ((<&>))
+import Data.Maybe          (fromMaybe)
 import Options.Applicative (Parser, help, long, many, metavar, optional, short,
                             showDefault, strOption, switch, value)
 
@@ -40,12 +43,14 @@ import Data.Location  ( Location(..) )
 -- External imports: actions or commands supported
 import           Command.Standalone (ErrorCode)
 import qualified Command.Standalone
+import           Data.Project       (Project (..), readProject)
 
 -- * Command
 
 -- | Options to generate Copilot from specification.
 data CommandOpts = CommandOpts
-  { standaloneTargetDir     :: FilePath
+  { standaloneProject       :: Maybe String
+  , standaloneTargetDir     :: FilePath
   , standaloneTemplateDir   :: Maybe FilePath
   , standaloneConditionExpr :: Maybe String
   , standaloneInputFiles    :: [FilePath]
@@ -59,8 +64,15 @@ data CommandOpts = CommandOpts
 
 -- | Transform an input specification into a Copilot specification.
 command :: CommandOpts -> IO (Result ErrorCode)
-command c =
-    Command.Standalone.command internalCommandOpts
+command c
+    | Just p <- standaloneProject c
+    = do optE <- commandProjectOptions p c
+         case optE of
+           Left msg  -> return $ Error cannotReadProject msg (LocationFile p)
+           Right opt -> Command.Standalone.command opt
+
+    | otherwise
+    = Command.Standalone.command internalCommandOpts
   where
     internalCommandOpts :: Command.Standalone.CommandOptions
     internalCommandOpts = Command.Standalone.CommandOptions
@@ -77,8 +89,56 @@ command c =
       }
 
     types :: [(String, String)]
-    types = map splitTypeMapping (standaloneTypes c)
+    types = typeMapping (standaloneTypes c)
 
+-- | Produce command options based on project settings and user-provided
+-- command options.
+commandProjectOptions :: FilePath
+                      -> CommandOpts
+                      -> IO (Either String Command.Standalone.CommandOptions)
+commandProjectOptions projectFile c = do
+  projectE <- readProject projectFile
+  return $ projectE <&> \project ->
+    Command.Standalone.CommandOptions
+      { Command.Standalone.commandConditionExpr = standaloneConditionExpr c
+
+      , Command.Standalone.commandInputFiles = concat
+          [ map (\(f, _, _) -> f) $ projectInputFiles project
+          , standaloneInputFiles c
+          ]
+
+      , Command.Standalone.commandTargetDir =
+          fromMaybe (standaloneTargetDir c) (projectTargetDir project)
+
+      , Command.Standalone.commandTemplateDir =
+          projectTemplateDir project <|> standaloneTemplateDir c
+
+      , Command.Standalone.commandFormat =
+          case projectInputFiles project of
+            []            -> standaloneFormat c
+            ((_, f, _):_) -> f
+
+      , Command.Standalone.commandPropFormat =
+          case projectInputFiles project of
+            []            -> standalonePropFormat c
+            ((_, _, f):_) -> f
+
+      , Command.Standalone.commandPropVia =
+          projectCommandPropVia project <|> standalonePropVia c
+
+      , Command.Standalone.commandExtraVars =
+          projectExtraJSONFile project <|> standaloneTemplateVars c
+
+      , Command.Standalone.commandFilename = standaloneTarget c
+
+      , Command.Standalone.commandTypeMapping = typeMapping (standaloneTypes c)
+
+      }
+
+-- | Parse a list of type associations, where two types are separated by ':'.
+typeMapping :: [String] -> [(String, String)]
+typeMapping = map splitTypeMapping
+  where
     splitTypeMapping :: String -> (String, String)
     splitTypeMapping s = (h, safeTail t)
       where
@@ -96,7 +156,14 @@ commandDesc =
 -- specification from an input specification file.
 commandOptsParser :: Parser CommandOpts
 commandOptsParser = CommandOpts
-  <$> strOption
+  <$> optional
+        ( strOption
+            (  long "project"
+            <> metavar "FILENAME"
+            <> help strStandaloneProjectArgDesc
+            )
+        )
+  <*> strOption
         (  long "target-dir"
         <> metavar "DIR"
         <> showDefault
@@ -169,6 +236,10 @@ commandOptsParser = CommandOpts
             )
         )
 
+-- | Project flag description.
+strStandaloneProjectArgDesc :: String
+strStandaloneProjectArgDesc = "Project file"
+
 -- | Target dir flag description.
 strStandaloneTargetDirDesc :: String
 strStandaloneTargetDirDesc = "Target directory"
@@ -212,3 +283,7 @@ strStandalonePropViaDesc =
 strStandaloneTemplateVarsArgDesc :: String
 strStandaloneTemplateVarsArgDesc =
   "JSON file containing additional variables to expand in template"
+
+-- | Error code for when a project cannot be read.
+cannotReadProject :: ErrorCode
+cannotReadProject = 1

--- a/ogma-core/CHANGELOG.md
+++ b/ogma-core/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Add missing dependency to Cabal file (#458).
 * Adjust overview command to accept multiple input files (#456).
 * Add Copilot file from F Prime template to data-files in Cabal file (#462).
+* Add module defining Ogma projects (#460).
 
 ## [1.14.0] - 2026-05-21
 

--- a/ogma-core/ogma-core.cabal
+++ b/ogma-core/ogma-core.cabal
@@ -113,6 +113,7 @@ library
     Command.Standalone
 
     Data.Location
+    Data.Project
 
     Language.Trans.CStruct2CopilotStruct
     Language.Trans.CStructs2Copilot

--- a/ogma-core/src/Data/Project.hs
+++ b/ogma-core/src/Data/Project.hs
@@ -1,0 +1,55 @@
+{-# LANGUAGE DeriveGeneric #-}
+-- Copyright 2024 United States Government as represented by the Administrator
+-- of the National Aeronautics and Space Administration. All Rights Reserved.
+--
+-- Disclaimers
+--
+-- Licensed under the Apache License, Version 2.0 (the "License"); you may
+-- not use this file except in compliance with the License. You may obtain a
+-- copy of the License at
+--
+--      https://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+-- WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+-- License for the specific language governing permissions and limitations
+-- under the License.
+--
+-- | Ogma projects.
+module Data.Project where
+
+-- External imports
+import           Control.Exception (IOException, try)
+import           Data.Aeson        (FromJSON, ToJSON, eitherDecodeStrict')
+import qualified Data.ByteString   as BS
+import           GHC.Generics      (Generic)
+
+-- -- Internal imports
+import Data.Either.Extra (mapLeft)
+
+data Project = Project
+    { projectName           :: Maybe String
+    , projectInputFiles     :: [(FilePath, String, String)]
+                               -- ^ File, format name, prop name
+    , projectVariableFiles  :: Maybe FilePath
+    , projectVariableDBFile :: Maybe FilePath
+    , projectHandlerFile    :: Maybe FilePath
+    , projectCommandPropVia :: Maybe FilePath
+    , projectTemplateDir    :: Maybe FilePath
+    , projectTargetDir      :: Maybe FilePath
+    , projectExtraJSONFile  :: Maybe FilePath
+    }
+  deriving (Generic, Show)
+
+instance FromJSON Project
+instance ToJSON Project
+
+-- | Read a project from a file.
+readProject :: FilePath -> IO (Either String Project)
+readProject path = do
+  bytesResult <- try (BS.readFile path)
+  pure $ case bytesResult of
+           Left e      -> Left (show (e :: IOException))
+           Right bytes -> mapLeft ("Failed to read project: " ++)
+                        $ eitherDecodeStrict' bytes


### PR DESCRIPTION
Add module to `ogma-core` defining the notion of a project, and adjust the `overview`, `standalone` and app generation commands to support specifying a project via a CLI flag, as prescribed in the solution proposed for #460.