### PR TITLE
`ogma-cli`: Address HLint suggestions. Refs #540.

### DIFF
--- a/ogma-cli/.hlint.yaml
+++ b/ogma-cli/.hlint.yaml
@@ -1,2 +1,12 @@
 - functions:
   - {name: unsafePerformIO, within: []} # unsafePerformIO cannot appear in any modules
+- ignore:
+    name: Use ++
+    within:
+      - CLI.CommandCFSApp
+      - CLI.CommandFPrimeApp
+      - CLI.CommandOverview
+      - CLI.CommandROSApp
+      - CLI.CommandReport
+      - CLI.CommandSearch
+      - CLI.CommandStandalone

--- a/ogma-cli/CHANGELOG.md
+++ b/ogma-cli/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Fix target directory name in project file in Turtlesim example (#530).
 * Add CI job to test ROS 2 backend using Turtlesim example (#534).
 * Disable secure mode for package repo in Cabal config in CI jobs (#537).
+* Address HLint suggestions (#540).
 
 ## [1.15.0] - 2026-07-21
 

--- a/ogma-cli/src/CLI/CommandFPrimeApp.hs
+++ b/ogma-cli/src/CLI/CommandFPrimeApp.hs
@@ -113,7 +113,7 @@ commandProjectOptions projectFile c = do
           fromMaybe (fprimeAppTarget c) (projectTargetDir project)
 
       , Command.FPrimeApp.commandTemplateDir =
-          maybe (fprimeAppTemplateDir c) Just (projectTemplateDir project)
+          projectTemplateDir project <|> fprimeAppTemplateDir c
 
       , Command.FPrimeApp.commandVariables =
           projectVariableFiles project <|> fprimeAppVariables c

--- a/ogma-cli/tests/Main.hs
+++ b/ogma-cli/tests/Main.hs
@@ -90,13 +90,7 @@ testCStructs2Copilot :: FilePath  -- ^ Path to a C header file with structs
                      -> Bool
                      -> IO ()
 testCStructs2Copilot file success = do
-    (ec, _out, _err) <- readProcessWithExitCode "ogma" args ""
-
-    -- True if success is expected and detected, or niether expected nor
-    -- detected.
-    let testPass = success == (ec == ExitSuccess)
-
-    assertBool errorMsg testPass
+    assertExecution "ogma" args success errorMsg
   where
     args     = ["structs", "--input-file", file]
     errorMsg = "Result of processing file " ++ file ++ " failed"
@@ -118,13 +112,7 @@ parseStandaloneFCS :: FilePath  -- ^ Path to an input file
                    -> Bool
                    -> IO ()
 parseStandaloneFCS file success = do
-    (ec, _out, _err) <- readProcessWithExitCode "ogma" args ""
-
-    -- True if success is expected and detected, or niether expected nor
-    -- detected.
-    let testPass = success == (ec == ExitSuccess)
-
-    assertBool errorMsg testPass
+    assertExecution "ogma" args success errorMsg
   where
     args     = ["standalone", "--input-file", file]
     errorMsg = "Parsing file " ++ file ++ " result unexpected."
@@ -145,8 +133,7 @@ parseStandaloneFCS file success = do
 parseStandaloneFDB :: FilePath  -- ^ Path to an input file
                    -> IO ()
 parseStandaloneFDB file = do
-    (ec, _out, _err) <- readProcessWithExitCode "ogma" args ""
-    assertBool errorMsg (ec == ExitSuccess)
+    assertExecution "ogma" args True errorMsg
   where
     args     = [ "standalone", "--input-file", file, "--input-format", "fdb"
                , "--prop-format", "lustre"]
@@ -169,14 +156,23 @@ runErrorCode :: [String] -- ^ Arguments to pass to ogma
              -> Bool
              -> IO ()
 runErrorCode args success = do
-    (ec, _out, _err) <- readProcessWithExitCode "ogma" args ""
-
-    -- True if success is expected and detected, or niether expected nor
-    -- detected.
-    let testPass = success == (ec == ExitSuccess)
-
-    assertBool errorMsg testPass
+    assertExecution "ogma" args success errorMsg
   where
     errorMsg = "Testing ogma's CLI parser with arguments "
              ++ intercalate "," args
              ++ " failed"
+
+-- | Run program and check result of execution against expectation.
+assertExecution :: String   -- ^ Program to run.
+                -> [String] -- ^ Arguments.
+                -> Bool     -- ^ Expectation (sucess).
+                -> String   -- ^ Message if expectation is not met.
+                -> IO ()
+assertExecution program args success errorMsg = do
+  (ec, _out, _err) <- readProcessWithExitCode program args ""
+
+  -- True if success is expected and detected, or neither expected nor
+  -- detected.
+  let testPass = success == (ec == ExitSuccess)
+
+  assertBool errorMsg testPass


### PR DESCRIPTION
Address all suggestions reported by HLint on `ogma-cli`, by re-writing the code or by making HLint ignore them, as prescribed in the solution proposed for #540.