### PR TITLE
Update cFS template, CI job, examples to work with cFS 7.0. Refs #509.

### DIFF
--- a/.github/workflows/repo-ghc-8.6-cabal-2.4-cfs.yml
+++ b/.github/workflows/repo-ghc-8.6-cabal-2.4-cfs.yml
@@ -50,7 +50,7 @@ jobs:
       run: |
 
         # Clone standard cFS
-        git clone --recursive -b v6.7.0a https://github.com/nasa/cfs.git
+        git clone --recursive -b v7.0.1 https://github.com/nasa/cfs.git
 
         # Generate cFS app with Ogma
         ogma cfs --target-dir cfs/apps/ \
@@ -61,22 +61,17 @@ jobs:
                  --template-vars ogma-cli/examples/cfs-001-hello-ogma/extra-vars.json
         cp ogma-cli/examples/cfs-001-hello-ogma/extra.h cfs/apps/copilot/fsw/src/
 
-        # Copy default settings for cFS
-        cd cfs/
-        cp cfe/cmake/Makefile.sample Makefile
-        cp -r cfe/cmake/sample_defs .
-
         # Enable Ogma-generated cFS app in cFS
-        sed -i -e 's/\(SET(TGT1_APPLIST.*\))/\1 copilot)/g' sample_defs/targets.cmake
-        sed -i -e '0,/^!/s//CFE_APP, \/cf\/copilot_cfs.so, COPILOT_AppMain, COPILOT_APP, 50, 16384, 0x0, 0;\n&/' sample_defs/cpu1_cfe_es_startup.scr
+        sed -i -e 's/\(SET(cpu1_APPLIST.*\))/\1 copilot)/g' cfs/sample_defs/targets.cmake
+        sed -i '/"CFE_APP, sample_app,/a \        "CFE_APP, copilot_cfs, COPILOT_AppMain,    COPILOT_APP,   50,   32768, 0x0, 0;\\n"' cfs/sample_defs/generate_startup.cmake
 
     - name: Compile cFS app and ground station
       run: |
         cd cfs/
 
         # Compile cFS
-        make SIMULATION=native prep
-        make install
+        make native_std.prep
+        make native_std.install -j$(nproc)
 
         # Compile ground station
         make -C tools/cFS-GroundSystem/Subsystems/cmdUtil/
@@ -94,5 +89,5 @@ jobs:
         setsid --fork bash -c 'sleep 20; sudo killall -SIGINT core-cpu1'
 
         # Start cFS
-        cd build/exe/cpu1/
+        cd build-native_std/exe/cpu1/
         sudo ./core-cpu1 && echo "Success"

