### PR TITLE
Add missing periods to Haddock comments. Refs #524.

### DIFF
--- a/ogma-cli/CHANGELOG.md
+++ b/ogma-cli/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Remove unnecessary line breaks (#520).
 * Update cFS examples to avoid MID collisions (#522).
+* Add missing periods to Haddock comments (#524).
 
 ## [1.15.0] - 2026-07-21
 

--- a/ogma-cli/src/CLI/CommandCFSApp.hs
+++ b/ogma-cli/src/CLI/CommandCFSApp.hs
@@ -144,7 +144,7 @@ commandProjectOptions projectFile c = do
 
 -- * CLI
 
--- | cFS command description
+-- | cFS command description.
 commandDesc :: String
 commandDesc = "Generate a complete cFS/Copilot application"
 
@@ -250,11 +250,11 @@ commandOptsParser = CommandOpts
 strCFSAppProjectArgDesc :: String
 strCFSAppProjectArgDesc = "Project file"
 
--- | Argument target directory to cFS app generation command
+-- | Argument target directory to cFS app generation command.
 strCFSAppDirArgDesc :: String
 strCFSAppDirArgDesc = "Target directory"
 
--- | Argument template directory to cFS app generation command
+-- | Argument template directory to cFS app generation command.
 strCFSAppTemplateDirArgDesc :: String
 strCFSAppTemplateDirArgDesc =
   "Directory holding cFS application source template"
@@ -263,20 +263,20 @@ strCFSAppTemplateDirArgDesc =
 strCFSAppConditionExprArgDesc :: String
 strCFSAppConditionExprArgDesc = "Expression used as guard or trigger condition"
 
--- | Argument input file to CFS app generation command
+-- | Argument input file to CFS app generation command.
 strCFSAppFileNameArgDesc :: String
 strCFSAppFileNameArgDesc = "File containing input specification"
 
--- | Argument variable list to cFS app generation command
+-- | Argument variable list to cFS app generation command.
 strCFSAppVarListArgDesc :: String
 strCFSAppVarListArgDesc =
   "File containing list of cFS variables to make accessible"
 
--- | Argument variable database to cFS app generation command
+-- | Argument variable database to cFS app generation command.
 strCFSAppVarDBArgDesc :: String
 strCFSAppVarDBArgDesc = "File containing a DB of known cFS variables"
 
--- | Argument handler list to cFS app generation command
+-- | Argument handler list to cFS app generation command.
 strCFSAppHandlerListArgDesc :: String
 strCFSAppHandlerListArgDesc =
   "File containing list of Copilot handlers used in the specification"
@@ -298,7 +298,7 @@ strCFSAppDiagramModeDesc :: String
 strCFSAppDiagramModeDesc =
   "Mode of operation for diagrams (check, calculate, safeguard)"
 
--- | Argument template variables to cFS app generation command
+-- | Argument template variables to cFS app generation command.
 strCFSAppTemplateVarsArgDesc :: String
 strCFSAppTemplateVarsArgDesc =
   "JSON file containing additional variables to expand in template"

--- a/ogma-cli/src/CLI/CommandCStructs2Copilot.hs
+++ b/ogma-cli/src/CLI/CommandCStructs2Copilot.hs
@@ -15,7 +15,7 @@
 -- License for the specific language governing permissions and limitations
 -- under the License.
 --
--- | CLI interface to the CStructs2Copilot subcommand
+-- | CLI interface to the CStructs2Copilot subcommand.
 module CLI.CommandCStructs2Copilot
     (
       -- * Direct command access
@@ -68,6 +68,6 @@ commandOptsParser = CommandOpts
         <> help strStructsInputFileArgDesc
         )
 
--- | Argument C header file to struct conversion command
+-- | Argument C header file to struct conversion command.
 strStructsInputFileArgDesc :: String
 strStructsInputFileArgDesc = "C header file with struct definitions"

--- a/ogma-cli/src/CLI/CommandCStructs2MsgHandlers.hs
+++ b/ogma-cli/src/CLI/CommandCStructs2MsgHandlers.hs
@@ -15,7 +15,7 @@
 -- License for the specific language governing permissions and limitations
 -- under the License.
 --
--- | CLI interface to the CStructs2Copilot subcommand
+-- | CLI interface to the CStructs2Copilot subcommand.
 module CLI.CommandCStructs2MsgHandlers
     (
       -- * Direct command access
@@ -67,6 +67,6 @@ commandOptsParser = CommandOpts
         <> help strMsgHandlersInputFileArgDesc
         )
 
--- | Argument C header file to handler generation command
+-- | Argument C header file to handler generation command.
 strMsgHandlersInputFileArgDesc :: String
 strMsgHandlersInputFileArgDesc = "C header file with struct definitions"

--- a/ogma-cli/src/CLI/CommandFPrimeApp.hs
+++ b/ogma-cli/src/CLI/CommandFPrimeApp.hs
@@ -142,7 +142,7 @@ commandProjectOptions projectFile c = do
 
 -- * CLI
 
--- | FPrime command description
+-- | FPrime command description.
 commandDesc :: String
 commandDesc = "Generate a complete F' monitoring component"
 
@@ -241,11 +241,11 @@ commandOptsParser = CommandOpts
 strFPrimeAppProjectArgDesc :: String
 strFPrimeAppProjectArgDesc = "Project file"
 
--- | Argument target directory to FPrime component generation command
+-- | Argument target directory to FPrime component generation command.
 strFPrimeAppDirArgDesc :: String
 strFPrimeAppDirArgDesc = "Target directory"
 
--- | Argument template directory to FPrime component generation command
+-- | Argument template directory to FPrime component generation command.
 strFPrimeAppTemplateDirArgDesc :: String
 strFPrimeAppTemplateDirArgDesc =
   "Directory holding F' component source template"
@@ -255,20 +255,20 @@ strFPrimeAppConditionExprArgDesc :: String
 strFPrimeAppConditionExprArgDesc =
   "Expression used as guard or trigger condition"
 
--- | Argument input file to FPrime component generation command
+-- | Argument input file to FPrime component generation command.
 strFPrimeAppFileNameArgDesc :: String
 strFPrimeAppFileNameArgDesc = "File containing input specification"
 
--- | Argument variable list to FPrime component generation command
+-- | Argument variable list to FPrime component generation command.
 strFPrimeAppVarListArgDesc :: String
 strFPrimeAppVarListArgDesc =
   "File containing list of F' variables to make accessible"
 
--- | Argument variable database to FPrime component generation command
+-- | Argument variable database to FPrime component generation command.
 strFPrimeAppVarDBArgDesc :: String
 strFPrimeAppVarDBArgDesc = "File containing a DB of known F' variables"
 
--- | Argument handler list to FPrime component generation command
+-- | Argument handler list to FPrime component generation command.
 strFPrimeAppHandlerListArgDesc :: String
 strFPrimeAppHandlerListArgDesc =
   "File containing list of Copilot handlers used in the specification"

--- a/ogma-cli/src/CLI/CommandROSApp.hs
+++ b/ogma-cli/src/CLI/CommandROSApp.hs
@@ -166,7 +166,7 @@ commandProjectOptions projectFile c = do
 
 -- * CLI
 
--- | ROS command description
+-- | ROS command description.
 commandDesc :: String
 commandDesc = "Generate a ROS 2 monitoring package"
 
@@ -278,11 +278,11 @@ commandOptsParser = CommandOpts
 strROSAppProjectArgDesc :: String
 strROSAppProjectArgDesc = "Project file"
 
--- | Argument target directory to ROS app generation command
+-- | Argument target directory to ROS app generation command.
 strROSAppDirArgDesc :: String
 strROSAppDirArgDesc = "Target directory"
 
--- | Argument template directory to ROS app generation command
+-- | Argument template directory to ROS app generation command.
 strROSAppTemplateDirArgDesc :: String
 strROSAppTemplateDirArgDesc =
   "Directory holding ROS application source template"
@@ -291,20 +291,20 @@ strROSAppTemplateDirArgDesc =
 strROSAppConditionExprArgDesc :: String
 strROSAppConditionExprArgDesc = "Expression used as guard or trigger condition"
 
--- | Argument input file to ROS app generation command
+-- | Argument input file to ROS app generation command.
 strROSAppFileNameArgDesc :: String
 strROSAppFileNameArgDesc = "File containing input specification"
 
--- | Argument variable list to ROS app generation command
+-- | Argument variable list to ROS app generation command.
 strROSAppVarListArgDesc :: String
 strROSAppVarListArgDesc =
   "File containing list of ROS variables to make accessible"
 
--- | Argument variable database to ROS app generation command
+-- | Argument variable database to ROS app generation command.
 strROSAppVarDBArgDesc :: String
 strROSAppVarDBArgDesc = "File containing a DB of known ROS variables"
 
--- | Argument handler list to ROS app generation command
+-- | Argument handler list to ROS app generation command.
 strROSAppHandlerListArgDesc :: String
 strROSAppHandlerListArgDesc =
   "File containing list of Copilot handlers used in the specification"
@@ -326,12 +326,12 @@ strROSAppTemplateVarsArgDesc :: String
 strROSAppTemplateVarsArgDesc =
   "JSON file containing additional variables to expand in template"
 
--- | Argument packages to tested list to ROS app generation command
+-- | Argument packages to tested list to ROS app generation command.
 strROSAppROSNodesTestingListArgDesc :: String
 strROSAppROSNodesTestingListArgDesc =
   "Turn on ROS 2 package node during testing"
 
--- | Argument variables to be tested list to ROS app generation command
+-- | Argument variables to be tested list to ROS app generation command.
 strROSAppVarsTestingListArgDesc :: String
 strROSAppVarsTestingListArgDesc =
   "Limit random input generation to these variables"

--- a/ogma-cli/src/CLI/CommandStandalone.hs
+++ b/ogma-cli/src/CLI/CommandStandalone.hs
@@ -15,7 +15,7 @@
 -- License for the specific language governing permissions and limitations
 -- under the License.
 --
--- | CLI interface to the Standalone subcommand
+-- | CLI interface to the Standalone subcommand.
 module CLI.CommandStandalone
     (
       -- * Direct command access

--- a/ogma-cli/src/Main.hs
+++ b/ogma-cli/src/Main.hs
@@ -66,6 +66,6 @@ fullCLIOpts = info (commandOptsParser <**> helper)
   <> header strProgramSummary
   )
 
--- | Short program description
+-- | Short program description.
 strProgramSummary :: String
 strProgramSummary = "ogma - an anything-to-Copilot application generator"

--- a/ogma-cli/tests/Main.hs
+++ b/ogma-cli/tests/Main.hs
@@ -1,4 +1,4 @@
--- | Test Ogma
+-- | Test Ogma.
 module Main where
 
 import Data.List                      ( intercalate )
@@ -13,7 +13,7 @@ import Test.HUnit                     ( assertBool )
 main :: IO ()
 main = defaultMainWithOpts tests mempty
 
--- | All unit tests for Ogma
+-- | All unit tests for Ogma.
 tests :: [Test.Framework.Test]
 tests =
   [

--- a/ogma-core/CHANGELOG.md
+++ b/ogma-core/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Replace adhoc function `mergeMaybe` with function from `base` (#516).
 * Fix malformed comments (#518).
 * Remove unnecessary line breaks (#520).
+* Add missing periods to Haddock comments (#524).
 
 ## [1.15.0] - 2026-07-21
 

--- a/ogma-core/src/Command/Result.hs
+++ b/ogma-core/src/Command/Result.hs
@@ -26,7 +26,7 @@ module Command.Result
 -- Internal imports
 import Data.Location ( Location )
 
--- | Result of the global process
+-- | Result of the global process.
 data Result a = Success
               | Error a String Location
 

--- a/ogma-core/src/Data/Diagram/Parser/Mermaid.hs
+++ b/ogma-core/src/Data/Diagram/Parser/Mermaid.hs
@@ -176,6 +176,6 @@ pSequenceArrow = void $ choice
   , string "-)"
   ]
 
--- | Consume spaces
+-- | Consume spaces.
 spaces :: MermaidParser ()
 spaces = L.space space1 empty empty

--- a/ogma-core/src/Language/Trans/CStruct2CopilotStruct.hs
+++ b/ogma-core/src/Language/Trans/CStruct2CopilotStruct.hs
@@ -35,7 +35,7 @@ import Language.Copilot.CStruct ( CField (CArray, CPlain), CStruct(..) )
 -- Internal imports
 import qualified Language.C.AbsC as C
 
--- | Convert a top-level struct declaration into a CStruct
+-- | Convert a top-level struct declaration into a CStruct.
 mkCStruct :: C.ExternalDeclaration -> Either String CStruct
 mkCStruct (C.MkExternalDeclarationFunctionDefinition _) = Left "C files must contain struct definitions only."
 mkCStruct (C.MkExternalDeclarationDeclaration (C.MkDeclaration specifiers initDecl)) =

--- a/ogma-core/tests/Main.hs
+++ b/ogma-core/tests/Main.hs
@@ -1,4 +1,4 @@
--- | Test ogma-core
+-- | Test ogma-core.
 module Main where
 
 import Data.Monoid                    ( mempty )

--- a/ogma-language-xmlspec/CHANGELOG.md
+++ b/ogma-language-xmlspec/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [1.X.Y] - 2026-07-23
 
 * Remove unnecessary line breaks (#520).
+* Add missing periods to Haddock comments (#524).
 
 ## [1.15.0] - 2026-07-21
 

--- a/ogma-language-xmlspec/src/Language/XMLSpec/Parser.hs
+++ b/ogma-language-xmlspec/src/Language/XMLSpec/Parser.hs
@@ -363,7 +363,7 @@ listToEither _   [x] = Right x
 listToEither msg []  = Left $ "Failed to find a value for " ++ msg
 listToEither msg _   = Left $ "Unexpectedly found multiple values for " ++ msg
 
--- | Replace a string by another string
+-- | Replace a string by another string.
 replace :: String -> String -> String -> String
 replace []           _k  _v    = []
 replace string@(h:t) key value


### PR DESCRIPTION
Adds missing periods at the end of Haddock comments, as prescribed in the solution proposed for #524.