### PR TITLE
`ogma-core`: Allow variable DB topics to carry extra info available to cFS template. Refs #496.

### DIFF
--- a/ogma-core/CHANGELOG.md
+++ b/ogma-core/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Revision history for ogma-core
 
-## [1.X.Y] - 2026-07-12
+## [1.X.Y] - 2026-07-14
 
 * Remove commented code from `Data.Spec.Parser` (#430).
 * Remove redundant `where` block (#432).
@@ -24,6 +24,7 @@
 * Adjust report command to accept multiple input files (#486).
 * Apply multiple style fixes (#492).
 * Adjust cFS app template to allow customizing MIDs (#494).
+* Allow variable DB topics to carry extra info available to cFS template (#496).
 
 ## [1.14.0] - 2026-05-21
 

--- a/ogma-core/src/Command/CFSApp.hs
+++ b/ogma-core/src/Command/CFSApp.hs
@@ -40,7 +40,7 @@ import           Control.Applicative    ( liftA2, (<|>) )
 import qualified Control.Exception      as E
 import           Control.Monad.Except   ( ExceptT (..), liftEither,
                                           throwError )
-import           Data.Aeson             ( ToJSON (..) )
+import           Data.Aeson             ( ToJSON (..), Value )
 import           Data.Maybe             ( fromMaybe, mapMaybe, maybeToList )
 import           GHC.Generics           ( Generic )
 
@@ -236,6 +236,8 @@ variableMap varDB varName = do
   mid       <- connectionTopic <$> findConnection inputDef "cfs"
   topicDef  <- findTopic varDB "cfs" mid
 
+  let extra = topicExtra topicDef
+
   let typeDef = findType varDB varName "cfs" "C"
 
   let typeMsgFromType  = typeFromType <$> typeDef
@@ -250,7 +252,7 @@ variableMap varDB varName = do
 
   return ( VarDecl varName typeVar'
          , mid
-         , MsgInfo mid mn
+         , MsgInfo mid mn extra
          , MsgData mn typeMsgFromType typeMsgFromField varName typeVar' active
          )
 
@@ -280,8 +282,9 @@ type MsgInfoId = String
 -- | A message ID to subscribe to and the name associated to it. The name is
 -- used to generate a suitable name for the message handler.
 data MsgInfo = MsgInfo
-    { msgInfoId   :: MsgInfoId
-    , msgInfoDesc :: String
+    { msgInfoId    :: MsgInfoId
+    , msgInfoDesc  :: String
+    , msgInfoExtra :: Value
     }
   deriving (Generic)
 

--- a/ogma-core/src/Command/VariableDB.hs
+++ b/ogma-core/src/Command/VariableDB.hs
@@ -1,5 +1,6 @@
-{-# LANGUAGE DeriveGeneric   #-}
-{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE DeriveGeneric     #-}
+{-# LANGUAGE TemplateHaskell   #-}
+{-# LANGUAGE OverloadedStrings #-}
 -- Copyright 2022 United States Government as represented by the Administrator
 -- of the National Aeronautics and Space Administration. All Rights Reserved.
 --
@@ -36,7 +37,8 @@ module Command.VariableDB
 
 -- External imports
 import Control.Monad.Except (ExceptT, throwError)
-import Data.Aeson           (FromJSON (..))
+import Data.Aeson           (FromJSON (..), Value (Object), (.:), withObject)
+import Data.Aeson.KeyMap    (filterWithKey)
 import Data.Aeson.TH        (defaultOptions, deriveFromJSON, fieldLabelModifier)
 import Data.Char            (toLower)
 import Data.List            (find)
@@ -82,6 +84,7 @@ data TopicDef = TopicDef
     { topicScope :: String
     , topicTopic :: String
     , topicType  :: String
+    , topicExtra :: Value  -- ^ Additional extra info.
     }
   deriving (Eq, Show)
 
@@ -315,15 +318,27 @@ mergeMaybe Nothing x       = x
 mergeMaybe x       Nothing = x
 mergeMaybe x       _       = x
 
--- | Implement default instances of parser to read variable DB from JSON,
--- dropping the prefix in each field name.
+-- | Implement instances of parser to read variable DB from JSON, dropping the
+-- prefix in each field name.
 deriveFromJSON
   defaultOptions {fieldLabelModifier = toHead toLower . drop 4 }
   ''TypeDef
 
-deriveFromJSON
-  defaultOptions {fieldLabelModifier = toHead toLower . drop 5 }
-  ''TopicDef
+instance FromJSON TopicDef where
+  parseJSON = withObject "TopicDef" $ \obj -> do
+    scope <- obj .: "scope"
+    topic <- obj .: "topic"
+    typeV <- obj .: "type"
+
+    let extra = Object $
+          filterWithKey (\k _ -> k `notElem` [ "scope", "topic", "type" ]) obj
+
+    pure TopicDef
+      { topicScope = scope
+      , topicTopic = topic
+      , topicType  = typeV
+      , topicExtra = extra
+      }
 
 deriveFromJSON
   defaultOptions {fieldLabelModifier = toHead toLower . drop 10 }


### PR DESCRIPTION
Modify variable DB parser to allow for extra fields in topic definitions, carrying that information forward in cFS backend and making it available as part of the message cases in the app data, as prescribed in the solution proposed for #496.