### PR TITLE
`ogma-core`: Allow for inputs to be deeply nested fields in ROS 2 template. Refs #547.

### DIFF
--- a/ogma-core/CHANGELOG.md
+++ b/ogma-core/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Add valid Haddock documentation to all top-level functions (#542).
 * Bump upper version constraints on `QuickCheck`, `megaparsec` (#545).
 * Make `Dockerfile` base image in default ROS 2 template customizable (#548).
+* Allow for inputs to be deeply nested fields in ROS 2 template (#547).
 
 ## [1.15.0] - 2026-07-21
 

--- a/ogma-core/templates/ros/test_requirements/src/test_requirements.cpp
+++ b/ogma-core/templates/ros/test_requirements/src/test_requirements.cpp
@@ -113,10 +113,10 @@ class RequirementsTest : public rclcpp::Node {
 
 {{#testingVariables}}
        {{#varDeclMsgField}}
-       {{varDeclType}} {{varDeclName}}_{{.}} = {{varDeclRandom}}();
-       auto {{varDeclName}}_{{.}}_msg = {{varDeclMsgType}}();
-       {{varDeclName}}_{{.}}_msg.{{.}} = {{varDeclName}}_{{.}};
-       {{varDeclName}}_publisher_->publish({{varDeclName}}_{{.}}_msg);
+       {{varDeclType}} {{varDeclName}}_data = {{varDeclRandom}}();
+       auto {{varDeclName}}_data_msg = {{varDeclMsgType}}();
+       {{varDeclName}}_data_msg.{{.}} = {{varDeclName}}_data;
+       {{varDeclName}}_publisher_->publish({{varDeclName}}_data_msg);
        {{/varDeclMsgField}}
        {{^varDeclMsgField}}
        {{varDeclType}} {{varDeclName}}_data = {{varDeclRandom}}();


### PR DESCRIPTION
Modify the default ROS 2 template so that the test node generated uses variable names that do not include the sub-field name, as prescribed in the solution proposed for #547.