### PR TITLE
`ogma-core`: Add regression test for mergeSpecs with multiple input files. Refs #555.

### DIFF
--- a/ogma-core/CHANGELOG.md
+++ b/ogma-core/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [1.X.Y] - 2026-08-20
 
+* Add regression test for `mergeSpecs` with multiple input files (#551).
 * Replace adhoc function `mergeMaybe` with function from `base` (#516).
 * Fix malformed comments (#518).
 * Remove unnecessary line breaks (#520).

--- a/ogma-core/ogma-core.cabal
+++ b/ogma-core/ogma-core.cabal
@@ -35,6 +35,8 @@ extra-source-files:  CHANGELOG.md
                      tests/fdb-example1.json
                      tests/reduced_geofence_msgs_bad.h
                      tests/reduced_geofence_msgs.h
+                     tests/merge-spec-1.json
+                     tests/merge-spec-2.json
 
 synopsis:            Ogma: Helper tool to interoperate between Copilot and other languages.
 

--- a/ogma-core/tests/Main.hs
+++ b/ogma-core/tests/Main.hs
@@ -60,6 +60,15 @@ tests =
   , testCase "structs-parse-fail-1"
       (testCStructs2Copilot "tests/reduced_geofence_msgs_bad.h" False)
     -- Should fail because a keyword is incorrect
+
+  , testCase "standalone-cmd-merge-specs-two-files"
+      (testStandaloneMergeSpecs
+         "tests/merge-spec-1.json"
+         "tests/merge-spec-2.json"
+         True
+      )
+    -- Should pass: merging two specs with distinct external variables
+    -- must preserve variables from both. Refs #551.
   ]
 
 -- | Test C struct parser and conversion to Copilot structs
@@ -119,10 +128,10 @@ testStandaloneFCS file success = do
     -- detected.
     let testPass = success == isSuccess result
 
-    assertBool errorMsg testPass
+    assertBool errorMsgFCS testPass
   where
-    errorMsg = "The result of the transformation of input file "
-               ++ file ++ " to Copilot was unexpected."
+    errorMsgFCS = "The result of the transformation of input file "
+                  ++ file ++ " to Copilot was unexpected."
 
 -- | Test standalone backend with FDB format.
 --
@@ -157,7 +166,38 @@ testStandaloneFDB file success = do
     -- detected.
     let testPass = success == isSuccess result
 
-    assertBool errorMsg testPass
+    assertBool errorMsgFDB testPass
   where
-    errorMsg = "The result of the transformation of input file "
-               ++ file ++ " to Copilot was unexpected."
+    errorMsgFDB = "The result of the transformation of input file "
+                  ++ file ++ " to Copilot was unexpected."
+
+-- | Test standalone backend with two input files to verify mergeSpecs.
+--
+-- Regression test for issue #551 where a copy-paste bug in mergeSpecs caused
+-- the first spec's external variables to be dropped.
+testStandaloneMergeSpecs :: FilePath
+                         -> FilePath
+                         -> Bool
+                         -> IO ()
+testStandaloneMergeSpecs file1 file2 success = do
+    targetDir <- getTemporaryDirectory
+    let opts = CommandOptions
+                 { commandConditionExpr = Nothing
+                 , commandInputFiles  = [ file1, file2 ]
+                 , commandFormat      = "fcs"
+                 , commandPropFormat  = "smv"
+                 , commandTypeMapping = [("real", "Float")]
+                 , commandFilename    = "monitor"
+                 , commandTargetDir   = targetDir
+                 , commandTemplateDir = Nothing
+                 , commandPropVia     = Nothing
+                 , commandExtraVars   = Nothing
+                 }
+    result <- command opts
+
+    let testPass = success == isSuccess result
+
+    assertBool mergeErrorMsg testPass
+  where
+    mergeErrorMsg = "mergeSpecs: merging " ++ file1 ++ " and " ++ file2
+                    ++ " produced an unexpected result. Refs #551."

--- a/ogma-core/tests/merge-spec-1.json
+++ b/ogma-core/tests/merge-spec-1.json
@@ -1,0 +1,16 @@
+{
+  "Spec1": {
+    "Internal_variables": [],
+    "Other_variables": [
+      {"name": "sensor_a", "type": "real"}
+    ],
+    "Requirements": [
+      {
+        "name": "propA",
+        "CoCoSpecCode": "sensor_a > 0.0",
+        "ptLTL": "sensor_a > 0.0",
+        "fretish": "sensor_a shall always be positive"
+      }
+    ]
+  }
+}

--- a/ogma-core/tests/merge-spec-2.json
+++ b/ogma-core/tests/merge-spec-2.json
@@ -1,0 +1,16 @@
+{
+  "Spec2": {
+    "Internal_variables": [],
+    "Other_variables": [
+      {"name": "sensor_b", "type": "real"}
+    ],
+    "Requirements": [
+      {
+        "name": "propB",
+        "CoCoSpecCode": "sensor_b > 0.0",
+        "ptLTL": "sensor_b > 0.0",
+        "fretish": "sensor_b shall always be positive"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Add a test case that exercises `mergeSpecs` with two input files containing distinct external variables, as prescribed in the solution proposed for #555.

This would have caught the copy-paste bug fixed in #552 (Refs #551).