### PR TITLE
Allow using file name as requirement ID in JSON or YAML files. Refs #472.

### DIFF
--- a/ogma-core/CHANGELOG.md
+++ b/ogma-core/CHANGELOG.md
@@ -17,6 +17,7 @@
 * Add module defining Ogma projects (#460).
 * Introduce search command (#464).
 * Remove unnecessary vertical space (#470).
+* Allow using file name as requirement ID in JSON or YAML files (#472).
 
 ## [1.14.0] - 2026-05-21
 

--- a/ogma-core/src/Data/Spec/Parser.hs
+++ b/ogma-core/src/Data/Spec/Parser.hs
@@ -138,7 +138,8 @@ readInputFile fp formatName propFormatName propVia exprT =
                    content <- B.safeReadFile fp
                    case content of
                      Left e  -> return $ Left e
-                     Right b -> parseYAMLSpec wrapper yamlFormat (L.toStrict b)
+                     Right b ->
+                       parseYAMLSpec wrapper yamlFormat fp (L.toStrict b)
              | otherwise
              -> do let jsonFormat = read format
                    content <- B.safeReadFile fp
@@ -150,6 +151,7 @@ readInputFile fp formatName propFormatName propVia exprT =
                                        parseJSONSpec
                                          (wrapper)
                                          jsonFormat
+                                         fp
                                          v
         case res of
           Left e  -> return $ Left $ cannotOpenInputFile fp

--- a/ogma-core/src/Language/YAMLSpec/Parser.hs
+++ b/ogma-core/src/Language/YAMLSpec/Parser.hs
@@ -25,12 +25,14 @@ import           Control.Monad.IO.Class (liftIO)
 import           Data.Aeson             (Value (..))
 import           Data.Aeson.Key         (fromString)
 import qualified Data.Aeson.KeyMap      as M
+import           Data.Bifunctor         (first)
 import qualified Data.ByteString        as BS
 import           Data.Char              (isSpace)
 import           Data.List              (intercalate)
 import           Data.Text              (unpack)
 import qualified Data.Vector            as V
 import qualified Data.Yaml              as Y
+import           System.FilePath        (takeBaseName, takeFileName)
 
 -- External imports: ogma-spec
 import Data.Either.Extra (mapLeft)
@@ -47,7 +49,7 @@ data YAMLFormat = YAMLFormat
     , specExternalVarId         :: String
     , specExternalVarType       :: Maybe String
     , specRequirements          :: Maybe String
-    , specRequirementId         :: Maybe String
+    , specRequirementId         :: Maybe FieldSource
     , specRequirementDesc       :: Maybe String
     , specRequirementExpr       :: String
     , specRequirementResultType :: Maybe String
@@ -55,13 +57,33 @@ data YAMLFormat = YAMLFormat
     }
   deriving (Read)
 
+-- | Source used to populate the value of a field in a spec.
+data FieldSource
+    = Field String -- ^ A field of the YAML header
+    | FileName     -- ^ Filename with extension
+    | BaseName     -- ^ Filename without extension
+  deriving (Show)
+
+-- | Custom instance to read a 'FieldSource' that allows YAML field names to be
+-- written down as plain strings.
+instance Read FieldSource where
+  readsPrec prec str =
+    case lex str of
+      [("Field", rest)]    -> first Field <$> readsPrec prec rest
+      [("FileName", rest)] -> [(FileName, rest)]
+      [("BaseName", rest)] -> [(BaseName, rest)]
+      -- If it doesn't match a constructor, we attempt to read a string and
+      -- treat it as the name of a YAML field.
+      _                    -> first Field <$> readsPrec prec str
+
 -- | Parse a spec from a YAML file.
 parseYAMLSpec :: forall a
               .  (String -> IO (Either String a))
               -> YAMLFormat
+              -> FilePath
               -> BS.ByteString
               -> IO (Either String (Spec a))
-parseYAMLSpec parseExpr yamlFormat bs = runExceptT $ do
+parseYAMLSpec parseExpr yamlFormat filepath bs = runExceptT $ do
   value <- except $ mapLeft Y.prettyPrintParseException $ Y.decodeEither' bs
 
   let values :: [Value]
@@ -111,7 +133,14 @@ parseYAMLSpec parseExpr yamlFormat bs = runExceptT $ do
 
       requirementDef value = do
         let msg = "Requirement name"
-        reqId <- except $ maybe (Right "") (\e -> valueToString msg =<< (listToEither msg (objectFieldValues e value))) (specRequirementId yamlFormat)
+
+        -- Handle the case where the requirement ID is the file name, with or
+        -- without extension.
+        reqId <- case specRequirementId yamlFormat of
+          Nothing        -> return ""
+          Just FileName  -> return $ takeFileName filepath
+          Just BaseName  -> return $ takeBaseName filepath
+          Just (Field p) -> except $ valueToString msg =<< (listToEither msg (objectFieldValues p value))
 
         let msg = "Requirement expression"
         reqExpr <- except $ valueToString msg =<< listToEither msg (objectFieldValues (specRequirementExpr yamlFormat) value)

--- a/ogma-language-jsonspec/CHANGELOG.md
+++ b/ogma-language-jsonspec/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Revision history for ogma-language-jsonspec
 
+## [1.X.Y] - 2026-07-02
+
+* Allow using file name as requirement ID in JSON files (#472).
+
 ## [1.14.0] - 2026-05-21
 
 * Version bump (1.14.0) (#425).

--- a/ogma-language-jsonspec/ogma-language-jsonspec.cabal
+++ b/ogma-language-jsonspec/ogma-language-jsonspec.cabal
@@ -58,6 +58,7 @@ library
   build-depends:
       base                   >= 4.11.0.0 && < 5
     , aeson                  >= 2.0.0.0  && < 2.3
+    , filepath               >= 1.4.2    && < 1.6
     , jsonpath               >= 0.3      && < 0.4
     , text                   >= 1.2.3.1  && < 2.2
     , megaparsec             >= 8.0.0    && < 9.8

--- a/ogma-language-jsonspec/src/Language/JSONSpec/Parser.hs
+++ b/ogma-language-jsonspec/src/Language/JSONSpec/Parser.hs
@@ -34,6 +34,7 @@ import           Data.Text             (pack, unpack)
 import qualified Data.Text             as T
 import qualified Data.Text.Encoding    as T
 import qualified Data.Text.IO          as T
+import           System.FilePath       (takeBaseName, takeFileName)
 import           Text.Megaparsec       (eof, errorBundlePretty, parse)
 
 -- External imports: ogma-spec
@@ -48,13 +49,32 @@ data JSONFormat = JSONFormat
     , specExternalVarId         :: String
     , specExternalVarType       :: Maybe String
     , specRequirements          :: String
-    , specRequirementId         :: String
+    , specRequirementId         :: FieldSource
     , specRequirementDesc       :: Maybe String
     , specRequirementExpr       :: String
     , specRequirementResultType :: Maybe String
     , specRequirementResultExpr :: Maybe String
     }
   deriving (Read)
+
+-- | Source used to populate the value of a field in a spec.
+data FieldSource
+    = JSONPath String -- ^ JSON path
+    | FileName        -- ^ Filename with extension
+    | BaseName        -- ^ Filename without extension
+  deriving (Show)
+
+-- | Custom instance to read a 'FieldSource' that allows JSON paths to be
+-- written down as plain strings.
+instance Read FieldSource where
+  readsPrec prec str =
+    case lex str of
+      [("JSONPath", rest)] -> first JSONPath <$> readsPrec prec rest
+      [("FileName", rest)] -> [(FileName, rest)]
+      [("BaseName", rest)] -> [(BaseName, rest)]
+      -- If it doesn't match a constructor, we attempt to read a string and
+      -- treat it as a JSONPath.
+      _                    -> first JSONPath <$> readsPrec prec str
 
 data JSONFormatInternal = JSONFormatInternal
   { jfiInternalVars          :: Maybe [JSONPathElement]
@@ -65,12 +85,20 @@ data JSONFormatInternal = JSONFormatInternal
   , jfiExternalVarId         :: [JSONPathElement]
   , jfiExternalVarType       :: Maybe [JSONPathElement]
   , jfiRequirements          :: [JSONPathElement]
-  , jfiRequirementId         :: [JSONPathElement]
+  , jfiRequirementId         :: FieldSourceInternal
   , jfiRequirementDesc       :: Maybe [JSONPathElement]
   , jfiRequirementExpr       :: [JSONPathElement]
   , jfiRequirementResultType :: Maybe [JSONPathElement]
   , jfiRequirementResultExpr :: Maybe [JSONPathElement]
   }
+
+-- | Internal representation of the source used to populate the value of a
+-- field in a spec.
+data FieldSourceInternal
+    = FSIJSONPath [JSONPathElement] -- ^ JSON path
+    | FSIFileName                   -- ^ Filename with extension
+    | FSIBaseName                   -- ^ Filename without extension
+  deriving (Show)
 
 parseJSONFormat :: JSONFormat -> Either String JSONFormatInternal
 parseJSONFormat jsonFormat = do
@@ -82,7 +110,14 @@ parseJSONFormat jsonFormat = do
   jfi7  <- showErrors $ parseJSONPath $ pack $ specExternalVarId   jsonFormat
   jfi8  <- showErrorsM $ fmap (parseJSONPath . pack) $ specExternalVarType jsonFormat
   jfi9  <- showErrors $ parseJSONPath $ pack $ specRequirements    jsonFormat
-  jfi10 <- showErrors $ parseJSONPath $ pack $ specRequirementId   jsonFormat
+
+  -- Handle the case where the requirement ID is the file name, with or without
+  -- extension.
+  jfi10 <- case specRequirementId jsonFormat of
+    FileName   -> return FSIFileName
+    BaseName   -> return FSIBaseName
+    JSONPath p -> showErrors $ fmap FSIJSONPath $ parseJSONPath $ pack p
+
   jfi11 <- showErrorsM $ fmap (parseJSONPath . pack) $ specRequirementDesc jsonFormat
   jfi12 <- showErrors $ parseJSONPath $ pack $ specRequirementExpr jsonFormat
   jfi13 <- showErrorsM $ fmap (parseJSONPath . pack) $ specRequirementResultType jsonFormat
@@ -103,8 +138,8 @@ parseJSONFormat jsonFormat = do
              , jfiRequirementResultExpr = jfi14
              }
 
-parseJSONSpec :: (String -> IO (Either String a)) -> JSONFormat -> Value -> IO (Either String (Spec a))
-parseJSONSpec parseExpr jsonFormat value = runExceptT $ do
+parseJSONSpec :: (String -> IO (Either String a)) -> JSONFormat -> FilePath -> Value -> IO (Either String (Spec a))
+parseJSONSpec parseExpr jsonFormat filepath value = runExceptT $ do
   jsonFormatInternal <- except $ parseJSONFormat jsonFormat
 
   let values :: [Value]
@@ -154,7 +189,13 @@ parseJSONSpec parseExpr jsonFormat value = runExceptT $ do
       -- requirementDef :: Value -> Either String (Requirement a)
       requirementDef value = do
         let msg = "Requirement name"
-        reqId <- except $ valueToString msg =<< (listToEither msg (executeJSONPath (jfiRequirementId jsonFormatInternal) value))
+
+        -- Handle the case where the requirement ID is the file name, with or
+        -- without extension.
+        reqId <- case jfiRequirementId jsonFormatInternal of
+          FSIFileName   -> return $ takeFileName filepath
+          FSIBaseName   -> return $ takeBaseName filepath
+          FSIJSONPath p -> except $ valueToString msg =<< (listToEither msg (executeJSONPath p value))
 
         let msg = "Requirement expression"
         reqExpr <- except $ valueToString msg =<< (listToEither msg (executeJSONPath (jfiRequirementExpr jsonFormatInternal) value))


### PR DESCRIPTION
Modify both JSON and YAML format description types to allow for requirement ID to come from the file name, and adjust `ogma-core` to provide the filename to the JSON and YAML parsing functions, as prescribed in the solution proposed for #472.