### PR TITLE
`ogma-cli`: Remove unused import from `CLI.CommandStandalone` module. Refs #490.

### DIFF
--- a/ogma-cli/CHANGELOG.md
+++ b/ogma-cli/CHANGELOG.md
@@ -19,6 +19,7 @@
 * Replace ROS2 with ROS 2 in help message (#484).
 * Adjust `report` command to accept multiple input files (#486).
 * Adjust `report` command to support projects (#488).
+* Remove unused import from `CLI.CommandStandalone` module (#490).
 
 ## [1.14.0] - 2026-05-21
 

--- a/ogma-cli/src/CLI/CommandStandalone.hs
+++ b/ogma-cli/src/CLI/CommandStandalone.hs
@@ -34,7 +34,7 @@ import Control.Applicative ((<|>))
 import Data.Functor        ((<&>))
 import Data.Maybe          (fromMaybe)
 import Options.Applicative (Parser, help, long, many, metavar, optional, short,
-                            showDefault, strOption, switch, value)
+                            showDefault, strOption, value)
 
 -- External imports: command results
 import Command.Result ( Result(..) )


### PR DESCRIPTION
Remove unused import from `ogma-cli:CLI.CommandStandalone`, as prescribed in the solution proposed for #490.