### PR TITLE
`ogma-core`: Make variable field names available to ROS template when present. Refs #499.

### DIFF
--- a/ogma-core/CHANGELOG.md
+++ b/ogma-core/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Revision history for ogma-core
 
-## [1.X.Y] - 2026-07-14
+## [1.X.Y] - 2026-07-16
 
 * Remove commented code from `Data.Spec.Parser` (#430).
 * Remove redundant `where` block (#432).
@@ -25,6 +25,7 @@
 * Apply multiple style fixes (#492).
 * Adjust cFS app template to allow customizing MIDs (#494).
 * Allow variable DB topics to carry extra info available to cFS template (#496).
+* Make variable field names available to ROS template when present (#499).
 
 ## [1.14.0] - 2026-05-21
 

--- a/ogma-core/src/Command/ROSApp.hs
+++ b/ogma-core/src/Command/ROSApp.hs
@@ -235,7 +235,11 @@ variableMap varDB varName = do
   let typeMsg' = fromMaybe
                    (topicType topicDef)
                    (typeFromType <$> findType varDB varName "ros/message" "C")
-  return $ VarDecl varName typeVar' mid typeMsg' (randomBaseType typeVar')
+
+      fieldMsg = typeFromField =<< findType varDB varName "ros/message" "C"
+
+  return $
+    VarDecl varName typeVar' mid typeMsg' fieldMsg (randomBaseType typeVar')
 
 -- | Return the monitor information needed to generate declarations and
 -- publishers for the given monitor info, and variable database.
@@ -251,11 +255,12 @@ monitorMap varDB (monitorName, Just ty) = do
 
 -- | The declaration of a variable in C, with a given type and name.
 data VarDecl = VarDecl
-    { varDeclName    :: String
-    , varDeclType    :: String
-    , varDeclId      :: String
-    , varDeclMsgType :: String
-    , varDeclRandom  :: String
+    { varDeclName     :: String
+    , varDeclType     :: String
+    , varDeclId       :: String
+    , varDeclMsgType  :: String
+    , varDeclMsgField :: Maybe String
+    , varDeclRandom   :: String
     }
   deriving Generic
 

--- a/ogma-core/templates/ros/copilot/src/copilot_monitor.cpp
+++ b/ogma-core/templates/ros/copilot/src/copilot_monitor.cpp
@@ -82,7 +82,12 @@ class CopilotRV : public rclcpp::Node {
   private:
     {{#variables}}
     void {{varDeclName}}_callback(const {{varDeclMsgType}}::SharedPtr msg) const {
+      {{#varDeclMsgField}}
+      {{varDeclName}} = msg->{{.}};
+      {{/varDeclMsgField}}
+      {{^varDeclMsgField}}
       {{varDeclName}} = msg->data;
+      {{/varDeclMsgField}}
       step();
     }
 

--- a/ogma-core/templates/ros/test_requirements/src/test_requirements.cpp
+++ b/ogma-core/templates/ros/test_requirements/src/test_requirements.cpp
@@ -109,10 +109,18 @@ class RequirementsTest : public rclcpp::Node {
     void tests_step_send () {
 
 {{#testingVariables}}
+       {{#varDeclMsgField}}
+       {{varDeclType}} {{varDeclName}}_{{.}} = {{varDeclRandom}}();
+       auto {{varDeclName}}_{{.}}_msg = {{varDeclMsgType}}();
+       {{varDeclName}}_{{.}}_msg.{{.}} = {{varDeclName}}_{{.}};
+       {{varDeclName}}_publisher_->publish({{varDeclName}}_{{.}}_msg);
+       {{/varDeclMsgField}}
+       {{^varDeclMsgField}}
        {{varDeclType}} {{varDeclName}}_data = {{varDeclRandom}}();
        auto {{varDeclName}}_data_msg = {{varDeclMsgType}}();
        {{varDeclName}}_data_msg.data = {{varDeclName}}_data;
        {{varDeclName}}_publisher_->publish({{varDeclName}}_data_msg);
+       {{/varDeclMsgField}}
 
 {{/testingVariables}}
 


### PR DESCRIPTION
Modify ROS backend to obtain field names and make them available in the result as part of variable declarations, and update default ROS template to use the custom field names when present, as prescribed in the solution proposed for #499.