### PR TITLE
`ogma-core`: Update `Dockerfile` in ROS 2 template for Space ROS `jazzy-2026.07.0`. Refs #569.

### DIFF
--- a/ogma-core/CHANGELOG.md
+++ b/ogma-core/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Revision history for ogma-core
 
-## [1.X.Y] - 2026-08-27
+## [1.X.Y] - 2026-08-28
 
 * Replace adhoc function `mergeMaybe` with function from `base` (#516).
 * Fix malformed comments (#518).
@@ -16,6 +16,7 @@
 * Fix incorrect creation of two instances of ROS 2 monitoring node (#564).
 * Increase detail in template expansion error messages (#390).
 * Use path prefixes to specify path resolution context in project files (#567).
+* Update `Dockerfile` in ROS 2 template for Space ROS `jazzy-2026.07.0` (#569).
 
 ## [1.15.0] - 2026-07-21
 

--- a/ogma-core/templates/ros/Dockerfile
+++ b/ogma-core/templates/ros/Dockerfile
@@ -2,7 +2,7 @@
 FROM {{.}}
 {{/BASE_DOCKER_IMAGE}}
 {{^BASE_DOCKER_IMAGE}}
-FROM osrf/space-ros:jazzy-2026.04.0
+FROM osrf/space-ros:jazzy-2026.07.0
 {{/BASE_DOCKER_IMAGE}}
 
 ARG USER=spaceros-user


### PR DESCRIPTION
Update `Dockerfile` included with the ROS 2 template to be based on Space ROS `jazzy-2026.07.0`, as prescribed in the solution proposed for #569.