### PR TITLE
`ogma-core`: Add Copilot file from F Prime template to `data-files` in Cabal file. Refs #462.

### DIFF
--- a/ogma-core/CHANGELOG.md
+++ b/ogma-core/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Revision history for ogma-core
 
-## [1.X.Y] - 2026-06-26
+## [1.X.Y] - 2026-06-27
 
 * Remove commented code from `Data.Spec.Parser` (#430).
 * Remove redundant `where` block (#432).
@@ -13,6 +13,7 @@
 * Remove empty Haddock section heading from `Command.Diagram` (#450).
 * Add missing dependency to Cabal file (#458).
 * Adjust overview command to accept multiple input files (#456).
+* Add Copilot file from F Prime template to data-files in Cabal file (#462).
 
 ## [1.14.0] - 2026-05-21
 

--- a/ogma-core/ogma-core.cabal
+++ b/ogma-core/ogma-core.cabal
@@ -71,6 +71,7 @@ data-files:          templates/cfs/Dockerfile
                      templates/fprime/Copilot.cpp
                      templates/fprime/Copilot.fpp
                      templates/fprime/Copilot.hpp
+                     templates/fprime/Copilot.hs
                      templates/fprime/Dockerfile
                      templates/fprime/instance-copilot
                      templates/report/Report.md


### PR DESCRIPTION
Add `Copilot.hs` from F Prime template to the field `data-files` in `ogma-core`'s Cabal file, as prescribed in the solution proposed for #462.