### PR TITLE
`ogma-cli`: Add `search` command. Refs #464.

### DIFF
--- a/ogma-cli/CHANGELOG.md
+++ b/ogma-cli/CHANGELOG.md
@@ -1,12 +1,13 @@
 # Revision history for ogma-cli
 
-## [1.X.Y] - 2026-06-27
+## [1.X.Y] - 2026-06-28
 
 * Fix typo in README (#428).
 * Update CI job to install Copilot 4.7.1 by default (#446).
 * Fix style of record definitions, constructions in multiple commands (#454).
 * Adjust `overview` command to accept multiple input files (#456).
 * Adjust `overview`, `standalone`, app commands to support projects (#460).
+* Expose `search` command (#464).
 
 ## [1.14.0] - 2026-05-21
 

--- a/ogma-cli/ogma-cli.cabal
+++ b/ogma-cli/ogma-cli.cabal
@@ -78,6 +78,7 @@ description:         Ogma is a tool to facilitate the integration of safe runtim
                      >
                      >Available commands:
                      >  overview                 Generate an overview of the input specification(s)
+                     >  search                   List items that match search query
                      >  structs                  Generate Copilot structs from C structs
                      >  handlers                 Generate message handlers from C structs
                      >  cfs                      Generate a complete CFS/Copilot application

--- a/ogma-cli/ogma-cli.cabal
+++ b/ogma-cli/ogma-cli.cabal
@@ -134,6 +134,7 @@ executable ogma
     CLI.CommandOverview
     CLI.CommandReport
     CLI.CommandROSApp
+    CLI.CommandSearch
     CLI.CommandStandalone
     CLI.CommandTop
     CLI.Result

--- a/ogma-cli/src/CLI/CommandSearch.hs
+++ b/ogma-cli/src/CLI/CommandSearch.hs
@@ -1,0 +1,242 @@
+{-# LANGUAGE OverloadedStrings #-}
+-- Copyright 2020 United States Government as represented by the Administrator
+-- of the National Aeronautics and Space Administration. All Rights Reserved.
+--
+-- Disclaimers
+--
+-- Licensed under the Apache License, Version 2.0 (the "License"); you may
+-- not use this file except in compliance with the License. You may obtain a
+-- copy of the License at
+--
+--      https://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+-- WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+-- License for the specific language governing permissions and limitations
+-- under the License.
+--
+-- | CLI interface to the Search subcommand.
+module CLI.CommandSearch
+    (
+      -- * Direct command access
+      command
+    , CommandOpts
+    , ErrorCode
+
+      -- * CLI
+    , commandDesc
+    , commandOptsParser
+    )
+  where
+
+-- External imports
+import           Data.Aeson          (toJSON)
+import           Data.Functor        ((<&>))
+import qualified Data.Text.Lazy      as T
+import qualified Data.Text.Lazy.IO   as T
+import           Options.Applicative (Parser, help, long, many, metavar,
+                                      optional, short, showDefault, strOption,
+                                      value)
+import           Text.Microstache    (compileMustacheText, renderMustache)
+
+-- External imports: command results
+import Command.Result (Result (..))
+import Data.Location  (Location (..))
+
+-- External imports: actions or commands supported
+import           Command.Search (ErrorCode)
+import qualified Command.Search
+import           Data.Project   (Project (..), readProject)
+
+-- * Command
+
+-- | Options to generate an search from the input specification(s).
+data CommandOpts = CommandOpts
+  { searchProject    :: Maybe String
+  , searchQuery      :: String
+  , searchInputFiles :: [SearchFile]
+  }
+
+-- | Options associated to a specific input file.
+data SearchFile = SearchFile
+  { searchFilePath       :: FilePath
+  , searchFileFormat     :: String
+  , searchFilePropFormat :: String
+  , searchFilePropVia    :: Maybe String
+  }
+
+-- | Print an search of the input specification(s).
+command :: CommandOpts -> IO (Result ErrorCode)
+command c
+    | Just p <- searchProject c
+    = do optE <- commandProjectOptions p c
+         case optE of
+           Left msg  -> return $ Error cannotReadProject msg (LocationFile p)
+           Right opt -> do
+             (mOutput, result) <- Command.Search.command opt
+             case mOutput of
+               Just output ->
+                 case outputString of
+                   Right template ->
+                     T.putStr $ renderMustache template (toJSON output)
+                   _              -> putStrLn "Error"
+               _           -> putStrLn "Error"
+             return result
+
+     | otherwise
+     = do (mOutput, result) <-
+            Command.Search.command internalCommandOpts
+
+          case mOutput of
+            Just output ->
+              case outputString of
+                Right template ->
+                  T.putStr $ renderMustache template (toJSON output)
+                _              -> putStrLn "Error"
+            _           -> putStrLn "Error"
+          return result
+
+  where
+
+    internalCommandOpts :: Command.Search.CommandOptions
+    internalCommandOpts = Command.Search.CommandOptions
+      { Command.Search.commandInputFiles  = map fileInfo (searchInputFiles c)
+      , Command.Search.commandSearchQuery = searchQuery c
+      }
+
+    fileInfo f = Command.Search.SearchFile
+      { Command.Search.searchFilePath       = searchFilePath   f
+      , Command.Search.searchFileFormat     = searchFileFormat f
+      , Command.Search.searchFilePropFormat = searchFilePropFormat f
+      , Command.Search.searchFilePropVia    = searchFilePropVia f
+      }
+
+    outputString =
+      compileMustacheText "output" $ T.unlines
+        [ "{{#searchResultRequirements}}"
+        , "{{requirementInfoLocation}}: requirement \"{{requirementInfoName}}\" matches"
+        , "{{/searchResultRequirements}}"
+        , "{{#searchResultDiagrams}}"
+        , "{{diagramInfoLocation}}: diagram file matches"
+        , "{{/searchResultDiagrams}}"
+        ]
+
+-- | Produce command options based on project settings and user-provided
+-- command options.
+commandProjectOptions :: FilePath
+                      -> CommandOpts
+                      -> IO (Either String Command.Search.CommandOptions)
+commandProjectOptions projectFile c = do
+    projectE <- readProject projectFile
+    return $ projectE <&> \project ->
+      Command.Search.CommandOptions
+        { Command.Search.commandInputFiles = concat
+            [ map (convertProjectFile project) $ projectInputFiles project
+            , map convertInputFile $ searchInputFiles c
+            ]
+        , Command.Search.commandSearchQuery = searchQuery c
+        }
+
+  where
+
+    convertProjectFile project (fp, format, propFormat) =
+      Command.Search.SearchFile
+        { Command.Search.searchFilePath       = fp
+        , Command.Search.searchFileFormat     = format
+        , Command.Search.searchFilePropFormat = propFormat
+        , Command.Search.searchFilePropVia    =
+            projectCommandPropVia project
+        }
+    convertInputFile f = Command.Search.SearchFile
+      { Command.Search.searchFilePath       = searchFilePath   f
+      , Command.Search.searchFileFormat     = searchFileFormat f
+      , Command.Search.searchFilePropFormat = searchFilePropFormat f
+      , Command.Search.searchFilePropVia    = searchFilePropVia f
+      }
+
+-- * CLI
+
+-- | Command description for CLI help.
+commandDesc :: String
+commandDesc = "List items that match search query"
+
+-- | Subparser for the @search@ command, used to generate an search
+-- of the input specifications.
+commandOptsParser :: Parser CommandOpts
+commandOptsParser = CommandOpts
+  <$> optional
+        ( strOption
+            (  long "project"
+            <> metavar "FILENAME"
+            <> help strSearchProjectArgDesc
+            )
+        )
+  <*> strOption
+        (  long "query"
+        <> metavar "STRING"
+        <> help strSearchQueryArgDesc
+        )
+  <*> many searchFileOptsParser
+
+-- | Subparser for information on one input file to be used with the @search@
+-- command.
+searchFileOptsParser :: Parser SearchFile
+searchFileOptsParser = SearchFile
+  <$> strOption
+        (  long "input-file"
+        <> metavar "FILENAME"
+        <> help strSearchInputFileDesc
+        )
+  <*> strOption
+        (  long "input-format"
+        <> short 'f'
+        <> metavar "FORMAT_NAME"
+        <> help strSearchFormatDesc
+        <> showDefault
+        <> value "fcs"
+        )
+  <*> strOption
+        (  long "prop-format"
+        <> short 'p'
+        <> metavar "FORMAT_NAME"
+        <> help strSearchPropFormatDesc
+        <> showDefault
+        <> value "smv"
+        )
+  <*> optional
+        ( strOption
+            (  long "parse-prop-via"
+            <> metavar "COMMAND"
+            <> help strSearchPropViaDesc
+            )
+        )
+
+-- | Project flag description.
+strSearchProjectArgDesc :: String
+strSearchProjectArgDesc = "Project file"
+
+-- | Query flag description.
+strSearchQueryArgDesc :: String
+strSearchQueryArgDesc = "Search string"
+
+-- | Input file flag description.
+strSearchInputFileDesc :: String
+strSearchInputFileDesc = "File with properties or requirements"
+
+-- | Format flag description.
+strSearchFormatDesc :: String
+strSearchFormatDesc = "Format of the input file"
+
+-- | Property format flag description.
+strSearchPropFormatDesc :: String
+strSearchPropFormatDesc = "Format of temporal or boolean properties"
+
+-- | External command to pre-process individual properties.
+strSearchPropViaDesc :: String
+strSearchPropViaDesc =
+  "Command to pre-process individual properties"
+
+-- | Error code for when a project cannot be read.
+cannotReadProject :: ErrorCode
+cannotReadProject = 1

--- a/ogma-cli/src/CLI/CommandTop.hs
+++ b/ogma-cli/src/CLI/CommandTop.hs
@@ -81,6 +81,7 @@ import qualified CLI.CommandFPrimeApp
 import qualified CLI.CommandOverview
 import qualified CLI.CommandReport
 import qualified CLI.CommandROSApp
+import qualified CLI.CommandSearch
 import qualified CLI.CommandStandalone
 
 -- * Command
@@ -98,6 +99,7 @@ data CommandOpts =
   | CommandOptsFPrimeApp                 CLI.CommandFPrimeApp.CommandOpts
   | CommandOptsOverview                  CLI.CommandOverview.CommandOpts
   | CommandOptsROSApp                    CLI.CommandROSApp.CommandOpts
+  | CommandOptsSearch                    CLI.CommandSearch.CommandOpts
   | CommandOptsStandalone                CLI.CommandStandalone.CommandOpts
   | CommandOptsReport                    CLI.CommandReport.CommandOpts
 
@@ -112,6 +114,7 @@ commandDesc =
 commandOptsParser :: Parser CommandOpts
 commandOptsParser = subparser
   (  subcommandOverview
+  <> subcommandSearch
   <> subcommandCStructs
   <> subcommandMsgHandlers
   <> subcommandCFSApp
@@ -130,6 +133,15 @@ subcommandOverview =
     "overview"
     (CommandOptsOverview <$> CLI.CommandOverview.commandOptsParser)
     CLI.CommandOverview.commandDesc
+
+-- | Modifier for the search subcommand, linking the subcommand options and
+-- description to the command @search@ at top level.
+subcommandSearch :: Mod CommandFields CommandOpts
+subcommandSearch =
+  subcommand
+    "search"
+    (CommandOptsSearch <$> CLI.CommandSearch.commandOptsParser)
+    CLI.CommandSearch.commandDesc
 
 -- | Modifier for the CStruct to Copilot Struct generation subcommand, linking
 -- the subcommand options and description to the command @structs@ at top
@@ -240,6 +252,8 @@ command (CommandOptsOverview c) =
   id <$> CLI.CommandOverview.command c
 command (CommandOptsROSApp c) =
   id <$> CLI.CommandROSApp.command c
+command (CommandOptsSearch c) =
+  id <$> CLI.CommandSearch.command c
 command (CommandOptsStandalone c) =
   id <$> CLI.CommandStandalone.command c
 command (CommandOptsDiagram c) =

--- a/ogma-core/CHANGELOG.md
+++ b/ogma-core/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Revision history for ogma-core
 
-## [1.X.Y] - 2026-06-27
+## [1.X.Y] - 2026-06-28
 
 * Remove commented code from `Data.Spec.Parser` (#430).
 * Remove redundant `where` block (#432).
@@ -15,6 +15,7 @@
 * Adjust overview command to accept multiple input files (#456).
 * Add Copilot file from F Prime template to data-files in Cabal file (#462).
 * Add module defining Ogma projects (#460).
+* Introduce search command (#464).
 
 ## [1.14.0] - 2026-05-21
 

--- a/ogma-core/ogma-core.cabal
+++ b/ogma-core/ogma-core.cabal
@@ -110,6 +110,7 @@ library
     Command.Report
     Command.Result
     Command.ROSApp
+    Command.Search
     Command.Standalone
 
     Data.Location

--- a/ogma-core/src/Command/Search.hs
+++ b/ogma-core/src/Command/Search.hs
@@ -1,0 +1,199 @@
+{-# LANGUAGE DeriveGeneric #-}
+-- Copyright 2025 United States Government as represented by the Administrator
+-- of the National Aeronautics and Space Administration. All Rights Reserved.
+--
+-- Disclaimers
+--
+-- Licensed under the Apache License, Version 2.0 (the "License"); you may
+-- not use this file except in compliance with the License. You may obtain a
+-- copy of the License at
+--
+--      https://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing, software
+-- distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+-- WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+-- License for the specific language governing permissions and limitations
+-- under the License.
+--
+-- | Find elements in a project that meet a search query.
+module Command.Search
+    ( command
+    , CommandOptions(..)
+    , SearchFile(..)
+    , CommandSearchResults(..)
+    , RequirementInfo(..)
+    , DiagramInfo(..)
+    , ErrorCode
+    )
+  where
+
+-- External imports
+import Control.Monad        (foldM)
+import Control.Monad.Except (runExceptT)
+import Data.Aeson           (ToJSON (..))
+import Data.List            (isInfixOf)
+import GHC.Generics         (Generic)
+
+-- External imports: ogma
+import Data.OgmaSpec (Requirement (..), Spec (..))
+
+-- Internal imports
+import Command.Common (InputFile (..), parseInputFile)
+import Command.Errors (ErrorCode, ErrorTriplet (..))
+import Command.Result (Result (..))
+import Data.Diagram   (Diagram (..))
+import Data.ExprPair  (ExprPair (..), exprPair)
+import Data.Location  (Location (..))
+
+-- | Find elements in a project that meet a search query.
+command :: CommandOptions -- ^ Customization options
+        -> IO (Maybe CommandSearchResults, Result ErrorCode)
+command options = do
+    fs <- foldM
+            processFile
+            (Right emptyCommandSearchResults)
+            (commandInputFiles options)
+
+    return $ commandResult options fs
+
+  where
+
+    processFile :: Either (FilePath, String) CommandSearchResults
+                -> SearchFile
+                -> IO (Either (FilePath, String) CommandSearchResults)
+    processFile acc file = case acc of
+      Left _     -> return acc
+      Right acc' -> do
+        let functions = exprPair (searchFilePropFormat file)
+        c <- command' file functions (commandSearchQuery options)
+        case c of
+          Left msg -> return $ Left (searchFilePath file, msg)
+          Right s  -> return $ Right $ mergeCommandSearchResults acc' s
+
+-- | Find elements in a file that meet a search query.
+command' :: SearchFile
+         -> ExprPair
+         -> String
+         -> IO (Either String CommandSearchResults)
+command' file (ExprPair exprT) query = do
+    res <- runExceptT $
+             parseInputFile fp formatName propFormatName propVia exprT
+
+    case res of
+      Left (ErrorTriplet _ s _) -> return $ Left s
+
+      Right (InputFileDiagram diagramR) ->
+        return $ Right $ diagramResults fp diagramR query
+
+      Right (InputFileSpec spec) ->
+        return $ Right $ specResults fp spec query
+
+  where
+
+    fp             = searchFilePath file
+    formatName     = searchFileFormat file
+    propFormatName = searchFilePropFormat file
+    propVia        = searchFilePropVia file
+
+-- | Find elements in a spec that meet a search query.
+specResults :: FilePath -> Spec a -> String -> CommandSearchResults
+specResults file spec query = CommandSearchResults
+  { searchResultRequirements =
+      [ RequirementInfo file n d
+      | r <- requirements spec
+      , let n = requirementName r
+      , let d = requirementDescription r
+      , query `isInfixOf` n || query `isInfixOf` d
+      ]
+  , searchResultDiagrams = []
+  }
+
+-- | Find elements in a diagram that meet a search query.
+diagramResults :: FilePath -> Diagram -> String -> CommandSearchResults
+diagramResults file diagramR query = CommandSearchResults
+  { searchResultRequirements = []
+  , searchResultDiagrams =
+      [ DiagramInfo file
+      | any (\(f, t, d) -> query `isInfixOf` (show f)
+                        || query `isInfixOf` t
+                        || query `isInfixOf` (show d))
+        (diagramTransitions diagramR)
+      ]
+  }
+
+-- | Options used to customize the interpretation of input specifications.
+data CommandOptions = CommandOptions
+  { commandInputFiles  :: [ SearchFile ]
+  , commandSearchQuery :: String
+  }
+
+-- | Information about one file in the command options.
+data SearchFile = SearchFile
+  { searchFilePath       :: FilePath
+  , searchFileFormat     :: String
+  , searchFilePropFormat :: String
+  , searchFilePropVia    :: Maybe String
+  }
+
+-- | Lists of search results.
+data CommandSearchResults = CommandSearchResults
+    { searchResultRequirements :: [RequirementInfo]
+    , searchResultDiagrams     :: [DiagramInfo]
+    }
+  deriving (Generic, Show)
+
+instance ToJSON CommandSearchResults
+
+-- | Empty lists of search results.
+emptyCommandSearchResults :: CommandSearchResults
+emptyCommandSearchResults = CommandSearchResults
+  { searchResultRequirements = []
+  , searchResultDiagrams     = []
+  }
+
+-- | Merge lists of search results.
+mergeCommandSearchResults :: CommandSearchResults
+                          -> CommandSearchResults
+                          -> CommandSearchResults
+mergeCommandSearchResults c1 c2 = CommandSearchResults
+  { searchResultRequirements =
+      searchResultRequirements c1 ++ searchResultRequirements c2
+  , searchResultDiagrams =
+      searchResultDiagrams c1 ++ searchResultDiagrams c2
+  }
+
+-- | Information about a requirement that matches the search query.
+data RequirementInfo = RequirementInfo
+    { requirementInfoLocation    :: FilePath
+    , requirementInfoName        :: String
+    , requirementInfoDescription :: String
+    }
+  deriving (Generic, Show)
+
+instance ToJSON RequirementInfo
+
+-- | Information about a diagram that matches the search query.
+data DiagramInfo = DiagramInfo
+    { diagramInfoLocation :: FilePath
+    }
+  deriving (Generic, Show)
+
+instance ToJSON DiagramInfo
+
+-- * Error codes
+
+-- | Error: the input file cannot be read due to it being unreadable or the
+-- format being incorrect.
+ecSearchError :: ErrorCode
+ecSearchError = 1
+
+-- * Result
+
+-- | Process the result of the transformation function.
+commandResult :: CommandOptions
+              -> Either (FilePath, String) a
+              -> (Maybe a, Result ErrorCode)
+commandResult _options result = case result of
+  Left (fp, msg) -> (Nothing, Error ecSearchError msg (LocationFile fp))
+  Right t        -> (Just t,  Success)


### PR DESCRIPTION
Add search command to `ogma-core` and expose in `ogma-cli`, as prescribed in the solution proposed for #464.