### PR TITLE
`ogma-cli`: Fix links in documentation. Refs #468.

### DIFF
--- a/ogma-cli/CHANGELOG.md
+++ b/ogma-cli/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Revision history for ogma-cli
 
-## [1.X.Y] - 2026-06-30
+## [1.X.Y] - 2026-07-01
 
 * Fix typo in README (#428).
 * Update CI job to install Copilot 4.7.1 by default (#446).
@@ -9,6 +9,7 @@
 * Adjust `overview`, `standalone`, app commands to support projects (#460).
 * Expose `search` command (#464).
 * Fix syntax, grammatical errors in diagram tutorial (#466).
+* Fix links in documentation (#468).
 
 ## [1.14.0] - 2026-05-21
 

--- a/ogma-cli/src/Main.hs
+++ b/ogma-cli/src/Main.hs
@@ -15,14 +15,14 @@
 -- License for the specific language governing permissions and limitations
 -- under the License.
 --
--- | Ogma: Tool to interoperate between <https://cfs.gsfc.nasa.gov/ Copilot>
--- and other languages.
+-- | Ogma: Tool to interoperate between
+-- <https://github.com/Copilot-Language/copilot Copilot> and other languages.
 --
 -- Ogma is a tool to facilitate integration of safe runtime monitors into other
 -- systems. It takes information from a system created in a language (e.g.,
 -- Lustre) and produces specifications for the runtime verification
--- framework <https://cfs.gsfc.nasa.gov/ Copilot>. Currently, features
--- supported are:
+-- framework <https://github.com/Copilot-Language/copilot Copilot>. Currently,
+-- features supported are:
 --
 -- * Translation properties defined in structured natural language into
 -- corresponding expressions in Copilot.


### PR DESCRIPTION
Update two links in the documentation of `ogma-cli/src/Main.hs` to point to the Copilot project repository instead, as prescribed in the solution proposed for #468.