### PR TITLE
`ogma-cli`: Adjust `report` command to accept multiple input files. Refs #486.

### DIFF
--- a/ogma-cli/CHANGELOG.md
+++ b/ogma-cli/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Revision history for ogma-cli
 
-## [1.X.Y] - 2026-07-09
+## [1.X.Y] - 2026-07-10
 
 * Fix typo in README (#428).
 * Update CI job to install Copilot 4.7.1 by default (#446).
@@ -17,6 +17,7 @@
 * Add example containing Doorstop requirements (#480).
 * Remove mentions of ICAROUS (#482).
 * Replace ROS2 with ROS 2 in help message (#484).
+* Adjust `report` command to accept multiple input files (#486).
 
 ## [1.14.0] - 2026-05-21
 

--- a/ogma-cli/src/CLI/CommandReport.hs
+++ b/ogma-cli/src/CLI/CommandReport.hs
@@ -43,7 +43,7 @@ module CLI.CommandReport
   where
 
 -- External imports
-import Options.Applicative (Parser, help, long, metavar, optional, short,
+import Options.Applicative (Parser, help, long, many, metavar, optional, short,
                             showDefault, strOption, value)
 
 -- External imports: command results
@@ -61,10 +61,15 @@ data CommandOpts = CommandOpts
                                              -- reoprt should be created.
   , commandTemplateDir :: Maybe FilePath     -- ^ Directory where the template
                                              -- is to be found.
-  , commandFileName    :: FilePath
-  , commandFormat      :: String
-  , commandPropFormat  :: String
-  , commandPropVia     :: Maybe String
+  , commandInputFiles  :: [ReportFile]
+  }
+
+-- | Options associated to a specific input file.
+data ReportFile = ReportFile
+  { reportFilePath       :: FilePath
+  , reportFileFormat     :: String
+  , reportFilePropFormat :: String
+  , reportFilePropVia    :: Maybe String
   }
 
 -- | Generate a report of the input specification(s).
@@ -78,10 +83,15 @@ command options = do
     internalCommandOpts = Command.Report.CommandOptions
       { Command.Report.commandTargetDir   = commandTargetDir options
       , Command.Report.commandTemplateDir = commandTemplateDir options
-      , Command.Report.commandInputFile   = commandFileName options
-      , Command.Report.commandFormat      = commandFormat options
-      , Command.Report.commandPropFormat  = commandPropFormat options
-      , Command.Report.commandPropVia     = commandPropVia options
+      , Command.Report.commandInputFiles  =
+          map fileInfo $ commandInputFiles options
+      }
+
+    fileInfo f = Command.Report.ReportFile
+      { Command.Report.reportFilePath       = reportFilePath   f
+      , Command.Report.reportFileFormat     = reportFileFormat f
+      , Command.Report.reportFilePropFormat = reportFilePropFormat f
+      , Command.Report.reportFilePropVia    = reportFilePropVia f
       }
 
 -- * CLI
@@ -108,7 +118,13 @@ commandOptsParser = CommandOpts
             <> help strReportTemplateDirArgDesc
             )
         )
-  <*> strOption
+  <*> many reportFileOptsParser
+
+-- | Subparser for information on one input file to be used with the @report@
+-- command.
+reportFileOptsParser :: Parser ReportFile
+reportFileOptsParser = ReportFile
+  <$> strOption
         (  long "file-name"
         <> metavar "FILENAME"
         <> help strReportFilenameDesc

--- a/ogma-core/CHANGELOG.md
+++ b/ogma-core/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Revision history for ogma-core
 
-## [1.X.Y] - 2026-07-09
+## [1.X.Y] - 2026-07-10
 
 * Remove commented code from `Data.Spec.Parser` (#430).
 * Remove redundant `where` block (#432).
@@ -21,6 +21,7 @@
 * Allow controlling when monitors are re-evaluated in cFS apps (#474).
 * Extend cFS backend with diagram mode (#476).
 * Replace mentions of ICAROUS (#482).
+* Adjust report command to accept multiple input files (#486).
 
 ## [1.14.0] - 2026-05-21
 

--- a/ogma-core/src/Command/Report.hs
+++ b/ogma-core/src/Command/Report.hs
@@ -20,6 +20,7 @@
 module Command.Report
     ( command
     , CommandOptions(..)
+    , ReportFile(..)
     , CommandSummary(..)
     , ErrorCode
     )
@@ -27,7 +28,9 @@ module Command.Report
 
 -- External imports
 import qualified Control.Exception      as E
-import           Control.Monad.Except   (ExceptT (..), liftEither, withExceptT)
+import           Control.Monad          (foldM)
+import           Control.Monad.Except   (ExceptT (..), liftEither, runExceptT,
+                                         withExceptT)
 import           Control.Monad.IO.Class (liftIO)
 import           Data.Aeson             (ToJSON (..))
 import           GHC.Generics           (Generic)
@@ -67,9 +70,10 @@ command options = processResult $ do
     -- Obtain template dir
     templateDir <- locateTemplateDir mTemplateDir "report"
 
-    let functions = exprPair (commandPropFormat options)
-
-    reportData <- command' options functions
+    reportData <- foldM
+                    processFile
+                    emptyCommandSummary
+                    (commandInputFiles options)
 
     -- Expand template
     ExceptT $ fmap (makeLeftE cannotCopyTemplate) $ E.try $
@@ -79,6 +83,14 @@ command options = processResult $ do
 
     targetDir    = commandTargetDir options
     mTemplateDir = commandTemplateDir options
+
+    processFile :: CommandSummary
+                -> ReportFile
+                -> ExceptT ErrorTriplet IO CommandSummary
+    processFile acc file = do
+      let functions = exprPair (reportFilePropFormat file)
+      s <- command' options functions file
+      return $ mergeCommandSummary acc s
 
 -- | Generate report of a spec or diagram given in an input file.
 --
@@ -90,28 +102,23 @@ command options = processResult $ do
 -- copy the files over.
 command' :: CommandOptions
          -> ExprPair
+         -> ReportFile
          -> ExceptT ErrorTriplet IO CommandSummary
-command' options (ExprPair exprT) = do
+command' options (ExprPair exprT) file = do
     res <- parseInputFile fp formatName propFormatName propVia exprT
     case res of
       InputFileDiagram diagramR -> do
         analysisResult <- liftIO $ analyzeDiagram diagramR
-        let diagramDetails = DiagramDetails
+        let diagramDetails = CommandSummaryDiagram
+                               fp
                                (numStates analysisResult)
                                (deterministic analysisResult)
 
         pure $ CommandSummary
-                 { commandExternalVariables      = 0
-                 , commandInternalVariables      = 0
-                 , commandRequirementsAny        = False
-                 , commandRequirements           = 0
-                 , commandRequirementsTrue       = 0
-                 , commandRequirementsFalse      = 0
-                 , commandRequirementsConsistent = True
-                 , commandRequirementList        = []
-                 , commandDiagramsAny            = True
-                 , commandDiagrams               = 1
-                 , commandDiagramList            = [diagramDetails]
+                 { commandRequirementsAny = False
+                 , commandRequirementList = []
+                 , commandDiagramsList    = [ diagramDetails ]
+                 , commandDiagramsAny     = True
                  }
 
       InputFileSpec spec -> withExceptT commandCannotAnalyzeF $ do
@@ -140,26 +147,30 @@ command' options (ExprPair exprT) = do
             falseReqs  = SpecAnalysis.alwaysFalseReq specFormalAnalysis
             consistent = SpecAnalysis.consistent     specFormalAnalysis
 
+            fileReqs   = CommandSummaryRequirements
+                           { summaryRequirementsFile       = fp
+                           , summaryExternalVariables      = numExterns
+                           , summaryInternalVariables      = numInternal
+                           , summaryRequirements           = numReqs
+                           , summaryRequirementsTrue       = numTrues
+                           , summaryRequirementsFalse      = numFalses
+                           , summaryRequirementsConsistent = consistent
+                           , summaryRequirementsDetails    = reqListDetails
+                           }
+
         pure $ CommandSummary
-                 { commandExternalVariables      = numExterns
-                 , commandInternalVariables      = numInternal
-                 , commandRequirementsAny        = numReqs > 0
-                 , commandRequirements           = numReqs
-                 , commandRequirementsTrue       = numTrues
-                 , commandRequirementsFalse      = numFalses
-                 , commandRequirementsConsistent = consistent
-                 , commandRequirementList        = reqListDetails
-                 , commandDiagramsAny            = False
-                 , commandDiagrams               = 0
-                 , commandDiagramList            = []
+                 { commandRequirementsAny = length reqListDetails > 0
+                 , commandRequirementList = [fileReqs]
+                 , commandDiagramsAny     = False
+                 , commandDiagramsList    = []
                  }
 
   where
 
-    fp             = commandInputFile options
-    formatName     = commandFormat options
-    propFormatName = commandPropFormat options
-    propVia        = commandPropVia options
+    fp             = reportFilePath file
+    formatName     = reportFileFormat file
+    propFormatName = reportFilePropFormat file
+    propVia        = reportFilePropVia file
 
     ExprPairT _parse replace printExpr ids _def = exprT
 
@@ -168,29 +179,59 @@ command' options (ExprPair exprT) = do
 data CommandOptions = CommandOptions
   { commandTargetDir   :: String
   , commandTemplateDir :: Maybe String
-  , commandInputFile   :: String
-  , commandFormat      :: String
-  , commandPropFormat  :: String
-  , commandPropVia     :: Maybe String
+  , commandInputFiles  :: [ ReportFile ]
+  }
+
+-- | Information about one file in the command options.
+data ReportFile = ReportFile
+  { reportFilePath       :: FilePath
+  , reportFileFormat     :: String
+  , reportFilePropFormat :: String
+  , reportFilePropVia    :: Maybe String
   }
 
 -- | Summary of the files read.
 data CommandSummary = CommandSummary
-    { commandExternalVariables      :: Int
-    , commandInternalVariables      :: Int
-    , commandRequirementsAny        :: Bool
-    , commandRequirements           :: Int
-    , commandRequirementsTrue       :: Int
-    , commandRequirementsFalse      :: Int
-    , commandRequirementsConsistent :: Bool
-    , commandRequirementList        :: [RequirementDetails]
-    , commandDiagramsAny            :: Bool
-    , commandDiagrams               :: Int
-    , commandDiagramList            :: [DiagramDetails]
+    { commandRequirementsAny :: Bool
+    , commandRequirementList :: [CommandSummaryRequirements]
+    , commandDiagramsAny     :: Bool
+    , commandDiagramsList    :: [CommandSummaryDiagram]
     }
   deriving (Generic, Show)
 
 instance ToJSON CommandSummary
+
+-- | Summary with empty data.
+emptyCommandSummary :: CommandSummary
+emptyCommandSummary = CommandSummary False [] False []
+
+-- | Merge two summaries.
+mergeCommandSummary :: CommandSummary -> CommandSummary -> CommandSummary
+mergeCommandSummary c1 c2 = CommandSummary
+  { commandRequirementsAny =
+      commandRequirementsAny c1 || commandRequirementsAny c2
+  , commandRequirementList =
+      commandRequirementList c1 ++ commandRequirementList c2
+  , commandDiagramsAny =
+      commandDiagramsAny c1 || commandDiagramsAny c2
+  , commandDiagramsList =
+      commandDiagramsList c1 ++ commandDiagramsList c2
+  }
+
+-- | Requirement data for inclusion in the summary.
+data CommandSummaryRequirements = CommandSummaryRequirements
+    { summaryRequirementsFile       :: FilePath
+    , summaryExternalVariables      :: Int
+    , summaryInternalVariables      :: Int
+    , summaryRequirements           :: Int
+    , summaryRequirementsTrue       :: Int
+    , summaryRequirementsFalse      :: Int
+    , summaryRequirementsConsistent :: Bool
+    , summaryRequirementsDetails    :: [RequirementDetails]
+    }
+  deriving (Generic, Show)
+
+instance ToJSON CommandSummaryRequirements
 
 -- | Information to include in a report about a requirement.
 data RequirementDetails = RequirementDetails
@@ -204,13 +245,14 @@ data RequirementDetails = RequirementDetails
 instance ToJSON RequirementDetails
 
 -- | Information to include in a report about a diagram.
-data DiagramDetails = DiagramDetails
-    { summaryDiagramNumStates     :: Int
+data CommandSummaryDiagram = CommandSummaryDiagram
+    { summaryDiagramFile          :: FilePath
+    , summaryDiagramNumStates     :: Int
     , summaryDiagramDeterministic :: Bool
     }
   deriving (Generic, Show)
 
-instance ToJSON DiagramDetails
+instance ToJSON CommandSummaryDiagram
 
 -- * Errors
 

--- a/ogma-core/templates/report/Report.md
+++ b/ogma-core/templates/report/Report.md
@@ -1,10 +1,11 @@
 {{#commandDiagramsAny}}
 # Diagrams
 
-{{#commandDiagramList}}
+{{#commandDiagramsList}}
 ## Diagram
 
-The diagram:
+The diagram `{{summaryDiagramFile}}`:
+
  - Has {{summaryDiagramNumStates}} states.
 {{#summaryDiagramDeterministic}}
  - Is deterministic.
@@ -13,38 +14,40 @@ The diagram:
  - Is not deterministic.
 {{/summaryDiagramDeterministic}}
 
-{{/commandDiagramList}}
+{{/commandDiagramsList}}
 {{/commandDiagramsAny}}
 {{#commandRequirementsAny}}
 # Requirements
 
-## Summary
+{{#commandRequirementList}}
+## File `{{summaryRequirementsFile}}`
 
-The project has {{commandRequirements}} requirements in total.
+The file `{{summaryRequirementsFile}}` has {{summaryRequirements}} requirements
+in total.
 
 Of these requirements:
 
-- {{commandRequirementsTrue}} requirements are constantly or always true.
+- {{summaryRequirementsTrue}} requirements are constantly or always true.
 
-- {{commandRequirementsFalse}} requirements are constantly or always false.
+- {{summaryRequirementsFalse}} requirements are constantly or always false.
 
-{{#commandRequirementsConsistent}}
+{{#summaryRequirementsConsistent}}
 No inconsistencies detected in the requirements.
-{{/commandRequirementsConsistent}}
-{{^commandRequirementsConsistent}}
+{{/summaryRequirementsConsistent}}
+{{^summaryRequirementsConsistent}}
 The requirements are not mutually consistent: there is no way for all
 requirements to be true at the same time.
-{{/commandRequirementsConsistent}}
+{{/summaryRequirementsConsistent}}
 
 The requirements mention:
 
-- {{commandExternalVariables}} external variables.
+- {{summaryExternalVariables}} external variables.
 
-- {{commandInternalVariables}} internal variables.
+- {{summaryInternalVariables}} internal variables.
 
 ## Detailed list
 
-{{#commandRequirementList}}
+{{#summaryRequirementDetails}}
 ### {{summaryRequirementName}}
 
 **Description:** {{summaryRequirementDesc}}
@@ -63,5 +66,6 @@ The requirements mention:
 {{/summaryRequirementFalse}}
 {{/summaryRequirementTrue}}
 
+{{/summaryRequirementDetails}}
 {{/commandRequirementList}}
 {{/commandRequirementsAny}}


### PR DESCRIPTION
Adjust `report` command in `ogma-cli` to accept multiple input files and present information on all of them, making the necessary changes in the internal implementation of the command in `ogma-core`, as prescribed in the solution proposed for #486.