### PR TITLE
`ogma-core`: Adjust ROS template to enable injecting dependencies. Refs #500.

### DIFF
--- a/ogma-core/CHANGELOG.md
+++ b/ogma-core/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Revision history for ogma-core
 
-## [1.X.Y] - 2026-07-16
+## [1.X.Y] - 2026-07-18
 
 * Remove commented code from `Data.Spec.Parser` (#430).
 * Remove redundant `where` block (#432).
@@ -26,6 +26,7 @@
 * Adjust cFS app template to allow customizing MIDs (#494).
 * Allow variable DB topics to carry extra info available to cFS template (#496).
 * Make variable field names available to ROS template when present (#499).
+* Adjust ROS template to enable injecting dependencies (#500).
 
 ## [1.14.0] - 2026-05-21
 

--- a/ogma-core/templates/ros/Dockerfile
+++ b/ogma-core/templates/ros/Dockerfile
@@ -13,9 +13,38 @@ USER ${USER}
 
 SHELL ["/bin/bash", "-c"]
 WORKDIR ${PACKAGE_PATH}
+
+ADD --chmod=644 https://raw.githubusercontent.com/ros/rosdistro/master/ros.key /usr/share/keyrings/ros-archive-keyring.gpg
+RUN sudo apt-get update
+
+ENV RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
+ENV ROS_DISTRO=humble
+
+ADD manual-deps*.repos /tmp/
+RUN if [ -f "/tmp/manual-deps.repos" ]; then \
+      vcs import src < /tmp/manual-deps.repos; \
+    fi
+
+ADD excluded-pkgs*.txt /tmp/
+RUN rosdep update
 RUN source /opt/spaceros/install/setup.bash && \
-    colcon build --packages-select copilot           && \
-    colcon build --packages-select test_requirements
+    if [ -f "/tmp/excluded-pkgs.txt" ]; then \
+      rosdep install -y \
+        --from-paths src --ignore-src \
+        --rosdistro ${ROS_DISTRO} \
+        --skip-keys "$(tr '\n' ' ' < '/tmp/excluded-pkgs.txt')"; \
+    else \
+      rosdep install -y \
+        --from-paths src --ignore-src \
+        --rosdistro ${ROS_DISTRO} ; \
+    fi
+
+ADD manually-installed-pkgs*.txt /tmp/
+RUN source /opt/spaceros/install/setup.bash && \
+    colcon build --packages-select \
+      copilot \
+      test_requirements \
+      $(find /tmp/ -maxdepth 1 -name "manually-installed-pkgs.txt" -exec cat {} +)
 
 ADD screenrc /home/spaceros-user/.screenrc
 USER root

--- a/ogma-core/templates/ros/copilot/CMakeLists.txt
+++ b/ogma-core/templates/ros/copilot/CMakeLists.txt
@@ -9,9 +9,18 @@ endif()
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(std_msgs REQUIRED)
+{{#target_extra_dependencies}}
+find_package({{{.}}} REQUIRED)
+{{/target_extra_dependencies}}
 
 add_executable(copilot src/copilot_monitor.cpp)
-ament_target_dependencies(copilot rclcpp std_msgs)
+ament_target_dependencies(copilot
+  rclcpp
+  std_msgs
+  {{#target_extra_dependencies}}
+  {{{.}}}
+  {{/target_extra_dependencies}}
+)
 
 # Uncomment to enable compiling the copilot logger
 # add_executable(copilot_logger src/copilot_logger.cpp)

--- a/ogma-core/templates/ros/copilot/package.xml
+++ b/ogma-core/templates/ros/copilot/package.xml
@@ -8,11 +8,21 @@
   <license>TODO: License declaration</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
+  {{#package_extra_buildtool_depend}}
+  <buildtool_depend>{{{.}}}</buildtool_depend>
+  {{/package_extra_buildtool_depend}}
+
   <depend>rclcpp</depend>
   <depend>std_msgs</depend>
+  {{#package_extra_depend}}
+  <depend>{{{.}}}</depend>
+  {{/package_extra_depend}}
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
+  {{#package_extra_test_depend}}
+  <test_depend>{{{.}}}</test_depend>
+  {{/package_extra_test_depend}}
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/ogma-core/templates/ros/copilot/src/copilot_monitor.cpp
+++ b/ogma-core/templates/ros/copilot/src/copilot_monitor.cpp
@@ -16,6 +16,9 @@
 #include "std_msgs/msg/float32.hpp"
 #include "std_msgs/msg/float64.hpp"
 #include <cstdint>
+{{#impl_extra_header}}
+{{{.}}}
+{{/impl_extra_header}}
 {{#copilot}}
 #include "{{{copilot.specName}}}_types.h"
 #include "{{{copilot.specName}}}.h"

--- a/ogma-core/templates/ros/test_requirements/CMakeLists.txt
+++ b/ogma-core/templates/ros/test_requirements/CMakeLists.txt
@@ -9,10 +9,19 @@ endif()
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(std_msgs REQUIRED)
+{{#target_extra_dependencies}}
+find_package({{{.}}} REQUIRED)
+{{/target_extra_dependencies}}
 
 # Uncomment to enable compiling the requirement tests
 add_executable(test_requirements src/test_requirements.cpp)
-ament_target_dependencies(test_requirements rclcpp std_msgs)
+ament_target_dependencies(test_requirements
+  rclcpp
+  std_msgs
+  {{#target_extra_dependencies}}
+  {{{.}}}
+  {{/target_extra_dependencies}}
+)
 
 install(TARGETS
   test_requirements

--- a/ogma-core/templates/ros/test_requirements/package.xml
+++ b/ogma-core/templates/ros/test_requirements/package.xml
@@ -8,11 +8,21 @@
   <license>TODO: License declaration</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
+  {{#package_extra_buildtool_depend}}
+  <buildtool_depend>{{{.}}}</buildtool_depend>
+  {{/package_extra_buildtool_depend}}
+
   <depend>rclcpp</depend>
   <depend>std_msgs</depend>
+  {{#package_extra_depend}}
+  <depend>{{{.}}}</depend>
+  {{/package_extra_depend}}
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
+  {{#package_extra_test_depend}}
+  <test_depend>{{{.}}}</test_depend>
+  {{/package_extra_test_depend}}
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/ogma-core/templates/ros/test_requirements/src/test_requirements.cpp
+++ b/ogma-core/templates/ros/test_requirements/src/test_requirements.cpp
@@ -18,6 +18,9 @@
 #include "std_msgs/msg/float32.hpp"
 #include "std_msgs/msg/float64.hpp"
 #include <cstdint>
+{{#impl_extra_header}}
+{{{.}}}
+{{/impl_extra_header}}
 
 using std::placeholders::_1;
 


### PR DESCRIPTION
Adjust ROS template to enable injecting dependencies in an auxiliary JSON file passed to the ROS backend, as prescribed in the solution proposed for #500.