### PR TITLE
`ogma-cli`: Add CI job to test ROS 2 backend using Turtlesim example. Refs #534.

### DIFF
--- a/.github/workflows/repo-ghc-9.10-cabal-3.12-ros-turtlesim.yml
+++ b/.github/workflows/repo-ghc-9.10-cabal-3.12-ros-turtlesim.yml
@@ -1,0 +1,54 @@
+name: ros-ghc-9.10-cabal-3.12-turtlesim
+
+# Trigger the workflow on push or pull request
+on:
+  - pull_request
+  - push
+
+jobs:
+  cabal:
+    name: ${{ matrix.os }} / ghc ${{ matrix.ghc }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        cabal: ["3.12"]
+        ghc:
+          - "9.10"
+
+    steps:
+
+    - uses: haskell-actions/setup@main
+      id: setup-haskell-cabal
+      name: Setup Haskell
+      with:
+        ghc-version: ${{ matrix.ghc }}
+        cabal-version: ${{ matrix.cabal }}
+
+    - name: Prepare environment
+      run: |
+        echo "$HOME/.ghcup/bin" >> $GITHUB_PATH
+        echo "$HOME/.cabal/bin" >> $GITHUB_PATH
+        echo "$HOME/.local/bin" >> $GITHUB_PATH
+
+    - uses: actions/checkout@v4
+
+    - name: Install dependencies
+      run: |
+        sudo apt-get install -y libbz2-dev libexpat-dev
+        cabal install --lib copilot copilot-c99 copilot-language copilot-theorem \
+          copilot-libraries copilot-interpreter
+
+    - name: Install ogma
+      run: |
+        cabal install ogma-cli:ogma
+
+    - name: Generate ROS app
+      run: |
+        ogma ros --project ogma-cli/examples/ros2-turtlesim/project.ogma
+        cp ogma-cli/examples/ros2-turtlesim/manual-deps.repos turtlesim-demo/
+        cp ogma-cli/examples/ros2-turtlesim/manually-installed-pkgs.txt turtlesim-demo/
+        cd turtlesim-demo/copilot/src/
+        runhaskell Copilot.hs
+        cd ../../
+        docker build -t ogma-turtlesim-demo .

--- a/ogma-cli/CHANGELOG.md
+++ b/ogma-cli/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Add missing periods to Haddock comments (#524).
 * Fix spelling of F Prime (#526).
 * Fix target directory name in project file in Turtlesim example (#530).
+* Add CI job to test ROS 2 backend using Turtlesim example (#534).
 
 ## [1.15.0] - 2026-07-21
 


### PR DESCRIPTION
Add a new CI workflow file that tests the Turtlesim example and compiles the generated code, as prescribed in the solution proposed for #534.