### PR TITLE
`ogma-cli`: Add missing argument to `docker run` in Turtlesim tutorial. Refs #571.

### DIFF
--- a/ogma-cli/CHANGELOG.md
+++ b/ogma-cli/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Address HLint suggestions (#540).
 * Attempt to recover from failure during Haskell tool setup in CI jobs (#558).
 * Make file paths in example project files relative to project path (#567).
+* Add missing argument to `docker run` in Turtlesim tutorial (#571).
 
 ## [1.15.0] - 2026-07-21
 

--- a/ogma-cli/examples/ros2-turtlesim/README.md
+++ b/ogma-cli/examples/ros2-turtlesim/README.md
@@ -118,7 +118,8 @@ $ docker run --rm -it \
    -e TERM \
    -e QT_X11_NO_MITSHM=1 \
    -v /tmp/.X11-unix:/tmp/.X11-unix:rw \
-   ogma-turtlesim-demo
+   ogma-turtlesim-demo \
+   /bin/bash
 ```
 
 Once container boots, we start the simulation itself, which brings up ta GUI


### PR DESCRIPTION
Update the `docker run` invocation in the Turtlesim tutorial to make `docker` open a terminal inside the container, as prescribed in the solution proposed for #571.