--- a/ogma-cli/CHANGELOG.md
+++ b/ogma-cli/CHANGELOG.md
@@ -22,6 +22,7 @@
 * Remove unused import from `CLI.CommandStandalone` module (#490).
 * Apply multiple style fixes (#492).
 * Standardize option name in `report` command (#505).
+* Update CI job, examples for cFS 7.0 (#509).
 
 ## [1.14.0] - 2026-05-21
 

--- a/ogma-cli/examples/cfs-001-hello-ogma/README.md
+++ b/ogma-cli/examples/cfs-001-hello-ogma/README.md
@@ -95,8 +95,8 @@ standard cFS header:
 
 ```C
 typedef struct sample_msg {
-   uint8_t CmdHeader[CFE_SB_CMD_HDR_SIZE];
-   int32_t payload;
+   CFE_MSG_CommandHeader_t CmdHeader;
+   int32_t                 payload;
 } sample_msg_t;
 ```
 
@@ -255,8 +255,8 @@ following:
 #define SAMPLE_MID 0x1878
 
 typedef struct sample_msg {
-   uint8_t CmdHeader[CFE_SB_CMD_HDR_SIZE];
-   int32_t payload;
+   CFE_MSG_CommandHeader_t CmdHeader;
+   int32_t                 payload;
 } sample_msg_t;
 ```
 
@@ -282,40 +282,32 @@ To build the application, we must first place it within an installation of cFS.
 Assuming a clean, new installation:
 
 ```sh
-$ git clone --recursive -b v6.7.0a git@github.com:nasa/cfs.git
+$ git clone --recursive -b v7.0.1 git@github.com:nasa/cfs.git
 $ mv demo/copilot cfs/apps/copilot
 $ cp ogma-cli/examples/cfs-001-hello-ogma/extra.h cfs/apps/copilot/fsw/src/
 ```
 
-Next, we copy the default definitions and `Makefile` provided with cFS:
-
-```sh
-$ cd cfs
-$ cp cfe/cmake/Makefile.sample Makefile
-$ cp -r cfe/cmake/sample_defs .
-```
-
 Because of how cFS applications work, we edit the file
 `sample_defs/targets.cmake` and add `copilot` to the list of applications
-compiled for `cpu1`. The setting of `TGT1_APPLIST` reads as follows:
+compiled for `cpu1`. The setting of `cpu1_APPLIST` reads as follows:
 
 ```C
-SET(TGT1_APPLIST sample_app sample_lib ci_lab to_lab sch_lab copilot)
+SET(cpu1_APPLIST ci_lab to_lab sch_lab copilot)
 ```
 
 Next, we add the generated application to the list of applications that will be
 executed upon starting cFS by modifying the file
-`sample_defs/cpu1_cfe_es_startup.scr` and adding the following to the head of
-the file (before the first `!` character):
+`sample_defs/generate_startup.cmake` and adding the following to the end of the
+list of apps that should always be present (after `sample_app`):
 
 ```csv
-CFE_APP, /cf/copilot_cfs.so, COPILOT_AppMain, COPILOT_APP, 50, 16384, 0x0, 0;
+CFE_APP, copilot_cfs, COPILOT_AppMain, COPILOT_APP, 50, 32768, 0x0, 0;
 ```
 
 To compile the application, run:
 ```sh
-$ make SIMULATION=native prep
-$ make install
+$ make native_std.prep
+$ make native_std.install -j$(nproc)
 ```
 
 # Running the cFS application
@@ -334,7 +326,7 @@ Now, in one terminal, we launch the cFS application. Note that we need to do so
 as root:
 
 ```sh
-$ cd build/exe/cpu1
+$ cd build-native_std/exe/cpu1
 $ sudo ./core-cpu1
 ```
 

--- a/ogma-cli/examples/cfs-001-hello-ogma/extra.h
+++ b/ogma-cli/examples/cfs-001-hello-ogma/extra.h
@@ -1,6 +1,6 @@
 #define SAMPLE_MID 0x1878
 
 typedef struct sample_msg {
-   uint8_t CmdHeader[CFE_SB_CMD_HDR_SIZE];
-   int32_t payload;
+   CFE_MSG_CommandHeader_t CmdHeader;
+   int32_t                 payload;
 } sample_msg_t;

--- a/ogma-cli/examples/cfs-002-state-machines/README.md
+++ b/ogma-cli/examples/cfs-002-state-machines/README.md
@@ -110,13 +110,13 @@ standard cFS header:
 
 ```C
 typedef struct sample_msg {
-   uint8_t CmdHeader[CFE_SB_CMD_HDR_SIZE];
-   uint8_t payload;
+   CFE_MSG_CommandHeader_t CmdHeader;
+   uint8_t                 payload;
 } state_msg_t;
 
 typedef struct sample_msg {
-   uint8_t CmdHeader[CFE_SB_CMD_HDR_SIZE];
-   int32_t payload;
+   CFE_MSG_CommandHeader_t CmdHeader;
+   int32_t                 payload;
 } sample_msg_t;
 ```
 
@@ -369,15 +369,15 @@ following:
 #define STATE_MID 0x1878
 
 typedef struct state_msg {
-   uint8_t CmdHeader[CFE_SB_CMD_HDR_SIZE];
-   uint8_t payload;
+   CFE_MSG_CommandHeader_t CmdHeader;
+   uint8_t                 payload;
 } state_msg_t;
 
 #define SAMPLE_MID 0x1879
 
 typedef struct sample_msg {
-   uint8_t CmdHeader[CFE_SB_CMD_HDR_SIZE];
-   int32_t payload;
+   CFE_MSG_CommandHeader_t CmdHeader;
+   int32_t                 payload;
 } sample_msg_t;
 ```
 
@@ -415,9 +415,9 @@ To build the application, we must first place it within an installation of cFS.
 Assuming a clean, new installation:
 
 ```sh
-$ git clone --recursive -b v6.7.0a git@github.com:nasa/cfs.git
+$ git clone --recursive -b v7.0.1 git@github.com:nasa/cfs.git
 $ mv demo/copilot cfs/apps/copilot
-$ cp ogma-cli/examples/cfs-002-state-machines/extra.h cfs/apps/copilot/fsw/src/
+$ cp ogma-cli/examples/cfs-001-hello-ogma/extra.h cfs/apps/copilot/fsw/src/
 ```
 
 We also modify the default MIDs used by the template, to avoid clashing with
@@ -427,35 +427,27 @@ the `sample_app`:
 $ sed -i -e 's/0x188/0x189/g' cfs/apps/copilot/fsw/platform_inc/copilot_cfs_msgids.h
 ```
 
-Next, we copy the default definitions and `Makefile` provided with cFS:
-
-```sh
-$ cd cfs
-$ cp cfe/cmake/Makefile.sample Makefile
-$ cp -r cfe/cmake/sample_defs .
-```
-
 Because of how cFS applications work, we edit the file
 `sample_defs/targets.cmake` and add `copilot` to the list of applications
-compiled for `cpu1`. The setting of `TGT1_APPLIST` reads as follows:
+compiled for `cpu1`. The setting of `cpu1_APPLIST` reads as follows:
 
 ```C
-SET(TGT1_APPLIST sample_app sample_lib ci_lab to_lab sch_lab copilot)
+SET(cpu1_APPLIST ci_lab to_lab sch_lab copilot)
 ```
 
 Next, we add the generated application to the list of applications that will be
 executed upon starting cFS by modifying the file
-`sample_defs/cpu1_cfe_es_startup.scr` and adding the following to the head of
-the file (before the first `!` character):
+`sample_defs/generate_startup.cmake` and adding the following to the end of the
+list of apps that should always be present (after `sample_app`):
 
 ```csv
-CFE_APP, /cf/copilot_cfs.so, COPILOT_AppMain, COPILOT_APP, 50, 16384, 0x0, 0;
+CFE_APP, copilot_cfs, COPILOT_AppMain, COPILOT_APP, 50, 32768, 0x0, 0;
 ```
 
 To compile the application, run:
 ```sh
-$ make SIMULATION=native prep
-$ make install
+$ make native_std.prep
+$ make native_std.install -j$(nproc)
 ```
 
 # Running the cFS application
@@ -475,7 +467,7 @@ Now, in one terminal, we launch the cFS application. Note that we need to do so
 as root:
 
 ```sh
-$ cd build/exe/cpu1
+$ cd build-native_std/exe/cpu1
 $ sudo ./core-cpu1
 ```
 

--- a/ogma-cli/examples/cfs-002-state-machines/extra.h
+++ b/ogma-cli/examples/cfs-002-state-machines/extra.h
@@ -2,11 +2,11 @@
 #define SAMPLE_MID 0x1879
 
 typedef struct state_msg {
-   uint8_t CmdHeader[CFE_SB_CMD_HDR_SIZE];
-   uint8_t payload;
+   CFE_MSG_CommandHeader_t CmdHeader;
+   uint8_t                 payload;
 } state_msg_t;
 
 typedef struct sample_msg {
-   uint8_t CmdHeader[CFE_SB_CMD_HDR_SIZE];
-   int32_t payload;
+   CFE_MSG_CommandHeader_t CmdHeader;
+   int32_t                 payload;
 } sample_msg_t;

--- a/ogma-core/CHANGELOG.md
+++ b/ogma-core/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Revision history for ogma-core
 
-## [1.X.Y] - 2026-07-19
+## [1.X.Y] - 2026-07-21
 
 * Remove commented code from `Data.Spec.Parser` (#430).
 * Remove redundant `where` block (#432).
@@ -28,6 +28,7 @@
 * Make variable field names available to ROS template when present (#499).
 * Adjust ROS template to enable injecting dependencies (#500).
 * Bump upper version constraints on Copilot packages (#501).
+* Update cFS template for cFS 7.0 (#509).
 
 ## [1.14.0] - 2026-05-21
 

--- a/ogma-core/templates/cfs/copilot/fsw/src/copilot_cfs.c
+++ b/ogma-core/templates/cfs/copilot/fsw/src/copilot_cfs.c
@@ -34,7 +34,8 @@
 
 copilot_hk_tlm_t    COPILOT_HkTelemetryPkt;
 CFE_SB_PipeId_t    COPILOT_CommandPipe;
-CFE_SB_MsgPtr_t    COPILOTMsgPtr;
+CFE_MSG_Message_t *COPILOTMsgPtr;
+CFE_SB_Buffer_t   *SBBufPtr;
 
 static CFE_EVS_BinFilter_t  COPILOT_EventFilters[] =
        {  /* Event ID    mask */
@@ -49,22 +50,27 @@ static CFE_EVS_BinFilter_t  COPILOT_EventFilters[] =
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *  * *  * * * * **/
 void COPILOT_AppMain( void )
 {
-    int32  status;
-    uint32 RunStatus = CFE_ES_APP_RUN;
+    CFE_Status_t status;
+    uint32 RunStatus = CFE_ES_RunStatus_APP_RUN;
 
     CFE_ES_PerfLogEntry(COPILOT_CFS_PERF_ID);
 
-    COPILOT_AppInit();
+    status = COPILOT_AppInit();
+
+    if (status != CFE_SUCCESS)
+    {
+        RunStatus = CFE_ES_RunStatus_APP_ERROR;
+    }
 
     /*
     ** COPILOT Runloop
     */
-    while (CFE_ES_RunLoop(&RunStatus) == TRUE)
+    while (CFE_ES_RunLoop(&RunStatus) == true)
     {
         CFE_ES_PerfLogExit(COPILOT_CFS_PERF_ID);
 
         /* Pend on receipt of command packet -- timeout set to 500 millisecs */
-        status = CFE_SB_RcvMsg(&COPILOTMsgPtr, COPILOT_CommandPipe, 500);
+        status = CFE_SB_ReceiveBuffer(&SBBufPtr, COPILOT_CommandPipe, 500);
 
         CFE_ES_PerfLogEntry(COPILOT_CFS_PERF_ID);
 
@@ -75,6 +81,8 @@ void COPILOT_AppMain( void )
 
     }
 
+    CFE_ES_PerfLogExit(COPILOT_CFS_PERF_ID);
+
     CFE_ES_ExitApp(RunStatus);
 
 } /* End of COPILOT_AppMain() */
@@ -84,36 +92,74 @@ void COPILOT_AppMain( void )
 /* COPILOT_AppInit() --  initialization                                       */
 /*                                                                            */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * **/
-void COPILOT_AppInit(void)
+CFE_Status_t COPILOT_AppInit(void)
 {
-    /*
-    ** Register the app with Executive services
-    */
-    CFE_ES_RegisterApp() ;
+    CFE_Status_t status;
 
     /*
     ** Register the events
     */
-    CFE_EVS_Register(COPILOT_EventFilters,
+    status = CFE_EVS_Register(COPILOT_EventFilters,
                      sizeof(COPILOT_EventFilters)/sizeof(CFE_EVS_BinFilter_t),
-                     CFE_EVS_BINARY_FILTER);
+                     CFE_EVS_EventFilter_BINARY);
 
-    /*
-    ** Create the Software Bus command pipe and subscribe to housekeeping
-    **  messages
-    */
-    CFE_SB_CreatePipe(&COPILOT_CommandPipe, COPILOT_PIPE_DEPTH,"COPILOT_CMD_PIPE");
+    if (status != CFE_SUCCESS)
+    {
+        CFE_ES_WriteToSysLog("Copilot App: Error Registering Events, RC = 0x%08lX\n", (unsigned long)status);
+    }
+    else
+    {
+        /*
+        ** Create the Software Bus command pipe and subscribe to housekeeping
+        **  messages
+        */
+        status = CFE_SB_CreatePipe(&COPILOT_CommandPipe, COPILOT_PIPE_DEPTH,"COPILOT_CMD_PIPE");
+
+        if (status != CFE_SUCCESS)
+        {
+            CFE_EVS_SendEvent(COPILOT_CR_PIPE_ERR_EID,
+                              CFE_EVS_EventType_ERROR,
+                              "Copilot App: Error creating SB Command Pipe, RC = 0x%08lX",
+                              (unsigned long)status);
+        }
+    }
+
     {{#msgIds}}
-    CFE_SB_Subscribe({{.}}, COPILOT_CommandPipe);
-    {{/msgIds}}
-    CFE_SB_Subscribe(COPILOT_CFS_REEVAL_CMD_MID, COPILOT_CommandPipe);
+    if (status == CFE_SUCCESS)
+    {
+        status = CFE_SB_Subscribe(CFE_SB_ValueToMsgId({{.}}), COPILOT_CommandPipe);
 
-    CFE_EVS_SendEvent (COPILOT_STARTUP_INF_EID, CFE_EVS_INFORMATION,
+        if (status != CFE_SUCCESS)
+        {
+            CFE_EVS_SendEvent(COPILOT_CR_SUB_ERR_EID,
+                              CFE_EVS_EventType_ERROR,
+                              "Copilot App: Error subscribing to necessary messages, RC = 0x%08lX",
+                              (unsigned long)status);
+        }
+    }
+    {{/msgIds}}
+
+    if (status == CFE_SUCCESS)
+    {
+        status = CFE_SB_Subscribe(CFE_SB_ValueToMsgId(COPILOT_CFS_REEVAL_CMD_MID), COPILOT_CommandPipe);
+
+        if (status != CFE_SUCCESS)
+        {
+            CFE_EVS_SendEvent(COPILOT_CR_SUB_ERR_EID,
+                              CFE_EVS_EventType_ERROR,
+                              "Copilot App: Error subscribing to necessary messages, RC = 0x%08lX",
+                              (unsigned long)status);
+        }
+    }
+
+    CFE_EVS_SendEvent (COPILOT_STARTUP_INF_EID, CFE_EVS_EventType_INFORMATION,
                "COPILOT App Initialized. Version %d.%d.%d.%d",
                 COPILOT_CFS_MAJOR_VERSION,
                 COPILOT_CFS_MINOR_VERSION,
                 COPILOT_CFS_REVISION,
                 COPILOT_CFS_MISSION_REV);
+
+    return status;
 
 } /* End of COPILOT_AppInit() */
 
@@ -127,31 +173,41 @@ void COPILOT_AppInit(void)
 /* * * * * * * * * * * * * * * * * * * * * * * *  * * * * * * *  * *  * * * * */
 void COPILOT_ProcessCommandPacket(void)
 {
-    CFE_SB_MsgId_t  MsgId;
+    {{#msgCases}}
+    static CFE_SB_MsgId_t {{msgInfoId}}_s = CFE_SB_MSGID_RESERVED;
+    {{/msgCases}}
 
-    MsgId = CFE_SB_GetMsgId(COPILOTMsgPtr);
+    static CFE_SB_MsgId_t COPILOT_CFS_REEVAL_CMD_MID_s = CFE_SB_MSGID_RESERVED;
 
-    switch (MsgId)
+    CFE_SB_MsgId_t MsgId = CFE_SB_INVALID_MSG_ID;
+
+    if (!CFE_SB_IsValidMsgId(COPILOT_CFS_REEVAL_CMD_MID_s))
     {
+        COPILOT_CFS_REEVAL_CMD_MID_s = CFE_SB_ValueToMsgId(COPILOT_CFS_REEVAL_CMD_MID);
         {{#msgCases}}
-        case {{msgInfoId}}:
-            COPILOT_Process{{msgInfoDesc}}();
-            break;
-
+        {{msgInfoId}}_s = CFE_SB_ValueToMsgId({{msgInfoId}});
         {{/msgCases}}
-
-        case COPILOT_CFS_REEVAL_CMD_MID:
-            copilot_step();
-            break;
-
-        default:
-            COPILOT_HkTelemetryPkt.copilot_command_error_count++;
-            CFE_EVS_SendEvent(COPILOT_COMMAND_ERR_EID,CFE_EVS_ERROR,
-              "COPILOT: invalid command packet,MID = 0x%x", MsgId);
-            break;
     }
 
-    return;
+    CFE_MSG_GetMsgId(&SBBufPtr->Msg, &MsgId);
+
+    if (CFE_SB_MsgId_Equal(MsgId, COPILOT_CFS_REEVAL_CMD_MID_s))
+    {
+        copilot_step();
+    }
+    {{#msgCases}}
+    else if (CFE_SB_MsgId_Equal(MsgId, {{msgInfoId}}_s))
+    {
+        COPILOTMsgPtr = &SBBufPtr->Msg;
+        COPILOT_Process{{msgInfoDesc}}();
+    }
+    {{/msgCases}}
+    else
+    {
+        COPILOT_HkTelemetryPkt.copilot_command_error_count++;
+        CFE_EVS_SendEvent(COPILOT_COMMAND_ERR_EID,CFE_EVS_EventType_ERROR,
+          "COPILOT: invalid command packet,MID = 0x%x", CFE_SB_MsgIdToValue(MsgId));
+    }
 
 } /* End COPILOT_ProcessCommandPacket */
 
@@ -183,8 +239,6 @@ void COPILOT_Process{{msgDataDesc}}(void)
 }
 
 {{/msgHandlers}}
-
-
 {{#triggers}}
 /**
  * Report copilot property violations.
@@ -195,7 +249,7 @@ void {{triggerName}}({{.}} arg) {
 {{^triggerType}}
 void {{triggerName}}(void) {
 {{/triggerType}}
-    CFE_EVS_SendEvent(COPILOT_COMMANDCPVIOL_INF_EID, CFE_EVS_ERROR,
+    CFE_EVS_SendEvent(COPILOT_COMMANDCPVIOL_INF_EID, CFE_EVS_EventType_ERROR,
         "COPILOT: violation: {{triggerName}}");
 }
 {{/triggers}}

--- a/ogma-core/templates/cfs/copilot/fsw/src/copilot_cfs.h
+++ b/ogma-core/templates/cfs/copilot/fsw/src/copilot_cfs.h
@@ -39,13 +39,13 @@
 **       functions are not called from any other source module.
 */
 void COPILOT_AppMain(void);
-void COPILOT_AppInit(void);
+CFE_Status_t COPILOT_AppInit(void);
 void COPILOT_ProcessCommandPacket(void);
 {{#msgCases}}
 void COPILOT_Process{{msgInfoDesc}}(void);
 {{/msgCases}}
 void COPILOT_ResetCounters(void);
 
-boolean COPILOT_VerifyCmdLength(CFE_SB_MsgPtr_t msg, uint16 ExpectedLength);
+bool COPILOT_VerifyCmdLength(CFE_MSG_Message_t *msg, size_t ExpectedLength);
 
 #endif /* _copilot_app_h_ */

--- a/ogma-core/templates/cfs/copilot/fsw/src/copilot_cfs_events.h
+++ b/ogma-core/templates/cfs/copilot/fsw/src/copilot_cfs_events.h
@@ -19,6 +19,8 @@
 #define COPILOT_COMMANDCPVIOL_INF_EID       3
 #define COPILOT_INVALID_MSGID_ERR_EID       4
 #define COPILOT_LEN_ERR_EID                 5
+#define COPILOT_CR_PIPE_ERR_EID             6
+#define COPILOT_CR_SUB_ERR_EID              7
 
 #endif /* _copilot_app_events_h_ */
 

--- a/ogma-core/templates/cfs/copilot/fsw/src/copilot_cfs_msg.h
+++ b/ogma-core/templates/cfs/copilot/fsw/src/copilot_cfs_msg.h
@@ -18,7 +18,7 @@
 */
 typedef struct
 {
-   uint8    CmdHeader[CFE_SB_CMD_HDR_SIZE];
+   CFE_MSG_CommandHeader_t CmdHeader;
 
 } COPILOT_NoArgsCmd_t;
 
@@ -28,12 +28,12 @@ typedef struct
 */
 typedef struct
 {
-    uint8              TlmHeader[CFE_SB_TLM_HDR_SIZE];
-    uint8              copilot_command_error_count;
-    uint8              copilot_command_count;
-    uint8              spare[2];
+    CFE_MSG_TelemetryHeader_t TlmHeader;
+    uint8                     copilot_command_error_count;
+    uint8                     copilot_command_count;
+    uint8                     spare[2];
 
-}   OS_PACK copilot_hk_tlm_t  ;
+}   copilot_hk_tlm_t  ;
 
 #endif /* _copilot_cfs_msg_h_ */
 


### PR DESCRIPTION
Update the cFS template, CI job, and the cFS examples to work with a version of cFS in the 7.0 series, as prescribed in the solution proposed for #509.