### PR TITLE
Increase detail in template expansion error messages. Refs #390.

### DIFF
--- a/ogma-core/CHANGELOG.md
+++ b/ogma-core/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Allow for inputs to be deeply nested fields in ROS 2 template (#547).
 * Adjust ROS 2 `Dockerfile` to run `rosdep init` only when needed (#561).
 * Fix incorrect creation of two instances of ROS 2 monitoring node (#564).
+* Increase detail in template expansion error messages (#390).
 
 ## [1.15.0] - 2026-07-21
 

--- a/ogma-core/src/Command/CFSApp.hs
+++ b/ogma-core/src/Command/CFSApp.hs
@@ -49,14 +49,15 @@ import qualified Command.Standalone
 
 -- Internal imports: auxiliary
 import Command.Result         ( Result (..) )
+import Data.Either.Extra      ( mapLeft )
 import Data.List.Extra        ( stripSuffix )
 import Data.String.Extra      ( pascalCase )
 import System.Directory.Extra ( copyTemplate )
 
 -- Internal imports
-import Command.Common                 (InputFile (..), cannotCopyTemplate,
+import Command.Common                 (InputFile (..), cannotCopyTemplateF,
                                        checkArguments, combineInputFiles,
-                                       locateTemplateDir, makeLeftE,
+                                       locateTemplateDir,
                                        openVarDBFilesWithDefault,
                                        parseInputFile,
                                        parseRequirementsListFile,
@@ -89,7 +90,7 @@ command options = processResult $ do
     let subst = mergeObjects (toJSON appData) templateVars
 
     -- Expand template
-    ExceptT $ fmap (makeLeftE cannotCopyTemplate) $ E.try $
+    ExceptT $ fmap (mapLeft cannotCopyTemplateF) $ E.try $
       copyTemplate templateDir subst targetDir
 
   where

--- a/ogma-core/src/Command/Common.hs
+++ b/ogma-core/src/Command/Common.hs
@@ -32,8 +32,7 @@ module Command.Common
     , specExtractExternalVariables
     , specExtractHandlers
     , processResult
-    , cannotCopyTemplate
-    , makeLeftE
+    , cannotCopyTemplateF
     , locateTemplateDir
     )
   where
@@ -47,8 +46,9 @@ import           Data.Aeson             (Value (Null, Object), eitherDecode,
 import           System.FilePath        ((</>))
 
 -- External imports: auxiliary
-import Data.ByteString.Extra as B (safeReadFile)
-import Data.String.Extra     (sanitizeLCIdentifier, sanitizeUCIdentifier)
+import Data.ByteString.Extra  as B (safeReadFile)
+import Data.String.Extra      (sanitizeLCIdentifier, sanitizeUCIdentifier)
+import System.Directory.Extra (CopyTemplateException(..))
 
 -- External imports: ogma
 import Data.OgmaSpec (Requirement (..), Spec (..), externalVariableName,
@@ -313,14 +313,12 @@ cannotReadObjectTemplateVars file =
 
 -- | Exception handler to deal with the case of files that cannot be
 -- copied/generated due lack of space or permissions or some I/O error.
-cannotCopyTemplate :: ErrorTriplet
-cannotCopyTemplate =
-    ErrorTriplet ecCannotCopyTemplate msg LocationNothing
+cannotCopyTemplateF :: CopyTemplateException -> ErrorTriplet
+cannotCopyTemplateF e =
+    ErrorTriplet ecCannotCopyTemplate (msg ++ show e) LocationNothing
   where
     msg =
-      "Generation failed during copy/write operation. Check that"
-      ++ " there's free space in the disk and that you have the necessary"
-      ++ " permissions to write in the destination directory."
+      "Generation failed during copy/write operation: "
 
 -- ** Error codes
 

--- a/ogma-core/src/Command/FPrimeApp.hs
+++ b/ogma-core/src/Command/FPrimeApp.hs
@@ -40,6 +40,7 @@ import           Data.Maybe             ( fromMaybe, mapMaybe, maybeToList )
 import           GHC.Generics           ( Generic )
 
 -- External imports: auxiliary
+import Data.Either.Extra      ( mapLeft )
 import System.Directory.Extra ( copyTemplate )
 
 import qualified Command.Standalone
@@ -48,9 +49,9 @@ import qualified Command.Standalone
 import Command.Result (Result (..))
 
 -- Internal imports
-import Command.Common                 (InputFile (..), cannotCopyTemplate,
+import Command.Common                 (InputFile (..), cannotCopyTemplateF,
                                        checkArguments, combineInputFiles,
-                                       locateTemplateDir, makeLeftE,
+                                       locateTemplateDir,
                                        openVarDBFilesWithDefault,
                                        parseInputFile,
                                        parseRequirementsListFile,
@@ -81,7 +82,7 @@ command options = processResult $ do
     let subst = mergeObjects (toJSON appData) templateVars
 
     -- Expand template
-    ExceptT $ fmap (makeLeftE cannotCopyTemplate) $ E.try $
+    ExceptT $ fmap (mapLeft cannotCopyTemplateF) $ E.try $
       copyTemplate templateDir subst targetDir
 
   where

--- a/ogma-core/src/Command/ROSApp.hs
+++ b/ogma-core/src/Command/ROSApp.hs
@@ -49,12 +49,13 @@ import System.Directory.Extra (copyTemplate)
 import qualified Command.Standalone
 
 -- Internal imports: auxiliary
-import Command.Result (Result (..))
+import Command.Result    ( Result (..) )
+import Data.Either.Extra ( mapLeft )
 
 -- Internal imports
-import Command.Common                 (InputFile (..), cannotCopyTemplate,
+import Command.Common                 (InputFile (..), cannotCopyTemplateF,
                                        checkArguments, combineInputFiles,
-                                       locateTemplateDir, makeLeftE,
+                                       locateTemplateDir,
                                        openVarDBFilesWithDefault,
                                        parseInputFile,
                                        parseRequirementsListFile,
@@ -87,7 +88,7 @@ command options = processResult $ do
     let subst = mergeObjects (toJSON appData) templateVars
 
     -- Expand template
-    ExceptT $ fmap (makeLeftE cannotCopyTemplate) $ E.try $
+    ExceptT $ fmap (mapLeft cannotCopyTemplateF) $ E.try $
       copyTemplate templateDir subst targetDir
 
   where

--- a/ogma-core/src/Command/Report.hs
+++ b/ogma-core/src/Command/Report.hs
@@ -36,14 +36,15 @@ import           Data.Aeson             (ToJSON (..))
 import           GHC.Generics           (Generic)
 
 -- External imports: Ogma
+import Data.Either.Extra      (mapLeft)
 import Data.OgmaSpec          (Requirement (..), Spec (..))
 import Data.String.Extra      (sanitizeUCIdentifier)
 import System.Directory.Extra (copyTemplate)
 
 -- Internal imports
 import           Command.Common              (InputFile (..),
-                                              cannotCopyTemplate,
-                                              locateTemplateDir, makeLeftE,
+                                              cannotCopyTemplateF,
+                                              locateTemplateDir,
                                               parseInputFile, processResult)
 import           Command.Errors              (ErrorCode, ErrorTriplet (..))
 import           Command.Result              (Result (..))
@@ -76,7 +77,7 @@ command options = processResult $ do
                     (commandInputFiles options)
 
     -- Expand template
-    ExceptT $ fmap (makeLeftE cannotCopyTemplate) $ E.try $
+    ExceptT $ fmap (mapLeft cannotCopyTemplateF) $ E.try $
       copyTemplate templateDir (toJSON reportData) targetDir
 
   where

--- a/ogma-core/src/Command/Standalone.hs
+++ b/ogma-core/src/Command/Standalone.hs
@@ -41,10 +41,10 @@ import GHC.Generics         (Generic)
 import System.Directory.Extra (copyTemplate)
 
 -- Internal imports
-import Command.Common                 (InputFile (..), cannotCopyTemplate,
+import Command.Common                 (InputFile (..), cannotCopyTemplateF,
                                        combineInputFiles, locateTemplateDir,
-                                       makeLeftE, parseInputFile,
-                                       parseTemplateVarsFile, processResult)
+                                       parseInputFile, parseTemplateVarsFile,
+                                       processResult)
 import Command.Errors                 (ErrorCode, ErrorTriplet (..))
 import Command.Result                 (Result (..))
 import Data.Aeson.Extra               (mergeObjects)
@@ -78,7 +78,7 @@ command options = processResult $ do
     let subst = mergeObjects (toJSON appData) templateVars
 
     -- Expand template
-    ExceptT $ fmap (makeLeftE cannotCopyTemplate) $ E.try $
+    ExceptT $ fmap (mapLeft cannotCopyTemplateF) $ E.try $
       copyTemplate templateDir subst targetDir
 
   where

--- a/ogma-extra/CHANGELOG.md
+++ b/ogma-extra/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Revision history for ogma-extra
 
-## [1.X.Y] - 2026-08-20
+## [1.X.Y] - 2026-08-27
 
 * Remove unnecessary line breaks (#520).
 * Bump upper version constraint on `QuickCheck` (#545).
+* Handle template expansion errors using specialized exception type (#390).
 
 ## [1.15.0] - 2026-07-21
 

--- a/ogma-extra/ogma-extra.cabal
+++ b/ogma-extra/ogma-extra.cabal
@@ -68,6 +68,7 @@ library
     , directory   >= 1.3.1.5  && < 1.4
     , filepath    >= 1.4.2    && < 1.6
     , microstache >= 1.0      && < 1.1
+    , parsec      >= 3.1.13.0 && < 3.2
     , text        >= 1.2.3.1  && < 2.2
 
   hs-source-dirs:

--- a/ogma-extra/src/System/Directory/Extra.hs
+++ b/ogma-extra/src/System/Directory/Extra.hs
@@ -19,13 +19,17 @@
 -- | Auxiliary functions for working with directories.
 module System.Directory.Extra
     ( copyTemplate
+    , CopyTemplateException(..)
     )
   where
 
 -- External imports
+import           Control.Exception         ( Exception, IOException, catch,
+                                             throwIO )
 import           Control.Monad             ( filterM, forM_ )
 import           Data.Aeson                ( Value (..) )
 import qualified Data.ByteString.Lazy      as B
+import           Data.List                 ( isInfixOf )
 import           Data.Text.Lazy            ( pack, unpack )
 import           Data.Text.Lazy.Encoding   ( encodeUtf8 )
 import           Distribution.Simple.Utils ( getDirectoryContentsRecursive )
@@ -33,9 +37,13 @@ import           System.Directory          ( createDirectoryIfMissing,
                                              doesFileExist )
 import           System.FilePath           ( makeRelative, splitFileName,
                                              takeDirectory, (</>) )
-import           Text.Microstache          ( compileMustacheFile,
+import           Text.Microstache          ( MustacheException (..), Template,
+                                             compileMustacheFile,
                                              compileMustacheText,
                                              renderMustache )
+import           Text.Parsec.Error         ( Message (..), errorMessages,
+                                             errorPos )
+import           Text.Parsec.Pos           ( sourceColumn, sourceLine )
 
 -- | Copy a template directory into a target location, expanding variables
 -- provided in a map in a JSON value, both in the file contents and in the
@@ -46,7 +54,8 @@ copyTemplate templateDir subst targetDir = do
   -- Get all files (not directories) in the template dir. To keep a directory,
   -- create an empty file in it (e.g., .keep).
   tmplContents <- map (templateDir </>) . filter (`notElem` ["..", "."])
-                    <$> getDirectoryContentsRecursive templateDir
+                    <$> getDirectoryContentsRecursiveE templateDir
+
   tmplFiles <- filterM doesFileExist tmplContents
 
   -- Copy files to new locations, expanding their name and contents as
@@ -71,11 +80,112 @@ copyTemplate templateDir subst targetDir = do
 
     -- File contents, treated as a mustache template.
     contents <- encodeUtf8 <$> (`renderMustache` subst)
-                           <$> compileMustacheFile fp
+                           <$> compileMustacheFileE fp
 
     -- Create target directory if necessary
     let dirName = fst $ splitFileName fullPath
-    createDirectoryIfMissing True dirName
+    createDirectoryIfMissingE True dirName
 
     -- Write expanded contents to expanded file path
-    B.writeFile fullPath contents
+    -- Capture exceptions here
+    writeFileE fullPath contents
+
+-- | Exception detected during the template expansion process.
+newtype CopyTemplateException = CopyTemplateException String
+
+instance Show CopyTemplateException where
+  show (CopyTemplateException s) = s
+
+instance Exception CopyTemplateException
+
+-- | Wrap 'getDirectoryContentsRecursive' and throw any 'IOException' as a
+-- 'CopyTemplateException'.
+getDirectoryContentsRecursiveE :: FilePath -> IO [FilePath]
+getDirectoryContentsRecursiveE s =
+    catch (getDirectoryContentsRecursive s) handler
+  where
+    handler :: IOException -> IO [FilePath]
+    handler e = throwIO (CopyTemplateException (show e))
+
+-- | Wrap 'createDirectoryIfMissing' and throw any 'IOException' as a
+-- 'CopyTemplateException', possibly making the error message more
+-- user-friendly.
+createDirectoryIfMissingE :: Bool -> FilePath -> IO ()
+createDirectoryIfMissingE parents fp =
+    catch (createDirectoryIfMissing parents fp) handler
+  where
+    handler :: IOException -> IO ()
+    handler e
+      | "createDirectory: permission denied" `isInfixOf` show e
+      = throwIO $ CopyTemplateException $
+          fp ++ ": " ++ "Error creating target directory (permission denied)"
+
+      | otherwise
+      = throwIO $ CopyTemplateException $ fp ++ ": " ++ show e
+
+-- | Wrap 'writeFile' and throw any 'IOException' as a 'CopyTemplateException',
+-- possibly making the error message more user-friendly.
+writeFileE :: FilePath -> B.ByteString -> IO ()
+writeFileE fp contents =
+    catch (B.writeFile fp contents) handler
+  where
+    handler :: IOException -> IO ()
+    handler e
+      | "permission denied" `isInfixOf` show e
+      = throwIO $ CopyTemplateException $
+          fp ++ ": " ++ "Error creating target file (permission denied)"
+
+      | "resource exhausted" `isInfixOf` show e
+      = throwIO $ CopyTemplateException $
+          fp ++ ": " ++ "No space left on device"
+
+      | otherwise
+      = throwIO $ CopyTemplateException $ fp ++ ": " ++ show e
+
+-- | Wrap 'compileMustacheFile' and throw any 'IOException' or
+-- 'MustacheException' as a 'CopyTemplateException', possibly making the error
+-- message more user-friendly.
+compileMustacheFileE :: FilePath -> IO Template
+compileMustacheFileE fp = do
+    catch (catch (compileMustacheFile fp) handler) handlerIO
+  where
+    handler :: MustacheException -> IO Template
+    handler (MustacheParserException p) = do
+      let pos      = errorPos p
+          line     = sourceLine pos
+          column   = sourceColumn pos
+          messages = keepHead $ map showMessage $ errorMessages p
+      throwIO $ CopyTemplateException $
+        fp ++ ":" ++ show line ++ ":" ++ show column ++ ": " ++ messages
+
+    handler e = do
+      throwIO $ CopyTemplateException $ fp ++ ": " ++ show e
+
+    handlerIO :: IOException -> IO Template
+    handlerIO e
+      | "hGetContents: invalid argument" `isInfixOf` show e
+      = throwIO $ CopyTemplateException $
+          fp ++ ": " ++ "Invalid UTF-8 byte sequence"
+
+      | "invalid byte sequence" `isInfixOf` show e
+      = throwIO $ CopyTemplateException $
+          fp ++ ": " ++ "Invalid UTF-8 byte sequence"
+
+      | "openFile: permission denied" `isInfixOf` show e
+      = throwIO $ CopyTemplateException $ fp ++ ": " ++ "Permission denied"
+
+      | otherwise
+      = throwIO $ CopyTemplateException $ fp ++ ": " ++ show e
+
+-- | Show a parse message.
+showMessage :: Message -> String
+showMessage (SysUnExpect s) = "Unexpected " ++ s
+showMessage (UnExpect s)    = "Unexpected " ++ s
+showMessage (Expect s)      = "Expected " ++ s
+showMessage (Message s)     = s
+
+-- | Keep the first element of a list of strings, returning the empty string if
+-- the list is empty.
+keepHead :: [String] -> String
+keepHead (a:_) = a
+keepHead _     = ""


### PR DESCRIPTION
Update `copyTemplate` to detect the reasons why template expansion may fail and throw a more detailed exception, and modify `ogma-core` to catch and print that exception, as prescribed in the solution proposed for #390.