### PR TITLE
`ogma-cli`: Disable secure mode for package repo in Cabal config in CI jobs. Refs #537.

### DIFF
--- a/.github/workflows/repo-ghc-8.6-cabal-2.4-cfs.yml
+++ b/.github/workflows/repo-ghc-8.6-cabal-2.4-cfs.yml
@@ -28,6 +28,8 @@ jobs:
       run: |
         echo "$HOME/.ghcup/bin" >> $GITHUB_PATH
         echo "$HOME/.cabal/bin" >> $GITHUB_PATH
+        sed -i -e 's/^.*\<secure: True/  secure: False/g' $HOME/.cabal/config
+        cabal update
 
     - uses: actions/checkout@v4
 

--- a/.github/workflows/repo-ghc-8.6-cabal-2.4-csv.yml
+++ b/.github/workflows/repo-ghc-8.6-cabal-2.4-csv.yml
@@ -28,6 +28,8 @@ jobs:
       run: |
         echo "$HOME/.ghcup/bin" >> $GITHUB_PATH
         echo "$HOME/.cabal/bin" >> $GITHUB_PATH
+        sed -i -e 's/^.*\<secure: True/  secure: False/g' $HOME/.cabal/config
+        cabal update
 
     - uses: actions/checkout@v4
 

--- a/.github/workflows/repo-ghc-8.6-cabal-2.4-diagram.yml
+++ b/.github/workflows/repo-ghc-8.6-cabal-2.4-diagram.yml
@@ -28,6 +28,8 @@ jobs:
       run: |
         echo "$HOME/.ghcup/bin" >> $GITHUB_PATH
         echo "$HOME/.cabal/bin" >> $GITHUB_PATH
+        sed -i -e 's/^.*\<secure: True/  secure: False/g' $HOME/.cabal/config
+        cabal update
 
     - uses: actions/checkout@v4
 

--- a/.github/workflows/repo-ghc-8.6-cabal-2.4-ros.yml
+++ b/.github/workflows/repo-ghc-8.6-cabal-2.4-ros.yml
@@ -30,6 +30,8 @@ jobs:
         echo "$HOME/.ghcup/bin" >> $GITHUB_PATH
         echo "$HOME/.cabal/bin" >> $GITHUB_PATH
         echo "$HOME/.local/bin" >> $GITHUB_PATH
+        sed -i -e 's/^.*\<secure: True/  secure: False/g' $HOME/.cabal/config
+        cabal update
 
     - uses: actions/checkout@v4
 

--- a/.github/workflows/repo-ghc-8.6-cabal-2.4-xlsx.yml
+++ b/.github/workflows/repo-ghc-8.6-cabal-2.4-xlsx.yml
@@ -28,6 +28,8 @@ jobs:
       run: |
         echo "$HOME/.ghcup/bin" >> $GITHUB_PATH
         echo "$HOME/.cabal/bin" >> $GITHUB_PATH
+        sed -i -e 's/^.*\<secure: True/  secure: False/g' $HOME/.cabal/config
+        cabal update
 
     - uses: actions/checkout@v4
 

--- a/.github/workflows/repo-ghc-8.6-cabal-2.4.yml
+++ b/.github/workflows/repo-ghc-8.6-cabal-2.4.yml
@@ -29,6 +29,8 @@ jobs:
       run: |
         echo "$HOME/.ghcup/bin" >> $GITHUB_PATH
         echo "$HOME/.cabal/bin" >> $GITHUB_PATH
+        sed -i -e 's/^.*\<secure: True/  secure: False/g' $HOME/.cabal/config
+        cabal update
 
     - uses: actions/checkout@v4
 

--- a/.github/workflows/repo-ghc-9.10-cabal-3.12-ros-turtlesim.yml
+++ b/.github/workflows/repo-ghc-9.10-cabal-3.12-ros-turtlesim.yml
@@ -30,6 +30,8 @@ jobs:
         echo "$HOME/.ghcup/bin" >> $GITHUB_PATH
         echo "$HOME/.cabal/bin" >> $GITHUB_PATH
         echo "$HOME/.local/bin" >> $GITHUB_PATH
+        sed -i -e 's/^.*\<secure: True/  secure: False/g' $HOME/.cabal/config
+        cabal update
 
     - uses: actions/checkout@v4
 

--- a/ogma-cli/CHANGELOG.md
+++ b/ogma-cli/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Revision history for ogma-cli
 
-## [1.X.Y] - 2026-08-01
+## [1.X.Y] - 2026-08-16
 
 * Remove unnecessary line breaks (#520).
 * Update cFS examples to avoid MID collisions (#522).
@@ -8,6 +8,7 @@
 * Fix spelling of F Prime (#526).
 * Fix target directory name in project file in Turtlesim example (#530).
 * Add CI job to test ROS 2 backend using Turtlesim example (#534).
+* Disable secure mode for package repo in Cabal config in CI jobs (#537).
 
 ## [1.15.0] - 2026-07-21
 


### PR DESCRIPTION
Modify the CI workflow files to disable secure mode for the package repository in Cabal's configuration file, and update the list of packages available, as prescribed in the solution proposed for #537.