### PR TITLE
Bump upper version constraints on `QuickCheck`, `megaparsec`. Refs #545.

### DIFF
--- a/ogma-core/CHANGELOG.md
+++ b/ogma-core/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Revision history for ogma-core
 
-## [1.X.Y] - 2026-08-16
+## [1.X.Y] - 2026-08-20
 
 * Replace adhoc function `mergeMaybe` with function from `base` (#516).
 * Fix malformed comments (#518).
@@ -9,6 +9,7 @@
 * Fix spelling of F Prime (#526).
 * Replace explicit recursion with calls to `base:Control.Monad.foldM` (#532).
 * Add valid Haddock documentation to all top-level functions (#542).
+* Bump upper version constraints on `QuickCheck`, `megaparsec` (#545).
 
 ## [1.15.0] - 2026-07-21
 

--- a/ogma-core/ogma-core.cabal
+++ b/ogma-core/ogma-core.cabal
@@ -198,7 +198,7 @@ test-suite unit-tests
       base                       >= 4.11.0.0 && < 5
     , directory                  >= 1.3.1.5  && < 1.4
     , HUnit                      >= 1.2.0.0  && < 1.7
-    , QuickCheck                 >= 2.8.2    && < 2.17
+    , QuickCheck                 >= 2.8.2    && < 2.19
     , test-framework             >= 0.8.2    && < 0.9
     , test-framework-hunit       >= 0.2.0    && < 0.4
     , test-framework-quickcheck2 >= 0.3.0.4  && < 0.4

--- a/ogma-core/ogma-core.cabal
+++ b/ogma-core/ogma-core.cabal
@@ -160,7 +160,7 @@ library
     , filepath                >= 1.4.2    && < 1.6
     , graphviz                >= 2999.20  && < 2999.21
     , hint                    >= 0.9.0    && < 1.10
-    , megaparsec              >= 8.0.0    && < 9.8
+    , megaparsec              >= 8.0.0    && < 9.9
     , mtl                     >= 2.2.2    && < 2.4
     , process                 >= 1.6      && < 1.7
     , text                    >= 1.2.3.1  && < 2.2

--- a/ogma-extra/CHANGELOG.md
+++ b/ogma-extra/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Revision history for ogma-extra
 
-## [1.X.Y] - 2026-07-23
+## [1.X.Y] - 2026-08-20
 
 * Remove unnecessary line breaks (#520).
+* Bump upper version constraint on `QuickCheck` (#545).
 
 ## [1.15.0] - 2026-07-21
 

--- a/ogma-extra/ogma-extra.cabal
+++ b/ogma-extra/ogma-extra.cabal
@@ -88,7 +88,7 @@ test-suite unit-tests
 
   build-depends:
       base                       >= 4.11.0.0 && < 5
-    , QuickCheck                 >= 2.8.2    && < 2.17
+    , QuickCheck                 >= 2.8.2    && < 2.19
     , test-framework             >= 0.8.2    && < 0.9
     , test-framework-quickcheck2 >= 0.3.0.4  && < 0.4
 

--- a/ogma-language-c/CHANGELOG.md
+++ b/ogma-language-c/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Revision history for ogma-language-c
 
-## [1.X.Y] - 2026-07-23
+## [1.X.Y] - 2026-08-20
 
 * Remove unnecessary line breaks (#520).
+* Bump upper version constraint on `QuickCheck` (#545).
 
 ## [1.15.0] - 2026-07-21
 

--- a/ogma-language-c/ogma-language-c.cabal
+++ b/ogma-language-c/ogma-language-c.cabal
@@ -98,7 +98,7 @@ test-suite unit-tests
 
   build-depends:
       base                       >= 4.11.0.0 && < 5
-    , QuickCheck                 >= 2.8.2    && < 2.17
+    , QuickCheck                 >= 2.8.2    && < 2.19
     , test-framework             >= 0.8.2    && < 0.9
     , test-framework-quickcheck2 >= 0.3.0.4  && < 0.4
 

--- a/ogma-language-jsonspec/CHANGELOG.md
+++ b/ogma-language-jsonspec/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Revision history for ogma-language-jsonspec
 
+## [1.X.Y] - 2026-08-20
+
+* Bump upper version constraint on `megaparsec` (#545).
+
 ## [1.15.0] - 2026-07-21
 
 * Version bump (1.15.0) (#508).

--- a/ogma-language-jsonspec/ogma-language-jsonspec.cabal
+++ b/ogma-language-jsonspec/ogma-language-jsonspec.cabal
@@ -61,7 +61,7 @@ library
     , filepath               >= 1.4.2    && < 1.6
     , jsonpath               >= 0.3      && < 0.4
     , text                   >= 1.2.3.1  && < 2.2
-    , megaparsec             >= 8.0.0    && < 9.8
+    , megaparsec             >= 8.0.0    && < 9.9
     , mtl                    >= 2.2.2    && < 2.4
     , bytestring             >= 0.10.8.2 && < 0.13
 

--- a/ogma-language-lustre/CHANGELOG.md
+++ b/ogma-language-lustre/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Revision history for ogma-language-lustre
 
-## [1.X.Y] - 2026-07-27
+## [1.X.Y] - 2026-08-20
 
 * Remove unnecessary line breaks (#520).
+* Bump upper version constraint on `QuickCheck` (#545).
 
 ## [1.15.0] - 2026-07-21
 

--- a/ogma-language-lustre/ogma-language-lustre.cabal
+++ b/ogma-language-lustre/ogma-language-lustre.cabal
@@ -99,7 +99,7 @@ test-suite unit-tests
 
   build-depends:
       base                       >= 4.11.0.0 && < 5
-    , QuickCheck                 >= 2.8.2    && < 2.17
+    , QuickCheck                 >= 2.8.2    && < 2.19
     , test-framework             >= 0.8.2    && < 0.9
     , test-framework-quickcheck2 >= 0.3.0.4  && < 0.4
 

--- a/ogma-language-smv/CHANGELOG.md
+++ b/ogma-language-smv/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Revision history for ogma-language-smv
 
-## [1.X.Y] - 2026-07-23
+## [1.X.Y] - 2026-08-20
 
 * Remove unnecessary line breaks (#520).
+* Bump upper version constraint on `QuickCheck` (#545).
 
 ## [1.15.0] - 2026-07-21
 

--- a/ogma-language-smv/ogma-language-smv.cabal
+++ b/ogma-language-smv/ogma-language-smv.cabal
@@ -99,7 +99,7 @@ test-suite unit-tests
 
   build-depends:
       base                       >= 4.11.0.0 && < 5
-    , QuickCheck                 >= 2.8.2    && < 2.17
+    , QuickCheck                 >= 2.8.2    && < 2.19
     , test-framework             >= 0.8.2    && < 0.9
     , test-framework-quickcheck2 >= 0.3.0.4  && < 0.4
 


### PR DESCRIPTION
Bump upper version constraints on `QuickCheck` and `megaparsec` across multiple packages, as prescribed in the solution proposed for #545.