### PR TITLE
`ogma-core`: Add valid Haddock documentation to all top-level functions. Refs #542.

### DIFF
--- a/ogma-core/CHANGELOG.md
+++ b/ogma-core/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Revision history for ogma-core
 
-## [1.X.Y] - 2026-08-01
+## [1.X.Y] - 2026-08-16
 
 * Replace adhoc function `mergeMaybe` with function from `base` (#516).
 * Fix malformed comments (#518).
@@ -8,6 +8,7 @@
 * Add missing periods to Haddock comments (#524).
 * Fix spelling of F Prime (#526).
 * Replace explicit recursion with calls to `base:Control.Monad.foldM` (#532).
+* Add valid Haddock documentation to all top-level functions (#542).
 
 ## [1.15.0] - 2026-07-21
 

--- a/ogma-core/src/Command/CFSApp.hs
+++ b/ogma-core/src/Command/CFSApp.hs
@@ -99,6 +99,8 @@ command options = processResult $ do
     functions     = exprPair (commandPropFormat options)
     templateVarsF = commandExtraVars options
 
+-- | Generate application data describing core elements of a new cFS
+-- application that implements the input requirements or diagrams.
 command' :: CommandOptions
          -> ExprPair
          -> ExceptT ErrorTriplet IO AppData

--- a/ogma-core/src/Command/FPrimeApp.hs
+++ b/ogma-core/src/Command/FPrimeApp.hs
@@ -91,6 +91,8 @@ command options = processResult $ do
     functions     = exprPair (commandPropFormat options)
     templateVarsF = commandExtraVars options
 
+-- | Generate application data describing core elements of a new F Prime
+-- component that implements the input requirements or diagrams.
 command' :: CommandOptions
          -> ExprPair
          -> ExceptT ErrorTriplet IO AppData

--- a/ogma-core/src/Command/ROSApp.hs
+++ b/ogma-core/src/Command/ROSApp.hs
@@ -97,6 +97,8 @@ command options = processResult $ do
     functions     = exprPair (commandPropFormat options)
     templateVarsF = commandExtraVars options
 
+-- | Generate application data describing core elements of a new ROS package
+-- that implements the input requirements or diagrams.
 command' :: CommandOptions
          -> ExprPair
          -> ExceptT ErrorTriplet IO AppData

--- a/ogma-core/src/Data/Diagram/Parser.hs
+++ b/ogma-core/src/Data/Diagram/Parser.hs
@@ -64,7 +64,7 @@ readDiagram fp format exprP = ExceptT $ do
            (\msg -> ErrorTriplet ecCannotReadDiagram msg (LocationFile fp))
            diagramE
 
---- | Generic function to parse a diagram.
+-- | Generic function to parse a diagram.
 parseDiagram :: DiagramFormat          -- ^ Format of the input file
              -> B.ByteString           -- ^ Contents of the diagram
              -> ExprPair               -- ^ Subparser for conditions or edge

--- a/ogma-core/src/Data/Spec/Parser.hs
+++ b/ogma-core/src/Data/Spec/Parser.hs
@@ -79,8 +79,8 @@ readInputExpr expr propFormatName propVia exprT =
     -- Return the spec, transforming the error message if applicable.
     pure $ mapLeft (cannotReadConditionExpr expr) spec
 
---- | Process input specification, if available, and return its abstract
---- representation.
+-- | Process input specification, if available, and return its abstract
+-- representation.
 readInputFile :: FilePath
               -> String
               -> String

--- a/ogma-core/src/Language/Trans/Spec2Copilot.hs
+++ b/ogma-core/src/Language/Trans/Spec2Copilot.hs
@@ -165,6 +165,8 @@ spec2Copilot specName typeMaps exprTransform showExpr spec =
     requirementNames = map requirementName
                      $ requirements spec
 
+-- | Check that a specification does not contain any name clashes between
+-- variables and/or requirements.
 specAnalyze :: Spec a -> Either String (Spec a)
 specAnalyze spec
     | not (null evnClash)


### PR DESCRIPTION
Add missing Haddock documentation and/or fix syntax of existing documentation for all top-level functions in `ogma-core`, as prescribed in the solution proposed for #542.