### PR TITLE
Allow controlling when monitors are re-evaluated in cFS apps. Refs #474.

### DIFF
--- a/ogma-cli/CHANGELOG.md
+++ b/ogma-cli/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Revision history for ogma-cli
 
-## [1.X.Y] - 2026-07-02
+## [1.X.Y] - 2026-07-04
 
 * Fix typo in README (#428).
 * Update CI job to install Copilot 4.7.1 by default (#446).
@@ -11,6 +11,7 @@
 * Fix syntax, grammatical errors in diagram tutorial (#466).
 * Fix links in documentation (#468).
 * Remove unnecessary vertical space (#470).
+* Update variable DBs in examples to indicate which inputs are active (#474).
 
 ## [1.14.0] - 2026-05-21
 

--- a/ogma-cli/examples/cfs-001-hello-ogma/README.md
+++ b/ogma-cli/examples/cfs-001-hello-ogma/README.md
@@ -174,6 +174,7 @@ provided in a `db.json`, which, in our example, contains the following:
 { "inputs":
      [ { "name": "input_value"
        , "type": "int32_t"
+       , "active": true
        , "connections":
            [ { "scope": "cfs"
              , "topic": "SAMPLE_MID"
@@ -204,7 +205,9 @@ This file indicates that:
 - The variable `input_value` can be used as an input variable in an expression.
   Its basic type in C is just `int32_t`. When targeting cFS, its values will be
   published to the topic or message ID `SAMPLE_MID`, and the value will
-  specifically be in the field `payload`.
+  specifically be in the field `payload`. The variable is `active`, meaning
+  that a change to the value of the variable will trigger a re-evaluation of
+  the Copilot monitors.
 
 - When targeting cFS, data published to the topic `SAMPLE_MID` is a message
   of type `sample_msg_t`.

--- a/ogma-cli/examples/cfs-001-hello-ogma/db.json
+++ b/ogma-cli/examples/cfs-001-hello-ogma/db.json
@@ -1,6 +1,7 @@
 { "inputs":
      [ { "name": "input_value"
        , "type": "int32_t"
+       , "active": true
        , "connections":
            [ { "scope": "cfs"
              , "topic": "SAMPLE_MID"

--- a/ogma-cli/examples/cfs-variable-db.json
+++ b/ogma-cli/examples/cfs-variable-db.json
@@ -1,6 +1,7 @@
 { "inputs":
      [ { "name": "position"
        , "type": "position_t"
+       , "active": true
        , "connections":
            [ { "scope": "cfs"
              , "topic": "ICAROUS_POSITION_MID"
@@ -9,6 +10,7 @@
        }
      , { "name": "velocity"
        , "type": "velocity_t"
+       , "active": true
        , "connections":
            [ { "scope": "cfs"
              , "topic": "ICAROUS_VELOCITY_MID"

--- a/ogma-cli/examples/ros-copilot/vars-db.json
+++ b/ogma-cli/examples/ros-copilot/vars-db.json
@@ -1,6 +1,7 @@
 { "inputs":
      [ { "name": "input_signal"
        , "type": "int64_t"
+       , "active": true
        , "connections":
            [ { "scope": "ros/message"
              , "topic": "/demo/topic"
@@ -9,6 +10,7 @@
        }
      , { "name": "input_signal_float"
        , "type": "float"
+       , "active": true
        , "connections":
            [ { "scope": "ros/message"
              , "topic": "/demo/topicf"
@@ -17,6 +19,7 @@
        }
      , { "name": "input_signal_double"
        , "type": "double"
+       , "active": true
        , "connections":
            [ { "scope": "ros/message"
              , "topic": "/demo/topicd"

--- a/ogma-cli/examples/ros2-001-hello-ogma/README.md
+++ b/ogma-cli/examples/ros2-001-hello-ogma/README.md
@@ -155,6 +155,7 @@ provided in a `db.json`, which, in our example, contains the following:
 { "inputs":
      [ { "name": "input_value"
        , "type": "int32_t"
+       , "active": true
        , "connections":
            [ { "scope": "ros/message"
              , "topic": "/ros2/example1"

--- a/ogma-cli/examples/ros2-001-hello-ogma/db.json
+++ b/ogma-cli/examples/ros2-001-hello-ogma/db.json
@@ -1,6 +1,7 @@
 { "inputs":
      [ { "name": "input_value"
        , "type": "int32_t"
+       , "active": true
        , "connections":
            [ { "scope": "ros/message"
              , "topic": "/ros2/example1"

--- a/ogma-core/CHANGELOG.md
+++ b/ogma-core/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Revision history for ogma-core
 
-## [1.X.Y] - 2026-07-02
+## [1.X.Y] - 2026-07-04
 
 * Remove commented code from `Data.Spec.Parser` (#430).
 * Remove redundant `where` block (#432).
@@ -18,6 +18,7 @@
 * Introduce search command (#464).
 * Remove unnecessary vertical space (#470).
 * Allow using file name as requirement ID in JSON or YAML files (#472).
+* Allow controlling when monitors are re-evaluated in cFS apps (#474).
 
 ## [1.14.0] - 2026-05-21
 

--- a/ogma-core/src/Command/CFSApp.hs
+++ b/ogma-core/src/Command/CFSApp.hs
@@ -57,7 +57,7 @@ import Command.Common
 import Command.Errors     (ErrorCode, ErrorTriplet (..))
 import Command.VariableDB (Connection (..), TopicDef (..), TypeDef (..),
                            VariableDB, findConnection, findInput, findTopic,
-                           findType, findTypeByType)
+                           findType, findTypeByType, inputActive)
 import Data.Aeson.Extra   (mergeObjects)
 import Data.ExprPair      (ExprPair(..), exprPair)
 import Data.Location      (Location (..))
@@ -215,6 +215,8 @@ variableMap varDB varName = do
   let typeMsgFromType  = typeFromType <$> typeDef
       typeMsgFromField = typeFromField =<< typeDef
 
+      active = inputActive inputDef
+
   let typeVar' = fromMaybe (topicType topicDef) (typeToType <$> typeDef)
 
   -- Pick name for the function to process a message ID.
@@ -223,7 +225,7 @@ variableMap varDB varName = do
   return ( VarDecl varName typeVar'
          , mid
          , MsgInfo mid mn
-         , MsgData mn typeMsgFromType typeMsgFromField varName typeVar'
+         , MsgData mn typeMsgFromType typeMsgFromField varName typeVar' active
          )
 
 -- | Return the monitor information needed to generate declarations and
@@ -267,6 +269,7 @@ data MsgData = MsgData
     , msgDataFromField :: Maybe String
     , msgDataVarName   :: String
     , msgDataVarType   :: String
+    , msgDataActive    :: Bool
     }
   deriving (Generic)
 

--- a/ogma-core/src/Command/VariableDB.hs
+++ b/ogma-core/src/Command/VariableDB.hs
@@ -64,6 +64,7 @@ data VariableDB = VariableDB
 data InputDef = InputDef
     { inputName        :: String
     , inputType        :: Maybe String
+    , inputActive      :: Bool
     , inputConnections :: [ Connection ]
     }
   deriving (Eq, Show)

--- a/ogma-core/templates/cfs/copilot/fsw/platform_inc/copilot_cfs_msgids.h
+++ b/ogma-core/templates/cfs/copilot/fsw/platform_inc/copilot_cfs_msgids.h
@@ -12,9 +12,10 @@
 #ifndef _copilot_cfs_msgids_h_
 #define _copilot_cfs_msgids_h_
 
-#define COPILOT_CFS_CMD_MID     0x1882
-#define COPILOT_CFS_SEND_HK_MID 0x1883
-#define COPILOT_CFS_HK_TLM_MID  0x0883
+#define COPILOT_CFS_CMD_MID        0x1882
+#define COPILOT_CFS_REEVAL_CMD_MID 0x1883
+#define COPILOT_CFS_SEND_HK_MID    0x1884
+#define COPILOT_CFS_HK_TLM_MID     0x0883
 
 #endif /* _copilot_cfs_msgids_h_ */
 

--- a/ogma-core/templates/cfs/copilot/fsw/src/copilot_cfs.c
+++ b/ogma-core/templates/cfs/copilot/fsw/src/copilot_cfs.c
@@ -176,8 +176,10 @@ void COPILOT_Process{{msgDataDesc}}(void)
     {{msgDataVarName}} = *msg;
     {{/msgDataFromField}}
 
+    {{#msgDataActive}}
     // Run all copilot monitors.
     copilot_step();
+    {{/msgDataActive}}
 }
 
 {{/msgHandlers}}

--- a/ogma-core/templates/cfs/copilot/fsw/src/copilot_cfs.c
+++ b/ogma-core/templates/cfs/copilot/fsw/src/copilot_cfs.c
@@ -106,7 +106,7 @@ void COPILOT_AppInit(void)
     {{#msgIds}}
     CFE_SB_Subscribe({{.}}, COPILOT_CommandPipe);
     {{/msgIds}}
-
+    CFE_SB_Subscribe(COPILOT_CFS_REEVAL_CMD_MID, COPILOT_CommandPipe);
 
     CFE_EVS_SendEvent (COPILOT_STARTUP_INF_EID, CFE_EVS_INFORMATION,
                "COPILOT App Initialized. Version %d.%d.%d.%d",
@@ -139,6 +139,10 @@ void COPILOT_ProcessCommandPacket(void)
             break;
 
         {{/msgCases}}
+
+        case COPILOT_CFS_REEVAL_CMD_MID:
+            copilot_step();
+            break;
 
         default:
             COPILOT_HkTelemetryPkt.copilot_command_error_count++;


### PR DESCRIPTION
Adjust the variable DB format to include which input variables should trigger re-evaluation of the monitors, making use of that information in cFS applications and updating examples accordingly, as prescribed in the solution proposed for #474 .