### PR TITLE
Extend cFS backend with support for diagram mode. Refs #476.

### DIFF
--- a/ogma-cli/CHANGELOG.md
+++ b/ogma-cli/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Revision history for ogma-cli
 
-## [1.X.Y] - 2026-07-04
+## [1.X.Y] - 2026-07-05
 
 * Fix typo in README (#428).
 * Update CI job to install Copilot 4.7.1 by default (#446).
@@ -12,6 +12,7 @@
 * Fix links in documentation (#468).
 * Remove unnecessary vertical space (#470).
 * Update variable DBs in examples to indicate which inputs are active (#474).
+* Expose diagram mode argument to cFS backend (#476).
 
 ## [1.14.0] - 2026-05-21
 

--- a/ogma-cli/src/CLI/CommandCFSApp.hs
+++ b/ogma-cli/src/CLI/CommandCFSApp.hs
@@ -61,6 +61,7 @@ data CommandOpts = CommandOpts
   , cFSAppFormat        :: String
   , cFSAppPropFormat    :: String
   , cFSAppPropVia       :: Maybe String
+  , cFSAppDiagramMode   :: String
   , cFSAppTemplateVars  :: Maybe String
   }
 
@@ -90,6 +91,7 @@ command c
         , Command.CFSApp.commandFormat        = cFSAppFormat c
         , Command.CFSApp.commandPropFormat    = cFSAppPropFormat c
         , Command.CFSApp.commandPropVia       = cFSAppPropVia c
+        , Command.CFSApp.commandDiagramMode   = cFSAppDiagramMode c
         , Command.CFSApp.commandExtraVars     = cFSAppTemplateVars c
         }
 
@@ -133,6 +135,8 @@ commandProjectOptions projectFile c = do
 
       , Command.CFSApp.commandPropVia =
           projectCommandPropVia project <|> cFSAppPropVia c
+
+      , Command.CFSApp.commandDiagramMode = cFSAppDiagramMode c
 
       , Command.CFSApp.commandExtraVars =
           projectExtraJSONFile project <|> cFSAppTemplateVars c
@@ -228,6 +232,13 @@ commandOptsParser = CommandOpts
             <> help strCFSAppPropViaDesc
             )
         )
+  <*> strOption
+        (  long "mode"
+        <> metavar "MODE"
+        <> help strCFSAppDiagramModeDesc
+        <> showDefault
+        <> value "calculate"
+        )
   <*> optional
         ( strOption
             (  long "template-vars"
@@ -286,6 +297,11 @@ strCFSAppPropFormatDesc = "Format of temporal or boolean properties"
 strCFSAppPropViaDesc :: String
 strCFSAppPropViaDesc =
   "Command to pre-process individual properties"
+
+-- | Mode name flag description.
+strCFSAppDiagramModeDesc :: String
+strCFSAppDiagramModeDesc =
+  "Mode of operation for diagrams (check, calculate, safeguard)"
 
 -- | Argument template variables to cFS app generation command
 strCFSAppTemplateVarsArgDesc :: String

--- a/ogma-core/CHANGELOG.md
+++ b/ogma-core/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Revision history for ogma-core
 
-## [1.X.Y] - 2026-07-04
+## [1.X.Y] - 2026-07-05
 
 * Remove commented code from `Data.Spec.Parser` (#430).
 * Remove redundant `where` block (#432).
@@ -19,6 +19,7 @@
 * Remove unnecessary vertical space (#470).
 * Allow using file name as requirement ID in JSON or YAML files (#472).
 * Allow controlling when monitors are re-evaluated in cFS apps (#474).
+* Extend cFS backend with diagram mode (#476).
 
 ## [1.14.0] - 2026-05-21
 

--- a/ogma-core/src/Command/CFSApp.hs
+++ b/ogma-core/src/Command/CFSApp.hs
@@ -38,7 +38,8 @@ module Command.CFSApp
 -- External imports
 import           Control.Applicative    ( liftA2, (<|>) )
 import qualified Control.Exception      as E
-import           Control.Monad.Except   ( ExceptT (..), liftEither )
+import           Control.Monad.Except   ( ExceptT (..), liftEither,
+                                          throwError )
 import           Data.Aeson             ( ToJSON (..) )
 import           Data.Maybe             ( fromMaybe, mapMaybe, maybeToList )
 import           GHC.Generics           ( Generic )
@@ -54,14 +55,16 @@ import System.Directory.Extra ( copyTemplate )
 
 -- Internal imports
 import Command.Common
-import Command.Errors     (ErrorCode, ErrorTriplet (..))
-import Command.VariableDB (Connection (..), TopicDef (..), TypeDef (..),
-                           VariableDB, findConnection, findInput, findTopic,
-                           findType, findTypeByType, inputActive)
-import Data.Aeson.Extra   (mergeObjects)
-import Data.ExprPair      (ExprPair(..), exprPair)
-import Data.Location      (Location (..))
-import Data.Spec.Parser   (readInputExpr)
+import Command.Errors                 (ErrorCode, ErrorTriplet (..))
+import Command.VariableDB             (Connection (..), TopicDef (..),
+                                       TypeDef (..), VariableDB, findConnection,
+                                       findInput, findTopic, findType,
+                                       findTypeByType, inputActive)
+import Data.Aeson.Extra               (mergeObjects)
+import Data.ExprPair                  (ExprPair (..), exprPair)
+import Data.Location                  (Location (..))
+import Data.Spec.Parser               (readInputExpr)
+import Language.Trans.Diagram2Copilot (DiagramMode (..))
 
 -- | Generate a new CFS application connected to Copilot.
 command :: CommandOptions
@@ -110,7 +113,9 @@ command' options (ExprPair exprT) = do
 
     liftEither $ checkArguments spec vs rs
 
-    copilotM <- sequenceA $ (\spec' -> processSpec spec' cExpr fpA) <$> spec
+    mode <- parseDiagramMode (commandDiagramMode options)
+
+    copilotM <- sequenceA $ (\spec' -> processSpec spec' cExpr fpA mode) <$> spec
 
     let varNames = fromMaybe (defaultVarNames spec) vs
         monitors = maybe (defaultMonitors spec) (map (\x -> (x, Nothing))) rs
@@ -137,8 +142,8 @@ command' options (ExprPair exprT) = do
     readInputFile' f =
       parseInputFile f formatName propFormatName propVia exprT
 
-    processSpec spec' expr' fp' =
-      Command.Standalone.commandLogic expr' fp' "copilot" [] exprT spec'
+    processSpec spec' expr' fp' mode =
+      Command.Standalone.commandLogic expr' fp' "copilot" [] exprT spec' mode
 
     defaultVarNames spec = case spec of
       Just (InputFileSpec spec') -> specExtractExternalVariables (Just spec')
@@ -149,6 +154,11 @@ command' options (ExprPair exprT) = do
       Just (InputFileSpec spec') -> specExtractHandlers (Just spec')
       Just (InputFileDiagram _)  -> [ ("handler", Just "uint8_t" ) ]
       Nothing                    -> specExtractHandlers Nothing
+
+    parseDiagramMode :: String -> ExceptT ErrorTriplet IO DiagramMode
+    parseDiagramMode "check"     = return CheckState
+    parseDiagramMode "calculate" = return ComputeState
+    parseDiagramMode mode        = throwError $ commandWrongDiagramMode mode
 
 -- | Generate a variable substitution map for a cFS application.
 commandLogic :: VariableDB
@@ -195,6 +205,7 @@ data CommandOptions = CommandOptions
   , commandPropFormat  :: String         -- ^ Format used for input properties.
   , commandPropVia     :: Maybe String   -- ^ Use external command to
                                          -- pre-process system properties.
+  , commandDiagramMode :: String         -- ^ Diagram mode.
   , commandExtraVars   :: Maybe FilePath -- ^ File containing additional
                                          -- variables to make available to the
                                          -- template.
@@ -310,3 +321,16 @@ commandMultipleInputTypes =
 -- | Error: multiple inputs of incompatible types.
 ecMultipleInputTypes :: ErrorCode
 ecMultipleInputTypes = 1
+
+-- | Error message associated to providing a diagram mode not supported by the
+-- cFS backend.
+commandWrongDiagramMode :: String -> ErrorTriplet
+commandWrongDiagramMode mode =
+    ErrorTriplet ecWrongDiagramMode msg LocationNothing
+  where
+    msg = "The diagram mode provided " ++ show mode ++ " is not known or is "
+       ++ "not supported by this backend."
+
+-- | Error: wrong diagram mode.
+ecWrongDiagramMode :: ErrorCode
+ecWrongDiagramMode = 1

--- a/ogma-core/src/Command/FPrimeApp.hs
+++ b/ogma-core/src/Command/FPrimeApp.hs
@@ -49,13 +49,14 @@ import Command.Result (Result (..))
 
 -- Internal imports
 import Command.Common
-import Command.Errors     (ErrorCode, ErrorTriplet (..))
-import Command.VariableDB (InputDef (..), TypeDef (..), VariableDB, findInput,
-                           findType, findTypeByType)
-import Data.Aeson.Extra   (mergeObjects)
-import Data.ExprPair      (ExprPair(..), exprPair)
-import Data.Location      (Location (..))
-import Data.Spec.Parser   (readInputExpr)
+import Command.Errors                 (ErrorCode, ErrorTriplet (..))
+import Command.VariableDB             (InputDef (..), TypeDef (..), VariableDB,
+                                       findInput, findType, findTypeByType)
+import Data.Aeson.Extra               (mergeObjects)
+import Data.ExprPair                  (ExprPair (..), exprPair)
+import Data.Location                  (Location (..))
+import Data.Spec.Parser               (readInputExpr)
+import Language.Trans.Diagram2Copilot (DiagramMode (..))
 
 -- | Generate a new FPrime component connected to Copilot.
 command :: CommandOptions -- ^ Options to the ROS backend.
@@ -133,7 +134,14 @@ command' options (ExprPair exprT) = do
       parseInputFile f formatName propFormatName propVia exprT
 
     processSpec spec' expr' fp' =
-      Command.Standalone.commandLogic expr' fp' "copilot" [] exprT spec'
+      Command.Standalone.commandLogic
+        expr'
+        fp'
+        "copilot"
+        []
+        exprT
+        spec'
+        ComputeState
 
     defaultVarNames spec = case spec of
       Just (InputFileSpec spec') -> specExtractExternalVariables (Just spec')

--- a/ogma-core/src/Command/ROSApp.hs
+++ b/ogma-core/src/Command/ROSApp.hs
@@ -53,14 +53,16 @@ import Command.Result (Result (..))
 
 -- Internal imports
 import Command.Common
-import Command.Errors     (ErrorCode, ErrorTriplet (..))
-import Command.VariableDB (Connection (..), InputDef (..), TopicDef (..),
-                           TypeDef (..), VariableDB, findConnection, findInput,
-                           findTopic, findType, findTypeByType)
-import Data.Aeson.Extra   (mergeObjects)
-import Data.ExprPair      (ExprPair(..), exprPair)
-import Data.Location      (Location (..))
-import Data.Spec.Parser   (readInputExpr)
+import Command.Errors                 (ErrorCode, ErrorTriplet (..))
+import Command.VariableDB             (Connection (..), InputDef (..),
+                                       TopicDef (..), TypeDef (..), VariableDB,
+                                       findConnection, findInput, findTopic,
+                                       findType, findTypeByType)
+import Data.Aeson.Extra               (mergeObjects)
+import Data.ExprPair                  (ExprPair (..), exprPair)
+import Data.Location                  (Location (..))
+import Data.Spec.Parser               (readInputExpr)
+import Language.Trans.Diagram2Copilot (DiagramMode (..))
 
 -- | Generate a new ROS application connected to Copilot.
 command :: CommandOptions -- ^ Options to the ROS backend.
@@ -146,7 +148,14 @@ command' options (ExprPair exprT) = do
       parseInputFile f formatName propFormatName propVia exprT
 
     processSpec spec' expr' fp' =
-      Command.Standalone.commandLogic expr' fp' "copilot" [] exprT spec'
+      Command.Standalone.commandLogic
+        expr'
+        fp'
+        "copilot"
+        []
+        exprT
+        spec'
+        ComputeState
 
     defaultVarNames spec = case spec of
       Just (InputFileSpec spec') -> specExtractExternalVariables (Just spec')

--- a/ogma-core/src/Command/Standalone.hs
+++ b/ogma-core/src/Command/Standalone.hs
@@ -115,7 +115,8 @@ command' options (ExprPair exprT) = do
 
     case spec of
       Nothing    -> liftEither $ Left $ commandMissingSpec
-      Just spec' -> commandLogic triggerExprM fpA name typeMaps exprT spec'
+      Just spec' ->
+        commandLogic triggerExprM fpA name typeMaps exprT spec' ComputeState
 
   where
     triggerExprM   = commandConditionExpr options
@@ -140,13 +141,14 @@ commandLogic :: Maybe String
              -> [(String, String)]
              -> ExprPairT a
              -> InputFile a
+             -> DiagramMode
              -> ExceptT ErrorTriplet IO AppData
-commandLogic expr fps name typeMaps exprT (InputFileDiagram d) =
+commandLogic expr fps name typeMaps exprT (InputFileDiagram d) mode =
     return $ AppData [] int [] trigs name
   where
-    (int, trigs) = diagram2CopilotSpec d ComputeState
+    (int, trigs) = diagram2CopilotSpec d mode
 
-commandLogic expr fps name typeMaps exprT (InputFileSpec input) =
+commandLogic expr fps name typeMaps exprT (InputFileSpec input) _mode =
 
     liftEither appData
 


### PR DESCRIPTION
Extend standalone command logic and cFS backend to receive diagram mode as argument, adjust ROS and F Prime backends accordingly, and expose the new argument to the cFS backend in the CLI, as prescribed in the solution proposed for #476.