### PR TITLE
`ogma-core`: Fix incorrect creation of two instances of ROS 2 monitoring node. Refs #564.

### DIFF
--- a/ogma-core/CHANGELOG.md
+++ b/ogma-core/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Revision history for ogma-core
 
-## [1.X.Y] - 2026-08-25
+## [1.X.Y] - 2026-08-27
 
 * Replace adhoc function `mergeMaybe` with function from `base` (#516).
 * Fix malformed comments (#518).
@@ -13,6 +13,7 @@
 * Make `Dockerfile` base image in default ROS 2 template customizable (#548).
 * Allow for inputs to be deeply nested fields in ROS 2 template (#547).
 * Adjust ROS 2 `Dockerfile` to run `rosdep init` only when needed (#561).
+* Fix incorrect creation of two instances of ROS 2 monitoring node (#564).
 
 ## [1.15.0] - 2026-07-21
 

--- a/ogma-core/templates/ros/copilot/src/copilot_monitor.cpp
+++ b/ogma-core/templates/ros/copilot/src/copilot_monitor.cpp
@@ -77,8 +77,8 @@ class CopilotRV : public rclcpp::Node {
 
 {{/monitors}}
     // Needed so we can report messages to the log.
-    static CopilotRV& getInstance() {
-      static CopilotRV instance;
+    static std::shared_ptr<CopilotRV> getInstance() {
+      static std::shared_ptr<CopilotRV> instance = std::shared_ptr<CopilotRV>(new CopilotRV());
       return instance;
     }
 
@@ -115,19 +115,19 @@ class CopilotRV : public rclcpp::Node {
 // communicate with other applications.
 {{#monitorType}}
 void {{monitorName}}({{.}} arg) {
-  CopilotRV::getInstance().{{monitorName}}(arg);
+  CopilotRV::getInstance()->{{monitorName}}(arg);
 }
 {{/monitorType}}
 {{^monitorType}}
 void {{monitorName}}() {
-  CopilotRV::getInstance().{{monitorName}}();
+  CopilotRV::getInstance()->{{monitorName}}();
 }
 {{/monitorType}}
 
 {{/monitors}}
 int main(int argc, char* argv[]) {
   rclcpp::init(argc, argv);
-  rclcpp::spin(std::make_shared<CopilotRV>());
+  rclcpp::spin(CopilotRV::getInstance());
   rclcpp::shutdown();
   return 0;
 }


### PR DESCRIPTION
Replace the ROS 2 monitoring class in the default ROS 2 template so that the `main` function uses the `getInstance()` to create the initial node, avoiding creating two nodes by mistake, as prescribed in the solution proposed for #564.