### PR TITLE
`ogma-core`: Bump upper version constraints on Copilot packages. Refs #501.

### DIFF
--- a/ogma-core/CHANGELOG.md
+++ b/ogma-core/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Revision history for ogma-core
 
-## [1.X.Y] - 2026-07-18
+## [1.X.Y] - 2026-07-19
 
 * Remove commented code from `Data.Spec.Parser` (#430).
 * Remove redundant `where` block (#432).
@@ -27,6 +27,7 @@
 * Allow variable DB topics to carry extra info available to cFS template (#496).
 * Make variable field names available to ROS template when present (#499).
 * Adjust ROS template to enable injecting dependencies (#500).
+* Bump upper version constraints on Copilot packages (#501).
 
 ## [1.14.0] - 2026-05-21
 

--- a/ogma-core/ogma-core.cabal
+++ b/ogma-core/ogma-core.cabal
@@ -152,10 +152,10 @@ library
     , aeson                   >= 2.0.0.0  && < 2.3
     , bytestring              >= 0.10.8.2 && < 0.13
     , containers              >= 0.5      && < 0.8
-    , copilot-core            >= 4.7.1    && < 4.8
-    , copilot-language        >= 4.7.1    && < 4.8
-    , copilot-libraries       >= 4.7.1    && < 4.8
-    , copilot-theorem         >= 4.7.1    && < 4.8
+    , copilot-core            >= 4.7.1    && < 4.9
+    , copilot-language        >= 4.7.1    && < 4.9
+    , copilot-libraries       >= 4.7.1    && < 4.9
+    , copilot-theorem         >= 4.7.1    && < 4.9
     , directory               >= 1.3.1.5  && < 1.4
     , filepath                >= 1.4.2    && < 1.6
     , graphviz                >= 2999.20  && < 2999.21


### PR DESCRIPTION
Bump upper version constraint on `copilot-core`, `copilot-language`, `copilot-libraries`, and `copilot-theorem`, as prescribed in the solution proposed for #501.