### PR TITLE
`ogma-cli`: Replace ROS2 with ROS 2 in help message. Refs #484.

### DIFF
--- a/ogma-cli/CHANGELOG.md
+++ b/ogma-cli/CHANGELOG.md
@@ -16,6 +16,7 @@
 * Add example explaining cFS app generation from state machine diagrams (#478).
 * Add example containing Doorstop requirements (#480).
 * Remove mentions of ICAROUS (#482).
+* Replace ROS2 with ROS 2 in help message (#484).
 
 ## [1.14.0] - 2026-05-21
 

--- a/ogma-cli/src/CLI/CommandROSApp.hs
+++ b/ogma-cli/src/CLI/CommandROSApp.hs
@@ -333,7 +333,7 @@ strROSAppTemplateVarsArgDesc =
 -- | Argument packages to tested list to ROS app generation command
 strROSAppROSNodesTestingListArgDesc :: String
 strROSAppROSNodesTestingListArgDesc =
-  "Turn on ROS2 package node during testing"
+  "Turn on ROS 2 package node during testing"
 
 -- | Argument variables to be tested list to ROS app generation command
 strROSAppVarsTestingListArgDesc :: String


### PR DESCRIPTION
Replace ROS2 with ROS 2 in the description of an argument to the `ros` command, as prescribed in the solution proposed for #484.