### PR TITLE
Use path prefixes to specify path resolution context in project files. Refs #567.

### DIFF
--- a/ogma-cli/CHANGELOG.md
+++ b/ogma-cli/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Revision history for ogma-cli
 
-## [1.X.Y] - 2026-08-24
+## [1.X.Y] - 2026-08-28
 
 * Remove unnecessary line breaks (#520).
 * Update cFS examples to avoid MID collisions (#522).
@@ -11,6 +11,7 @@
 * Disable secure mode for package repo in Cabal config in CI jobs (#537).
 * Address HLint suggestions (#540).
 * Attempt to recover from failure during Haskell tool setup in CI jobs (#558).
+* Make file paths in example project files relative to project path (#567).
 
 ## [1.15.0] - 2026-07-21
 

--- a/ogma-cli/examples/doorstop/project.ogma
+++ b/ogma-cli/examples/doorstop/project.ogma
@@ -2,13 +2,13 @@
   "projectName": "Doorstop demo",
   "projectInputFiles": [
     [
-      "ogma-cli/examples/doorstop/REQ001.yml",
-      "ogma-cli/examples/doorstop/doorstop-with-formula.cfg",
+      "REQ001.yml",
+      "doorstop-with-formula.cfg",
       "literal"
     ]
   , [
-      "ogma-cli/examples/doorstop/REQ002.yml",
-      "ogma-cli/examples/doorstop/doorstop-with-formula.cfg",
+      "REQ002.yml",
+      "doorstop-with-formula.cfg",
       "literal"
     ]
   ],
@@ -17,6 +17,6 @@
   "projectHandlerFile": null,
   "projectCommandPropVia": null,
   "projectTemplateDir": null,
-  "projectTargetDir": "monitor",
-  "projectExtraJSONFile": "ogma-cli/examples/doorstop/extra-vars-yaml.json"
+  "projectTargetDir": "cwd:monitor",
+  "projectExtraJSONFile": "extra-vars-yaml.json"
 }

--- a/ogma-cli/examples/ros2-turtlesim/project.ogma
+++ b/ogma-cli/examples/ros2-turtlesim/project.ogma
@@ -2,16 +2,16 @@
   "projectName": "Turtlesim demo",
   "projectInputFiles": [
     [
-      "ogma-cli/examples/ros2-turtlesim/document-turtlesim.json",
-      "ogma-cli/examples/ros2-turtlesim/json-format-turtlesim.cfg",
+      "document-turtlesim.json",
+      "json-format-turtlesim.cfg",
       "literal"
     ]
   ],
-  "projectVariableFiles": "ogma-cli/examples/ros2-turtlesim/variables-turtlesim",
-  "projectVariableDBFile": "ogma-cli/examples/ros2-turtlesim/vars-db-turtlesim.json",
+  "projectVariableFiles": "variables-turtlesim",
+  "projectVariableDBFile": "vars-db-turtlesim.json",
   "projectHandlerFile": null,
   "projectCommandPropVia": null,
   "projectTemplateDir": null,
-  "projectTargetDir": "turtlesim-demo",
-  "projectExtraJSONFile": "ogma-cli/examples/ros2-turtlesim/extra-vars-turtlesim.json"
+  "projectTargetDir": "cwd:turtlesim-demo",
+  "projectExtraJSONFile": "extra-vars-turtlesim.json"
 }

--- a/ogma-core/CHANGELOG.md
+++ b/ogma-core/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Adjust ROS 2 `Dockerfile` to run `rosdep init` only when needed (#561).
 * Fix incorrect creation of two instances of ROS 2 monitoring node (#564).
 * Increase detail in template expansion error messages (#390).
+* Use path prefixes to specify path resolution context in project files (#567).
 
 ## [1.15.0] - 2026-07-21
 

--- a/ogma-core/src/Data/Project.hs
+++ b/ogma-core/src/Data/Project.hs
@@ -17,13 +17,20 @@
 -- under the License.
 --
 -- | Ogma projects.
-module Data.Project where
+module Data.Project
+    ( Project(..)
+    , readProject
+    )
+  where
 
 -- External imports
 import           Control.Exception (IOException, try)
 import           Data.Aeson        (FromJSON, ToJSON, eitherDecodeStrict')
 import qualified Data.ByteString   as BS
+import           Data.List         (stripPrefix)
 import           GHC.Generics      (Generic)
+import           System.Directory  (makeAbsolute)
+import           System.FilePath   (isAbsolute, takeDirectory, (</>))
 
 -- Internal imports
 import Data.Either.Extra (mapLeft)
@@ -49,7 +56,49 @@ instance ToJSON Project
 readProject :: FilePath -> IO (Either String Project)
 readProject path = do
   bytesResult <- try (BS.readFile path)
-  pure $ case bytesResult of
-           Left e      -> Left (show (e :: IOException))
-           Right bytes -> mapLeft ("Failed to read project: " ++)
-                        $ eitherDecodeStrict' bytes
+  let project = case bytesResult of
+                  Left e      -> Left (show (e :: IOException))
+                  Right bytes -> mapLeft ("Failed to read project: " ++)
+                               $ eitherDecodeStrict' bytes
+
+  projectDir <- takeDirectory <$> makeAbsolute path
+
+  pure $ resolveProjectPaths projectDir <$> project
+
+-- | Resolve paths inside a project.
+resolveProjectPaths :: FilePath -> Project -> Project
+resolveProjectPaths projectDir p = p
+  { projectInputFiles     = resolveInputFile projectDir <$> projectInputFiles p
+  , projectVariableFiles  = resolvePath projectDir <$> projectVariableFiles p
+  , projectVariableDBFile = resolvePath projectDir <$> projectVariableDBFile p
+  , projectHandlerFile    = resolvePath projectDir <$> projectHandlerFile p
+  , projectCommandPropVia = resolvePath projectDir <$> projectCommandPropVia p
+  , projectTemplateDir    = resolvePath projectDir <$> projectTemplateDir p
+  , projectTargetDir      = resolvePath projectDir <$> projectTargetDir p
+  , projectExtraJSONFile  = resolvePath projectDir <$> projectExtraJSONFile p
+  }
+
+-- | Resolve the locations of input file pairs, possibly in relation to the
+-- project path.
+resolveInputFile :: FilePath
+                 -> (FilePath, String, String)
+                 -> (FilePath, String, String)
+resolveInputFile projectDir (filePath, fileFormat, propName) =
+    (filePath', fileFormat', propName)
+  where
+    filePath'   = resolvePath projectDir filePath
+    fileFormat' = resolvePath projectDir fileFormat
+
+-- | Resolve the path to a file, possibly in relation to the project path.
+resolvePath :: FilePath -> FilePath -> FilePath
+resolvePath projectDir path
+  | isAbsolute path
+  = path
+  | Just path' <- stripPrefix "cwd:" path
+  = path'
+  | Just path' <- stripPrefix "cmd:" path
+  = path'
+  | Just path' <- stripPrefix "project:" path
+  = projectDir </> path'
+  | otherwise
+  = projectDir </> path


### PR DESCRIPTION
Introduce syntax to allow file paths in project files to be relative to the user's current working directory, the project path, or external commands (when applicable), and adjust existing examples accordingly, as prescribed in the solution proposed for #567.