### PR TITLE
Remove unnecessary line breaks. Refs #520.

### DIFF
--- a/ogma-cli/CHANGELOG.md
+++ b/ogma-cli/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Revision history for ogma-cli
 
+## [1.X.Y] - 2026-07-23
+
+* Remove unnecessary line breaks (#520).
+
 ## [1.15.0] - 2026-07-21
 
 * Version bump (1.15.0) (#508).

--- a/ogma-cli/src/CLI/CommandCFSApp.hs
+++ b/ogma-cli/src/CLI/CommandCFSApp.hs
@@ -261,13 +261,11 @@ strCFSAppTemplateDirArgDesc =
 
 -- | Argument expression to CFS app generation command.
 strCFSAppConditionExprArgDesc :: String
-strCFSAppConditionExprArgDesc =
-  "Expression used as guard or trigger condition"
+strCFSAppConditionExprArgDesc = "Expression used as guard or trigger condition"
 
 -- | Argument input file to CFS app generation command
 strCFSAppFileNameArgDesc :: String
-strCFSAppFileNameArgDesc =
-  "File containing input specification"
+strCFSAppFileNameArgDesc = "File containing input specification"
 
 -- | Argument variable list to cFS app generation command
 strCFSAppVarListArgDesc :: String
@@ -276,8 +274,7 @@ strCFSAppVarListArgDesc =
 
 -- | Argument variable database to cFS app generation command
 strCFSAppVarDBArgDesc :: String
-strCFSAppVarDBArgDesc =
-  "File containing a DB of known cFS variables"
+strCFSAppVarDBArgDesc = "File containing a DB of known cFS variables"
 
 -- | Argument handler list to cFS app generation command
 strCFSAppHandlerListArgDesc :: String
@@ -294,8 +291,7 @@ strCFSAppPropFormatDesc = "Format of temporal or boolean properties"
 
 -- | External command to pre-process individual properties.
 strCFSAppPropViaDesc :: String
-strCFSAppPropViaDesc =
-  "Command to pre-process individual properties"
+strCFSAppPropViaDesc = "Command to pre-process individual properties"
 
 -- | Mode name flag description.
 strCFSAppDiagramModeDesc :: String

--- a/ogma-cli/src/CLI/CommandDiagram.hs
+++ b/ogma-cli/src/CLI/CommandDiagram.hs
@@ -122,8 +122,7 @@ command c
 
 -- | Command description for CLI help.
 commandDesc :: String
-commandDesc =
-  "Generate a monitor from state machine diagram"
+commandDesc = "Generate a monitor from state machine diagram"
 
 -- | Subparser for the @diagram@ command, used to generate a Copilot
 -- specification from an input diagram file.
@@ -216,21 +215,17 @@ strDiagramPropFormatDesc =
 
 -- | Target file name flag description.
 strDiagramTargetDesc :: String
-strDiagramTargetDesc =
-  "Filename prefix for monitoring files in target language"
+strDiagramTargetDesc = "Filename prefix for monitoring files in target language"
 
 -- | Mode name flag description.
 strDiagramModeDesc :: String
-strDiagramModeDesc =
-  "Mode of operation (check, calculate, safeguard)"
+strDiagramModeDesc = "Mode of operation (check, calculate, safeguard)"
 
 strDiagramInputVarDesc :: String
-strDiagramInputVarDesc =
-  "Name of the input variable"
+strDiagramInputVarDesc = "Name of the input variable"
 
 strDiagramStateVarDesc :: String
-strDiagramStateVarDesc =
-  "Name of the state variable"
+strDiagramStateVarDesc = "Name of the state variable"
 
 -- * Error codes
 

--- a/ogma-cli/src/CLI/CommandFPrimeApp.hs
+++ b/ogma-cli/src/CLI/CommandFPrimeApp.hs
@@ -257,8 +257,7 @@ strFPrimeAppConditionExprArgDesc =
 
 -- | Argument input file to FPrime component generation command
 strFPrimeAppFileNameArgDesc :: String
-strFPrimeAppFileNameArgDesc =
-  "File containing input specification"
+strFPrimeAppFileNameArgDesc = "File containing input specification"
 
 -- | Argument variable list to FPrime component generation command
 strFPrimeAppVarListArgDesc :: String
@@ -267,8 +266,7 @@ strFPrimeAppVarListArgDesc =
 
 -- | Argument variable database to FPrime component generation command
 strFPrimeAppVarDBArgDesc :: String
-strFPrimeAppVarDBArgDesc =
-  "File containing a DB of known F' variables"
+strFPrimeAppVarDBArgDesc = "File containing a DB of known F' variables"
 
 -- | Argument handler list to FPrime component generation command
 strFPrimeAppHandlerListArgDesc :: String
@@ -285,8 +283,7 @@ strFPrimeAppPropFormatDesc = "Format of temporal or boolean properties"
 
 -- | External command to pre-process individual properties.
 strFPrimeAppPropViaDesc :: String
-strFPrimeAppPropViaDesc =
-  "Command to pre-process individual properties"
+strFPrimeAppPropViaDesc = "Command to pre-process individual properties"
 
 -- | Additional template variable file flag description.
 strFPrimeAppTemplateVarsArgDesc :: String

--- a/ogma-cli/src/CLI/CommandOverview.hs
+++ b/ogma-cli/src/CLI/CommandOverview.hs
@@ -247,8 +247,7 @@ strOverviewPropFormatDesc = "Format of temporal or boolean properties"
 
 -- | External command to pre-process individual properties.
 strOverviewPropViaDesc :: String
-strOverviewPropViaDesc =
-  "Command to pre-process individual properties"
+strOverviewPropViaDesc = "Command to pre-process individual properties"
 
 -- | Error code for when a project cannot be read.
 cannotReadProject :: ErrorCode

--- a/ogma-cli/src/CLI/CommandROSApp.hs
+++ b/ogma-cli/src/CLI/CommandROSApp.hs
@@ -293,8 +293,7 @@ strROSAppConditionExprArgDesc = "Expression used as guard or trigger condition"
 
 -- | Argument input file to ROS app generation command
 strROSAppFileNameArgDesc :: String
-strROSAppFileNameArgDesc =
-  "File containing input specification"
+strROSAppFileNameArgDesc = "File containing input specification"
 
 -- | Argument variable list to ROS app generation command
 strROSAppVarListArgDesc :: String
@@ -303,8 +302,7 @@ strROSAppVarListArgDesc =
 
 -- | Argument variable database to ROS app generation command
 strROSAppVarDBArgDesc :: String
-strROSAppVarDBArgDesc =
-  "File containing a DB of known ROS variables"
+strROSAppVarDBArgDesc = "File containing a DB of known ROS variables"
 
 -- | Argument handler list to ROS app generation command
 strROSAppHandlerListArgDesc :: String
@@ -321,8 +319,7 @@ strROSAppPropFormatDesc = "Format of temporal or boolean properties"
 
 -- | External command to pre-process individual properties.
 strROSAppPropViaDesc :: String
-strROSAppPropViaDesc =
-  "Command to pre-process individual properties"
+strROSAppPropViaDesc = "Command to pre-process individual properties"
 
 -- | Additional template variable file flag description.
 strROSAppTemplateVarsArgDesc :: String

--- a/ogma-cli/src/CLI/CommandSearch.hs
+++ b/ogma-cli/src/CLI/CommandSearch.hs
@@ -235,8 +235,7 @@ strSearchPropFormatDesc = "Format of temporal or boolean properties"
 
 -- | External command to pre-process individual properties.
 strSearchPropViaDesc :: String
-strSearchPropViaDesc =
-  "Command to pre-process individual properties"
+strSearchPropViaDesc = "Command to pre-process individual properties"
 
 -- | Error code for when a project cannot be read.
 cannotReadProject :: ErrorCode

--- a/ogma-cli/src/CLI/CommandStandalone.hs
+++ b/ogma-cli/src/CLI/CommandStandalone.hs
@@ -149,8 +149,7 @@ typeMapping = map splitTypeMapping
 
 -- | Command description for CLI help.
 commandDesc :: String
-commandDesc =
-  "Generate a standalone Copilot file from an input specification"
+commandDesc = "Generate a standalone Copilot file from an input specification"
 
 -- | Subparser for the @standalone@ command, used to generate a Copilot
 -- specification from an input specification file.
@@ -276,8 +275,7 @@ strStandaloneTargetDesc =
 
 -- | External command to pre-process individual properties.
 strStandalonePropViaDesc :: String
-strStandalonePropViaDesc =
-  "Command to pre-process individual properties"
+strStandalonePropViaDesc = "Command to pre-process individual properties"
 
 -- | Additional template variable file flag description.
 strStandaloneTemplateVarsArgDesc :: String

--- a/ogma-cli/src/Main.hs
+++ b/ogma-cli/src/Main.hs
@@ -68,5 +68,4 @@ fullCLIOpts = info (commandOptsParser <**> helper)
 
 -- | Short program description
 strProgramSummary :: String
-strProgramSummary =
-  "ogma - an anything-to-Copilot application generator"
+strProgramSummary = "ogma - an anything-to-Copilot application generator"

--- a/ogma-cli/tests/Main.hs
+++ b/ogma-cli/tests/Main.hs
@@ -11,8 +11,7 @@ import Test.HUnit                     ( assertBool )
 
 -- | Run all unit tests on Ogma.
 main :: IO ()
-main =
-  defaultMainWithOpts tests mempty
+main = defaultMainWithOpts tests mempty
 
 -- | All unit tests for Ogma
 tests :: [Test.Framework.Test]

--- a/ogma-core/CHANGELOG.md
+++ b/ogma-core/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Replace adhoc function `mergeMaybe` with function from `base` (#516).
 * Fix malformed comments (#518).
+* Remove unnecessary line breaks (#520).
 
 ## [1.15.0] - 2026-07-21
 

--- a/ogma-core/src/Command/VariableDB.hs
+++ b/ogma-core/src/Command/VariableDB.hs
@@ -105,8 +105,7 @@ emptyVariableDB = VariableDB [] [] []
 
 -- | Find an input with a given name.
 findInput :: VariableDB -> String -> Maybe InputDef
-findInput varDB name =
-  find (\x -> inputName x == name) (inputs varDB)
+findInput varDB name = find (\x -> inputName x == name) (inputs varDB)
 
 -- | Find a connection a given scope.
 findConnection :: InputDef -> String -> Maybe Connection

--- a/ogma-core/tests/Main.hs
+++ b/ogma-core/tests/Main.hs
@@ -14,8 +14,7 @@ import Command.Standalone       (CommandOptions (..), command)
 
 -- | Run all unit tests on ogma-core.
 main :: IO ()
-main =
-  defaultMainWithOpts tests mempty
+main = defaultMainWithOpts tests mempty
 
 -- | All unit tests for ogma-core.
 tests :: [Test.Framework.Test]

--- a/ogma-extra/CHANGELOG.md
+++ b/ogma-extra/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Revision history for ogma-extra
 
+## [1.X.Y] - 2026-07-23
+
+* Remove unnecessary line breaks (#520).
+
 ## [1.15.0] - 2026-07-21
 
 * Version bump (1.15.0) (#508).

--- a/ogma-extra/tests/Main.hs
+++ b/ogma-extra/tests/Main.hs
@@ -29,8 +29,7 @@ import Data.List.Extra ( headEither, toHead, toTail )
 
 -- | Run all unit tests on Ogma's core.
 main :: IO ()
-main =
-  defaultMainWithOpts tests mempty
+main = defaultMainWithOpts tests mempty
 
 -- | All unit tests for Ogma's core.
 tests :: [Test.Framework.Test]

--- a/ogma-language-c/CHANGELOG.md
+++ b/ogma-language-c/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Revision history for ogma-language-c
 
+## [1.X.Y] - 2026-07-23
+
+* Remove unnecessary line breaks (#520).
+
 ## [1.15.0] - 2026-07-21
 
 * Version bump (1.15.0) (#508).

--- a/ogma-language-c/tests/Main.hs
+++ b/ogma-language-c/tests/Main.hs
@@ -30,8 +30,7 @@ import qualified Language.C.ParC as C ( myLexer, pTranslationUnit )
 
 -- | Run all unit tests for the C parser.
 main :: IO ()
-main =
-  defaultMainWithOpts tests mempty
+main = defaultMainWithOpts tests mempty
 
 -- | All unit tests for the C parser.
 tests :: [Test.Framework.Test]

--- a/ogma-language-lustre/CHANGELOG.md
+++ b/ogma-language-lustre/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Revision history for ogma-language-lustre
 
+## [1.X.Y] - 2026-07-27
+
+* Remove unnecessary line breaks (#520).
+
 ## [1.15.0] - 2026-07-21
 
 * Version bump (1.15.0) (#508).

--- a/ogma-language-lustre/tests/Main.hs
+++ b/ogma-language-lustre/tests/Main.hs
@@ -30,8 +30,7 @@ import qualified Language.Lustre.ParLustre as Lustre ( myLexer, pBoolSpec )
 
 -- | Run all unit tests for the Lustre parser.
 main :: IO ()
-main =
-  defaultMainWithOpts tests mempty
+main = defaultMainWithOpts tests mempty
 
 -- | All unit tests for the Lustre parser.
 tests :: [Test.Framework.Test]

--- a/ogma-language-smv/CHANGELOG.md
+++ b/ogma-language-smv/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Revision history for ogma-language-smv
 
+## [1.X.Y] - 2026-07-23
+
+* Remove unnecessary line breaks (#520).
+
 ## [1.15.0] - 2026-07-21
 
 * Version bump (1.15.0) (#508).

--- a/ogma-language-smv/tests/Main.hs
+++ b/ogma-language-smv/tests/Main.hs
@@ -30,8 +30,7 @@ import qualified Language.SMV.ParSMV as SMV ( myLexer, pBoolSpec )
 
 -- | Run all unit tests for the SMV parser.
 main :: IO ()
-main =
-  defaultMainWithOpts tests mempty
+main = defaultMainWithOpts tests mempty
 
 -- | All unit tests for the SMV parser.
 tests :: [Test.Framework.Test]

--- a/ogma-language-xmlspec/CHANGELOG.md
+++ b/ogma-language-xmlspec/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Revision history for ogma-language-xmlspec
 
+## [1.X.Y] - 2026-07-23
+
+* Remove unnecessary line breaks (#520).
+
 ## [1.15.0] - 2026-07-21
 
 * Version bump (1.15.0) (#508).

--- a/ogma-language-xmlspec/src/Language/XMLSpec/Parser.hs
+++ b/ogma-language-xmlspec/src/Language/XMLSpec/Parser.hs
@@ -227,8 +227,7 @@ type XPathExpr = String
 resolveIndirectly :: String
                   -> (String, Maybe (String, String))
                   -> ExceptT String IO XPathExpr
-resolveIndirectly _ (query, Nothing) =
-  liftEither $ checkXPathExpr query
+resolveIndirectly _ (query, Nothing) = liftEither $ checkXPathExpr query
 
 resolveIndirectly xml (query, Just (key, val)) = do
   -- Check that the given query string parses correctly.


### PR DESCRIPTION
Remove unnecessary line breaks in top-level definitions across multiple libraries, as prescribed in the solution proposed for #520.