### PR TITLE
`ogma-cli`: Standardize option name in `report` command. Refs #505.

### DIFF
--- a/ogma-cli/CHANGELOG.md
+++ b/ogma-cli/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Revision history for ogma-cli
 
-## [1.X.Y] - 2026-07-12
+## [1.X.Y] - 2026-07-21
 
 * Fix typo in README (#428).
 * Update CI job to install Copilot 4.7.1 by default (#446).
@@ -21,6 +21,7 @@
 * Adjust `report` command to support projects (#488).
 * Remove unused import from `CLI.CommandStandalone` module (#490).
 * Apply multiple style fixes (#492).
+* Standardize option name in `report` command (#505).
 
 ## [1.14.0] - 2026-05-21
 

--- a/ogma-cli/src/CLI/CommandReport.hs
+++ b/ogma-cli/src/CLI/CommandReport.hs
@@ -170,9 +170,9 @@ commandOptsParser = CommandOpts
 reportFileOptsParser :: Parser ReportFile
 reportFileOptsParser = ReportFile
   <$> strOption
-        (  long "file-name"
+        (  long "input-file"
         <> metavar "FILENAME"
-        <> help strReportFilenameDesc
+        <> help strReportInputFileDesc
         )
   <*> strOption
         (  long "input-format"
@@ -210,9 +210,9 @@ strReportTargetDirDesc = "Target directory"
 strReportTemplateDirArgDesc :: String
 strReportTemplateDirArgDesc = "Directory holding report template"
 
--- | Filename flag description.
-strReportFilenameDesc :: String
-strReportFilenameDesc = "File with properties, requirements or a diagram"
+-- | Input file flag description.
+strReportInputFileDesc :: String
+strReportInputFileDesc = "File with properties, requirements or a diagram"
 
 -- | Format flag description.
 strReportFormatDesc :: String


### PR DESCRIPTION
Modify name of the `report` command option used to pass input files so that it is named `--input-file`, as prescribed in the solution proposed for #505.