### PR TITLE
`ogma-cli`: Fix container name in call to `docker exec` in Turtlesim example. Refs #573.

### DIFF
--- a/ogma-cli/CHANGELOG.md
+++ b/ogma-cli/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Attempt to recover from failure during Haskell tool setup in CI jobs (#558).
 * Make file paths in example project files relative to project path (#567).
 * Add missing argument to `docker run` in Turtlesim tutorial (#571).
+* Fix container name in call to `docker exec` in Turtlesim example (#573).
 
 ## [1.15.0] - 2026-07-21
 

--- a/ogma-cli/examples/ros2-turtlesim/README.md
+++ b/ogma-cli/examples/ros2-turtlesim/README.md
@@ -137,7 +137,7 @@ That should bring up a GUI with a turtle in the middle.
 In the second terminal we execute:
 
 ```
-$ docker exec -it ogma-turtlesim-container /bin/bash
+$ docker exec -it ogma-turtlesim-demo-container /bin/bash
 ```
 
 Once the container boots, we run a ROS 2 that allows us to control the turtle
@@ -153,7 +153,7 @@ $ ros2 run turtlesim turtle_teleop_key
 In the third terminal we execute:
 
 ```
-$ docker exec -it ogma-turtlesim-container /bin/bash
+$ docker exec -it ogma-turtlesim-demo-container /bin/bash
 ```
 
 Once the container boots, we start the monitoring node, which awaits for
@@ -167,7 +167,7 @@ $ ros2 run copilot copilot
 ## Terminal 4
 
 ```
-$ docker exec -it ogma-turtlesim-container /bin/bash
+$ docker exec -it ogma-turtlesim-demo-container /bin/bash
 ```
 
 Once the container boots, we listen for message violations reported by the


### PR DESCRIPTION
Modify the Turtlesim tutorial to use the correct container name in the invocation of `docker exec` listed as part of the execution steps, as prescribed in the solution proposed for #573.