### PR TITLE
`ogma-core`: Make `Dockerfile` base image in default ROS 2 template customizable. Refs #548.

### DIFF
--- a/ogma-core/CHANGELOG.md
+++ b/ogma-core/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Replace explicit recursion with calls to `base:Control.Monad.foldM` (#532).
 * Add valid Haddock documentation to all top-level functions (#542).
 * Bump upper version constraints on `QuickCheck`, `megaparsec` (#545).
+* Make `Dockerfile` base image in default ROS 2 template customizable (#548).
 
 ## [1.15.0] - 2026-07-21
 

--- a/ogma-core/templates/ros/Dockerfile
+++ b/ogma-core/templates/ros/Dockerfile
@@ -1,4 +1,9 @@
+{{#BASE_DOCKER_IMAGE}}
+FROM {{.}}
+{{/BASE_DOCKER_IMAGE}}
+{{^BASE_DOCKER_IMAGE}}
 FROM osrf/space-ros:jazzy-2026.04.0
+{{/BASE_DOCKER_IMAGE}}
 
 ARG USER=spaceros-user
 ARG PACKAGE_PATH=/home/${USER}/monitors


### PR DESCRIPTION
Modify the default ROS 2 template to make the base image name that the auto-generated `Dockerfile` builds on customizable via a JSON variable, as prescribed in the solution proposed for #548.