### PR TITLE
`ogma-core`: Adjust cFS app template to allow customizing MIDs. Refs #494.

### DIFF
--- a/ogma-core/CHANGELOG.md
+++ b/ogma-core/CHANGELOG.md
@@ -23,6 +23,7 @@
 * Replace mentions of ICAROUS (#482).
 * Adjust report command to accept multiple input files (#486).
 * Apply multiple style fixes (#492).
+* Adjust cFS app template to allow customizing MIDs (#494).
 
 ## [1.14.0] - 2026-05-21
 

--- a/ogma-core/templates/cfs/copilot/fsw/platform_inc/copilot_cfs_msgids.h
+++ b/ogma-core/templates/cfs/copilot/fsw/platform_inc/copilot_cfs_msgids.h
@@ -12,10 +12,30 @@
 #ifndef _copilot_cfs_msgids_h_
 #define _copilot_cfs_msgids_h_
 
+{{#CFS_CMD_MID}}
+#define COPILOT_CFS_CMD_MID        {{.}}
+{{/CFS_CMD_MID}}
+{{^CFS_CMD_MID}}
 #define COPILOT_CFS_CMD_MID        0x1882
+{{/CFS_CMD_MID}}
+{{#CFS_REEVAL_CMD_MID}}
+#define COPILOT_CFS_REEVAL_CMD_MID {{.}}
+{{/CFS_REEVAL_CMD_MID}}
+{{^CFS_REEVAL_CMD_MID}}
 #define COPILOT_CFS_REEVAL_CMD_MID 0x1883
+{{/CFS_REEVAL_CMD_MID}}
+{{#CFS_SEND_HK_MID}}
+#define COPILOT_CFS_SEND_HK_MID    {{.}}
+{{/CFS_SEND_HK_MID}}
+{{^CFS_SEND_HK_MID}}
 #define COPILOT_CFS_SEND_HK_MID    0x1884
+{{/CFS_SEND_HK_MID}}
+{{#CFS_HK_TLM_MID}}
+#define COPILOT_CFS_HK_TLM_MID     {{.}}
+{{/CFS_HK_TLM_MID}}
+{{^CFS_HK_TLM_MID}}
 #define COPILOT_CFS_HK_TLM_MID     0x0883
+{{/CFS_HK_TLM_MID}}
 
 #endif /* _copilot_cfs_msgids_h_ */
 


### PR DESCRIPTION
Modify cFS app template to allow customizing the MIDs used by the generated app, as prescribed in the solution proposed for #494.