### PR TITLE
`ogma-cli`: Fix target directory name in project file in Turtlesim example. Refs #530.

### DIFF
--- a/ogma-cli/CHANGELOG.md
+++ b/ogma-cli/CHANGELOG.md
@@ -1,11 +1,12 @@
 # Revision history for ogma-cli
 
-## [1.X.Y] - 2026-07-29
+## [1.X.Y] - 2026-08-01
 
 * Remove unnecessary line breaks (#520).
 * Update cFS examples to avoid MID collisions (#522).
 * Add missing periods to Haddock comments (#524).
 * Fix spelling of F Prime (#526).
+* Fix target directory name in project file in Turtlesim example (#530).
 
 ## [1.15.0] - 2026-07-21
 

--- a/ogma-cli/examples/ros2-turtlesim/project.ogma
+++ b/ogma-cli/examples/ros2-turtlesim/project.ogma
@@ -12,6 +12,6 @@
   "projectHandlerFile": null,
   "projectCommandPropVia": null,
   "projectTemplateDir": null,
-  "projectTargetDir": "ros2-turtlesim",
+  "projectTargetDir": "turtlesim-demo",
   "projectExtraJSONFile": "ogma-cli/examples/ros2-turtlesim/extra-vars-turtlesim.json"
 }


### PR DESCRIPTION
Modify the project file included with the Turtlesim example to use the same target directory used in the accompanying README, as prescribed in the solution proposed for #530.