### PR TITLE
Remove unnecessary vertical space. Refs #470.

### DIFF
--- a/ogma-cli/CHANGELOG.md
+++ b/ogma-cli/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Revision history for ogma-cli
 
-## [1.X.Y] - 2026-07-01
+## [1.X.Y] - 2026-07-02
 
 * Fix typo in README (#428).
 * Update CI job to install Copilot 4.7.1 by default (#446).
@@ -10,6 +10,7 @@
 * Expose `search` command (#464).
 * Fix syntax, grammatical errors in diagram tutorial (#466).
 * Fix links in documentation (#468).
+* Remove unnecessary vertical space (#470).
 
 ## [1.14.0] - 2026-05-21
 

--- a/ogma-cli/README.md
+++ b/ogma-cli/README.md
@@ -52,7 +52,6 @@ verification framework that generates hard real-time C99 code.
 - [Acknowledgements](#acknowledgements)
 - [License](#license)
 
-
 # Installation
 <sup>[(Back to top)](#table-of-contents)</sup>
 
@@ -178,7 +177,6 @@ Like before, the `ogma` executable will be placed in the directory
 
 ## Troubleshooting
 <sup>[(Back to top)](#table-of-contents)</sup>
-
 
 Feel free to open an issue if you are unable to install Ogma following these
 instructions.

--- a/ogma-cli/src/CLI/CommandCFSApp.hs
+++ b/ogma-cli/src/CLI/CommandCFSApp.hs
@@ -259,7 +259,6 @@ strCFSAppFileNameArgDesc :: String
 strCFSAppFileNameArgDesc =
   "File containing input specification"
 
-
 -- | Argument variable list to cFS app generation command
 strCFSAppVarListArgDesc :: String
 strCFSAppVarListArgDesc =

--- a/ogma-core/CHANGELOG.md
+++ b/ogma-core/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Revision history for ogma-core
 
-## [1.X.Y] - 2026-06-28
+## [1.X.Y] - 2026-07-02
 
 * Remove commented code from `Data.Spec.Parser` (#430).
 * Remove redundant `where` block (#432).
@@ -16,6 +16,7 @@
 * Add Copilot file from F Prime template to data-files in Cabal file (#462).
 * Add module defining Ogma projects (#460).
 * Introduce search command (#464).
+* Remove unnecessary vertical space (#470).
 
 ## [1.14.0] - 2026-05-21
 

--- a/ogma-core/src/Command/CFSApp.hs
+++ b/ogma-core/src/Command/CFSApp.hs
@@ -145,7 +145,6 @@ command' options (ExprPair exprT) = do
       Just (InputFileDiagram _)  -> []
       Nothing                    -> specExtractExternalVariables Nothing
 
-
     defaultMonitors spec = case spec of
       Just (InputFileSpec spec') -> specExtractHandlers (Just spec')
       Just (InputFileDiagram _)  -> [ ("handler", Just "uint8_t" ) ]

--- a/ogma-core/src/Command/FPrimeApp.hs
+++ b/ogma-core/src/Command/FPrimeApp.hs
@@ -140,7 +140,6 @@ command' options (ExprPair exprT) = do
       Just (InputFileDiagram _)  -> []
       Nothing                    -> specExtractExternalVariables Nothing
 
-
     defaultMonitors spec = case spec of
       Just (InputFileSpec spec') -> specExtractHandlers (Just spec')
       Just (InputFileDiagram _)  -> [ ("handler", Just "uint8_t" ) ]

--- a/ogma-core/src/Command/ROSApp.hs
+++ b/ogma-core/src/Command/ROSApp.hs
@@ -153,7 +153,6 @@ command' options (ExprPair exprT) = do
       Just (InputFileDiagram _)  -> []
       Nothing                    -> specExtractExternalVariables Nothing
 
-
     defaultMonitors spec = case spec of
       Just (InputFileSpec spec') -> specExtractHandlers (Just spec')
       Just (InputFileDiagram _)  -> [ ("handler", Just "uint8_t" ) ]

--- a/ogma-core/src/Command/Standalone.hs
+++ b/ogma-core/src/Command/Standalone.hs
@@ -132,7 +132,6 @@ command' options (ExprPair exprT) = do
     readInputFile' f =
       parseInputFile f formatName propFormatName propVia exprT
 
-
 -- | Generate the data of a new standalone Copilot monitor that implements the
 -- spec, using a subexpression handler.
 commandLogic :: Maybe String

--- a/ogma-core/src/Data/Spec/Parser.hs
+++ b/ogma-core/src/Data/Spec/Parser.hs
@@ -155,8 +155,6 @@ readInputFile fp formatName propFormatName propVia exprT =
           Left e  -> return $ Left $ cannotOpenInputFile fp
           Right x -> return $ Right x
 
-
-
 -- | Exception handler to deal with the case in which the trigger expression
 -- cannot be understood.
 cannotReadConditionExpr :: String -> String -> ErrorTriplet

--- a/ogma-core/src/Language/Trans/Spec2Copilot.hs
+++ b/ogma-core/src/Language/Trans/Spec2Copilot.hs
@@ -125,7 +125,6 @@ spec2Copilot specName typeMaps exprTransform showExpr spec =
             reqBody subs = reqName ++ " = " ++
                              (showExpr (exprTransform subs (requirementExpr i)))
 
-
     -- Main specification triggers
     triggers :: String
     triggers = unlines' $ fmap reqTrigger (requirements spec)

--- a/ogma-language-xlsx/CHANGELOG.md
+++ b/ogma-language-xlsx/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Revision history for ogma-language-xlsx
 
+## [1.X.Y] - 2026-07-02
+
+* Remove unnecessary vertical space (#470).
+
 ## [1.14.0] - 2026-05-21
 
 * Version bump (1.14.0) (#425).

--- a/ogma-language-xlsx/ogma-language-xlsx.cabal
+++ b/ogma-language-xlsx/ogma-language-xlsx.cabal
@@ -57,7 +57,6 @@ library
 
     , ogma-spec >= 1.14.0 && < 1.15
 
-
   hs-source-dirs:
     src
 


### PR DESCRIPTION
Remove unnecessary vertical space, or consecutive empty lines, across all Haskell, Cabal or Markdown files in the codebase, as prescribed in the solution proposed for #470.