### PR TITLE
Fix spelling of F Prime. Refs #526.

### DIFF
--- a/ogma-cli/CHANGELOG.md
+++ b/ogma-cli/CHANGELOG.md
@@ -1,10 +1,11 @@
 # Revision history for ogma-cli
 
-## [1.X.Y] - 2026-07-23
+## [1.X.Y] - 2026-07-29
 
 * Remove unnecessary line breaks (#520).
 * Update cFS examples to avoid MID collisions (#522).
 * Add missing periods to Haddock comments (#524).
+* Fix spelling of F Prime (#526).
 
 ## [1.15.0] - 2026-07-21
 

--- a/ogma-cli/README.md
+++ b/ogma-cli/README.md
@@ -13,7 +13,7 @@ verification framework that generates hard real-time C99 code.
 - Generating [Robot Operating System](https://ros.org) runtime monitoring
   applications.
 
-- Generating [F' (FPrime)](https://github.com/nasa/fprime/) runtime monitoring
+- Generating [F' (F Prime)](https://github.com/nasa/fprime/) runtime monitoring
   components.
 
 - Generating message handlers for NASA Core Flight System applications to make
@@ -567,7 +567,7 @@ or variables file but a matching entry is not found in the variable DB.
 
 ## F' Component Generation
 
-F' (FPrime) is a component-based framework for spaceflight applications.
+F' (F Prime) is a component-based framework for spaceflight applications.
 
 Ogma is able to generate F' monitoring components that subscribe to obtain
 the data needed by the monitors and report any violations. At present, support
@@ -651,7 +651,7 @@ In our example, we only care about the boolean variables; it is sufficient that
 they be listed in the variable DB file.
 
 Finally, the handlers file is a list of monitor handlers that the generated
-FPrime component should restrict to monitoring. They are listed one per line:
+F Prime component should restrict to monitoring. They are listed one per line:
 ```sh
 $ cat handlers
 handlerpropREQ_001

--- a/ogma-cli/src/CLI/CommandFPrimeApp.hs
+++ b/ogma-cli/src/CLI/CommandFPrimeApp.hs
@@ -47,7 +47,7 @@ import qualified Command.FPrimeApp
 
 -- * Command
 
--- | Options needed to generate the FPrime component.
+-- | Options needed to generate the F Prime component.
 data CommandOpts = CommandOpts
   { fprimeAppProject       :: Maybe String
   , fprimeAppConditionExpr :: Maybe String
@@ -63,7 +63,7 @@ data CommandOpts = CommandOpts
   , fprimeAppTemplateVars  :: Maybe String
   }
 
--- | Create <https://github.com/nasa/fprime FPrime> component that subscribe
+-- | Create <https://github.com/nasa/fprime F Prime> component that subscribe
 -- to obtain necessary data from the bus and call Copilot when new data
 -- arrives.
 --
@@ -142,11 +142,11 @@ commandProjectOptions projectFile c = do
 
 -- * CLI
 
--- | FPrime command description.
+-- | F Prime command description.
 commandDesc :: String
 commandDesc = "Generate a complete F' monitoring component"
 
--- | Subparser for the @fprime@ command, used to generate an FPrime component
+-- | Subparser for the @fprime@ command, used to generate an F Prime component
 -- connected to Copilot monitors.
 commandOptsParser :: Parser CommandOpts
 commandOptsParser = CommandOpts
@@ -237,38 +237,38 @@ commandOptsParser = CommandOpts
             )
         )
 
--- | Argument project to FPrime app generation command.
+-- | Argument project to F Prime app generation command.
 strFPrimeAppProjectArgDesc :: String
 strFPrimeAppProjectArgDesc = "Project file"
 
--- | Argument target directory to FPrime component generation command.
+-- | Argument target directory to F Prime component generation command.
 strFPrimeAppDirArgDesc :: String
 strFPrimeAppDirArgDesc = "Target directory"
 
--- | Argument template directory to FPrime component generation command.
+-- | Argument template directory to F Prime component generation command.
 strFPrimeAppTemplateDirArgDesc :: String
 strFPrimeAppTemplateDirArgDesc =
   "Directory holding F' component source template"
 
--- | Argument expression to FPrime app generation command.
+-- | Argument expression to F Prime app generation command.
 strFPrimeAppConditionExprArgDesc :: String
 strFPrimeAppConditionExprArgDesc =
   "Expression used as guard or trigger condition"
 
--- | Argument input file to FPrime component generation command.
+-- | Argument input file to F Prime component generation command.
 strFPrimeAppFileNameArgDesc :: String
 strFPrimeAppFileNameArgDesc = "File containing input specification"
 
--- | Argument variable list to FPrime component generation command.
+-- | Argument variable list to F Prime component generation command.
 strFPrimeAppVarListArgDesc :: String
 strFPrimeAppVarListArgDesc =
   "File containing list of F' variables to make accessible"
 
--- | Argument variable database to FPrime component generation command.
+-- | Argument variable database to F Prime component generation command.
 strFPrimeAppVarDBArgDesc :: String
 strFPrimeAppVarDBArgDesc = "File containing a DB of known F' variables"
 
--- | Argument handler list to FPrime component generation command.
+-- | Argument handler list to F Prime component generation command.
 strFPrimeAppHandlerListArgDesc :: String
 strFPrimeAppHandlerListArgDesc =
   "File containing list of Copilot handlers used in the specification"

--- a/ogma-cli/src/CLI/CommandTop.hs
+++ b/ogma-cli/src/CLI/CommandTop.hs
@@ -182,7 +182,7 @@ subcommandROSApp =
     (CommandOptsROSApp <$> CLI.CommandROSApp.commandOptsParser)
     CLI.CommandROSApp.commandDesc
 
--- | Modifier for the FPrime app expansion subcommand, linking the subcommand
+-- | Modifier for the F Prime app expansion subcommand, linking the subcommand
 -- options and description to the command @fprime@ at top level.
 subcommandFPrimeApp :: Mod CommandFields CommandOpts
 subcommandFPrimeApp =

--- a/ogma-cli/src/Main.hs
+++ b/ogma-cli/src/Main.hs
@@ -39,7 +39,7 @@
 -- * Generate Robot Operating System (ROS) applications for runtime monitoring
 -- using Copilot.
 --
--- * Generate F' (FPrime) components for runtime monitoring using Copilot.
+-- * Generate F' (F Prime) components for runtime monitoring using Copilot.
 --
 -- More information can be obtained by calling ogma with the argument @--help@.
 module Main

--- a/ogma-core/CHANGELOG.md
+++ b/ogma-core/CHANGELOG.md
@@ -1,11 +1,12 @@
 # Revision history for ogma-core
 
-## [1.X.Y] - 2026-07-23
+## [1.X.Y] - 2026-07-29
 
 * Replace adhoc function `mergeMaybe` with function from `base` (#516).
 * Fix malformed comments (#518).
 * Remove unnecessary line breaks (#520).
 * Add missing periods to Haddock comments (#524).
+* Fix spelling of F Prime (#526).
 
 ## [1.15.0] - 2026-07-21
 

--- a/ogma-core/src/Command/FPrimeApp.hs
+++ b/ogma-core/src/Command/FPrimeApp.hs
@@ -19,7 +19,7 @@
 -- License for the specific language governing permissions and limitations
 -- under the License.
 --
--- | Create <https://github.com/nasa/fprime FPrime> components that subscribe
+-- | Create <https://github.com/nasa/fprime F Prime> components that subscribe
 -- to obtain data and call Copilot when new values arrive.
 
 {- HLINT ignore "Functor law" -}
@@ -67,7 +67,7 @@ import Data.Location                  (Location (..))
 import Data.Spec.Parser               (readInputExpr)
 import Language.Trans.Diagram2Copilot (DiagramMode (..))
 
--- | Generate a new FPrime component connected to Copilot.
+-- | Generate a new F Prime component connected to Copilot.
 command :: CommandOptions -- ^ Options to the ROS backend.
         -> IO (Result ErrorCode)
 command options = processResult $ do

--- a/ogma-core/templates/fprime/Dockerfile
+++ b/ogma-core/templates/fprime/Dockerfile
@@ -1,11 +1,11 @@
-# This dockerfile compiles a monitoring application inside FPrime's Reference
+# This dockerfile compiles a monitoring application inside F Prime's Reference
 # Application.
 FROM ubuntu:focal
 
 # Avoid questions during package installation.
 ENV DEBIAN_FRONTEND=noninteractive
 
-# Install FPrime dependencies and clone fprime from the repo.
+# Install F Prime dependencies and clone fprime from the repo.
 RUN apt-get update
 RUN apt-get install -y git cmake gcc python3 pip default-jre
 


### PR DESCRIPTION
Replace all occurrences of FPrime with F Prime in comments, strings and documentation, as prescribed in the solution proposed for #526.