### PR TITLE
`ogma-core`: Fix malformed comments. Refs #518.

### DIFF
--- a/ogma-core/CHANGELOG.md
+++ b/ogma-core/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Revision history for ogma-core
 
-## [1.X.Y] - 2026-07-22
+## [1.X.Y] - 2026-07-23
 
 * Replace adhoc function `mergeMaybe` with function from `base` (#516).
+* Fix malformed comments (#518).
 
 ## [1.15.0] - 2026-07-21
 

--- a/ogma-core/src/Data/Project.hs
+++ b/ogma-core/src/Data/Project.hs
@@ -25,7 +25,7 @@ import           Data.Aeson        (FromJSON, ToJSON, eitherDecodeStrict')
 import qualified Data.ByteString   as BS
 import           GHC.Generics      (Generic)
 
--- -- Internal imports
+-- Internal imports
 import Data.Either.Extra (mapLeft)
 
 data Project = Project

--- a/ogma-core/src/Language/Trans/CStruct2CopilotStruct.hs
+++ b/ogma-core/src/Language/Trans/CStruct2CopilotStruct.hs
@@ -48,7 +48,7 @@ mkCStruct (C.MkExternalDeclarationDeclaration (C.MkDeclaration specifiers initDe
       in CStruct <$> name <*> fields
     _ -> Left "C files must contain struct definitions only."
 
--- -- | Convert a declaration within a struct into a field declaration.
+-- | Convert a declaration within a struct into a field declaration.
 buildCField :: C.StructDeclaration -> Either String CField
 buildCField (C.MkStructDeclaration field name)
     | fieldLength > 0 = CArray <$> fieldType <*> fieldName <*> pure fieldLength
@@ -77,7 +77,7 @@ showTypeSpecifier C.MkTypeSpecifierInt32  = "int32_t"
 showTypeSpecifier C.MkTypeSpecifierInt64  = "int64_t"
 showTypeSpecifier C.MkTypeSpecifierInt    = "int"
 
--- -- | Extract the name of a field from a struct declarator.
+-- | Extract the name of a field from a struct declarator.
 extractFieldName :: Read n => C.StructDeclarator -> Either String n
 extractFieldName (C.MkStructDeclaratorDeclarator (C.MkDeclarator C.MkPointerOptNothing (C.MkDirectDeclaratorIdentifier (C.Identifier d)))) = Right $ read $ show d
 extractFieldName (C.MkStructDeclaratorDeclarator
@@ -92,8 +92,8 @@ extractFieldName (C.MkStructDeclaratorDeclarator
 extractFieldName _ = Left $ "only struct declarations that are IDs without a"
                         ++  " pointer, or plain arrays without a pointer, are"
                         ++  " supported."
---
--- -- | Extract the length of an array field from a struct declarator.
+
+-- | Extract the length of an array field from a struct declarator.
 extractFieldLength :: C.StructDeclarator -> Integer
 extractFieldLength (C.MkStructDeclaratorDeclarator
                      (C.MkDeclarator
@@ -139,7 +139,6 @@ extractFieldLength (C.MkStructDeclaratorDeclarator
                    ) = read i
 extractFieldLength _ = 0
 
---
 -- | Convert a 'String' to camel case, also eliminating the @_t@ at the end if
 -- present.
 camelCaseTypeName :: String -> String


### PR DESCRIPTION
Remove all occurrences of an extraneous `--` on the same line as the start of a comment, or the line before, as prescribed in the solution proposed for #518.