### PR TITLE
`ogma-core`: Adjust ROS 2 `Dockerfile` to run `rosdep init` only when needed. Refs #561.

### DIFF
--- a/ogma-core/CHANGELOG.md
+++ b/ogma-core/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Revision history for ogma-core
 
-## [1.X.Y] - 2026-08-20
+## [1.X.Y] - 2026-08-25
 
 * Replace adhoc function `mergeMaybe` with function from `base` (#516).
 * Fix malformed comments (#518).
@@ -12,6 +12,7 @@
 * Bump upper version constraints on `QuickCheck`, `megaparsec` (#545).
 * Make `Dockerfile` base image in default ROS 2 template customizable (#548).
 * Allow for inputs to be deeply nested fields in ROS 2 template (#547).
+* Adjust ROS 2 `Dockerfile` to run `rosdep init` only when needed (#561).
 
 ## [1.15.0] - 2026-07-21
 

--- a/ogma-core/templates/ros/Dockerfile
+++ b/ogma-core/templates/ros/Dockerfile
@@ -31,7 +31,7 @@ RUN if [ -f "/tmp/manual-deps.repos" ]; then \
     fi
 
 ADD excluded-pkgs*.txt /tmp/
-RUN sudo rosdep init
+RUN if [ ! -f "/etc/ros/rosdep/sources.list.d/20-default.list" ]; then sudo rosdep init; fi
 RUN rosdep update
 RUN source /opt/ros/spaceros/setup.bash && \
     if [ -f "/tmp/excluded-pkgs.txt" ]; then \


### PR DESCRIPTION
Modify `Dockerfile` included in ROS 2 template to execute `sudo rosdep init` only when `rosdep` has not been initialized before, as prescribed in the solution proposed for #561.