### PR TITLE
docs: twin-model verification pattern for generated monitors

### DIFF
--- a/docs/TWIN_MODEL_VERIFICATION.md
+++ b/docs/TWIN_MODEL_VERIFICATION.md
@@ -1,0 +1,29 @@
+# Twin-Model Verification for Ogma Monitors
+
+Ogma generates runtime monitors from temporal logic specifications.
+This doc describes a dual-model verification pattern.
+
+## Pattern
+
+```
+Generator model  ->  CoCoSpec/Lustre spec draft
+     down
+Gate model (local) ->  verifies temporal operators,
+    guarantees have assume scopes, state machines complete
+     down
+ogma  ->  generates Rust/C/Lustre monitor
+```
+
+## Key Invariants
+
+- Every `guarantee` has a corresponding `assume` scope
+- Temporal operators used correctly (always, eventually, until)
+- State machine transitions are complete (no dead states)
+- Output monitor covers the stated property
+
+## Connection to Formal Verification
+
+This pattern mirrors the sorry gate in Lean 4:
+a model can declare correctness while producing an incorrect artifact.
+An external gate with the spec loaded catches the contradiction cheaply
+before full formal verification runs.


### PR DESCRIPTION
## Summary

- Adds `docs/TWIN_MODEL_VERIFICATION.md` — documents a dual-model pattern for verifying AI-generated CoCoSpec/Lustre specifications before passing them to `ogma generate`

## Motivation

When using AI assistance to write temporal logic specs, generator models may produce specs that are syntactically valid but semantically incomplete (missing hysteresis, incomplete state machines). A local gate model with the ogma spec loaded catches these before monitor generation.

The pattern mirrors formal verification: a model can declare correctness while producing an incorrect artifact. The gate model checks the content, not the framing.

🤖 Generated with [Claude Code](https://claude.com/claude-code) — EDAULC, SNAPKITTYWEST