### PR TITLE
`ogma-cli`: Add example containing Doorstop requirements. Refs #480.

### DIFF
--- a/ogma-cli/CHANGELOG.md
+++ b/ogma-cli/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Revision history for ogma-cli
 
-## [1.X.Y] - 2026-07-05
+## [1.X.Y] - 2026-07-06
 
 * Fix typo in README (#428).
 * Update CI job to install Copilot 4.7.1 by default (#446).
@@ -14,6 +14,7 @@
 * Update variable DBs in examples to indicate which inputs are active (#474).
 * Expose diagram mode argument to cFS backend (#476).
 * Add example explaining cFS app generation from state machine diagrams (#478).
+* Add example containing Doorstop requirements (#480).
 
 ## [1.14.0] - 2026-05-21
 

--- a/ogma-cli/examples/doorstop/.doorstop.yml
+++ b/ogma-cli/examples/doorstop/.doorstop.yml
@@ -1,0 +1,5 @@
+settings:
+  digits: 3
+  itemformat: yaml
+  prefix: REQ
+  sep: ''

--- a/ogma-cli/examples/doorstop/README.md
+++ b/ogma-cli/examples/doorstop/README.md
@@ -1,0 +1,36 @@
+# Generating monitors from Doorstop requirements
+
+This directory contains two requirements generated using Doorstop. The
+requirements contain a description, and a manually added formula that
+formalizes the requirement in the language
+[Copilot](https://github.com/Copilot-Language/copilot/).
+
+> For an alternative, more natural representation of requirements using a
+> parenthesized form of EARS, see `ogma-cli/examples/snl-pears`. To rely on an
+> LLM or an external translator to automatically convert requirements in plain
+> English into some formal notation, consider using the parameter
+> `--parse-prop-via` when invoking `ogma`.
+
+To generate monitors from the Doorstop requirements included in this directory,
+run, from the top level directory of a clone of the `ogma` repository:
+
+```sh
+ogma standalone --project ogma-cli/examples/doorstop/project.ogma
+```
+
+That call will generate a `monitor` directory with a Copilot spec in a file
+`Copilot.hs`. The spec constitutes a formally verifiable executable
+implementation of the properties specified in Doorstop in the files
+`REQ001.yml` and `REQ002.yml`.
+
+Alternatively, you can generate the same spec with the following command:
+
+```sh
+ogma standalone \
+  --input-format ogma-cli/examples/doorstop/doorstop-with-formula.cfg \
+  --prop-format literal \
+  --input-file ogma-cli/examples/doorstop/REQ001.yml \
+  --input-file ogma-cli/examples/doorstop/REQ002.yml \
+  --template-vars ogma-cli/examples/doorstop/extra-vars-yaml.json \
+  --target-dir monitor
+```

--- a/ogma-cli/examples/doorstop/REQ001.yml
+++ b/ogma-cli/examples/doorstop/REQ001.yml
@@ -1,0 +1,10 @@
+active: true
+derived: false
+header: ''
+level: 1.0
+links: []
+normative: true
+ref: ''
+reviewed: null
+text: 'The temperature shall always be lower than or equal to 180 degrees'
+formula: 'temperature <= 180'

--- a/ogma-cli/examples/doorstop/REQ002.yml
+++ b/ogma-cli/examples/doorstop/REQ002.yml
@@ -1,0 +1,10 @@
+active: true
+derived: false
+header: ''
+level: 1.1
+links: []
+normative: true
+ref: ''
+reviewed: null
+text: 'The temperature shall always be greater than or equal to 120 degrees'
+formula: 'temperature >= 120'

--- a/ogma-cli/examples/doorstop/doorstop-with-formula.cfg
+++ b/ogma-cli/examples/doorstop/doorstop-with-formula.cfg
@@ -1,0 +1,15 @@
+YAMLFormat
+  { specInternalVars          = Nothing
+  , specInternalVarId         = "id"
+  , specInternalVarExpr       = "expr"
+  , specInternalVarType       = Nothing
+  , specExternalVars          = Nothing
+  , specExternalVarId         = "id"
+  , specExternalVarType       = Nothing
+  , specRequirements          = Nothing
+  , specRequirementId         = Just BaseName
+  , specRequirementDesc       = Just "text"
+  , specRequirementExpr       = "formula"
+  , specRequirementResultType = Nothing
+  , specRequirementResultExpr = Nothing
+  }

--- a/ogma-cli/examples/doorstop/extra-vars-yaml.json
+++ b/ogma-cli/examples/doorstop/extra-vars-yaml.json
@@ -1,0 +1,6 @@
+{ "copilot_extra_defs": [
+    "temperature :: Stream Int8"
+  , "temperature = extern \"temperature\" Nothing"
+  , ""
+  ]
+}

--- a/ogma-cli/examples/doorstop/project.ogma
+++ b/ogma-cli/examples/doorstop/project.ogma
@@ -1,0 +1,22 @@
+{
+  "projectName": "Doorstop demo",
+  "projectInputFiles": [
+    [
+      "ogma-cli/examples/doorstop/REQ001.yml",
+      "ogma-cli/examples/doorstop/doorstop-with-formula.cfg",
+      "literal"
+    ]
+  , [
+      "ogma-cli/examples/doorstop/REQ002.yml",
+      "ogma-cli/examples/doorstop/doorstop-with-formula.cfg",
+      "literal"
+    ]
+  ],
+  "projectVariableFiles": null,
+  "projectVariableDBFile": null,
+  "projectHandlerFile": null,
+  "projectCommandPropVia": null,
+  "projectTemplateDir": null,
+  "projectTargetDir": "monitor",
+  "projectExtraJSONFile": "ogma-cli/examples/doorstop/extra-vars-yaml.json"
+}


### PR DESCRIPTION
Add an example with requirements created using Doorstop, together with any auxiliary files needed to compile the requirements, as well as a README with instructions on how to generate a Copilot spec from the Doorstop files, as prescribed in the solution proposed for #480.