### PR TITLE
`ogma-core`: Update `Dockerfile` in ROS 2 template for Space ROS `jazzy-2026.04.0`. Refs #512.

### DIFF
--- a/ogma-core/CHANGELOG.md
+++ b/ogma-core/CHANGELOG.md
@@ -29,6 +29,7 @@
 * Adjust ROS template to enable injecting dependencies (#500).
 * Bump upper version constraints on Copilot packages (#501).
 * Update cFS template for cFS 7.0 (#509).
+* Update `Dockerfile` in ROS 2 template for Space ROS `jazzy-2026.04.0` (#512).
 
 ## [1.14.0] - 2026-05-21
 

--- a/ogma-core/templates/ros/Dockerfile
+++ b/ogma-core/templates/ros/Dockerfile
@@ -1,4 +1,4 @@
-FROM osrf/space-ros:humble-2024.10.0
+FROM osrf/space-ros:jazzy-2026.04.0
 
 ARG USER=spaceros-user
 ARG PACKAGE_PATH=/home/${USER}/monitors
@@ -18,7 +18,7 @@ ADD --chmod=644 https://raw.githubusercontent.com/ros/rosdistro/master/ros.key /
 RUN sudo apt-get update
 
 ENV RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
-ENV ROS_DISTRO=humble
+ENV ROS_DISTRO=jazzy
 
 ADD manual-deps*.repos /tmp/
 RUN if [ -f "/tmp/manual-deps.repos" ]; then \
@@ -26,8 +26,9 @@ RUN if [ -f "/tmp/manual-deps.repos" ]; then \
     fi
 
 ADD excluded-pkgs*.txt /tmp/
+RUN sudo rosdep init
 RUN rosdep update
-RUN source /opt/spaceros/install/setup.bash && \
+RUN source /opt/ros/spaceros/setup.bash && \
     if [ -f "/tmp/excluded-pkgs.txt" ]; then \
       rosdep install -y \
         --from-paths src --ignore-src \
@@ -40,7 +41,7 @@ RUN source /opt/spaceros/install/setup.bash && \
     fi
 
 ADD manually-installed-pkgs*.txt /tmp/
-RUN source /opt/spaceros/install/setup.bash && \
+RUN source /opt/ros/spaceros/setup.bash && \
     colcon build --packages-select \
       copilot \
       test_requirements \


### PR DESCRIPTION
Updates `Dockerfile` included with the ROS 2 template to be based on Space ROS `jazzy-2026.04.0`, as prescribed in the solution proposed for #512.