### PR TITLE
Introduce default input format configuration files. Refs #575.

### DIFF
--- a/ogma-cli/CHANGELOG.md
+++ b/ogma-cli/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Add missing argument to `docker run` in Turtlesim tutorial (#571).
 * Fix container name in call to `docker exec` in Turtlesim example (#573).
 * Update package index before installing dependencies in CI jobs (#577).
+* Update commands to use new input file format by default (#575).
 
 ## [1.15.0] - 2026-07-21
 

--- a/ogma-cli/src/CLI/CommandCFSApp.hs
+++ b/ogma-cli/src/CLI/CommandCFSApp.hs
@@ -214,7 +214,7 @@ commandOptsParser = CommandOpts
         <> metavar "FORMAT_NAME"
         <> help strCFSAppFormatDesc
         <> showDefault
-        <> value "fcs"
+        <> value "default"
         )
   <*> strOption
         (  long "prop-format"

--- a/ogma-cli/src/CLI/CommandFPrimeApp.hs
+++ b/ogma-cli/src/CLI/CommandFPrimeApp.hs
@@ -212,7 +212,7 @@ commandOptsParser = CommandOpts
         <> metavar "FORMAT_NAME"
         <> help strFPrimeAppFormatDesc
         <> showDefault
-        <> value "fcs"
+        <> value "default"
         )
   <*> strOption
         (  long "prop-format"

--- a/ogma-cli/src/CLI/CommandOverview.hs
+++ b/ogma-cli/src/CLI/CommandOverview.hs
@@ -211,7 +211,7 @@ overviewFileOptsParser = OverviewFile
         <> metavar "FORMAT_NAME"
         <> help strOverviewFormatDesc
         <> showDefault
-        <> value "fcs"
+        <> value "default"
         )
   <*> strOption
         (  long "prop-format"

--- a/ogma-cli/src/CLI/CommandROSApp.hs
+++ b/ogma-cli/src/CLI/CommandROSApp.hs
@@ -236,7 +236,7 @@ commandOptsParser = CommandOpts
         <> metavar "FORMAT_NAME"
         <> help strROSAppFormatDesc
         <> showDefault
-        <> value "fcs"
+        <> value "default"
         )
   <*> strOption
         (  long "prop-format"

--- a/ogma-cli/src/CLI/CommandReport.hs
+++ b/ogma-cli/src/CLI/CommandReport.hs
@@ -180,7 +180,7 @@ reportFileOptsParser = ReportFile
         <> metavar "FORMAT_NAME"
         <> help strReportFormatDesc
         <> showDefault
-        <> value "fcs"
+        <> value "default"
         )
   <*> strOption
         (  long "prop-format"

--- a/ogma-cli/src/CLI/CommandSearch.hs
+++ b/ogma-cli/src/CLI/CommandSearch.hs
@@ -195,7 +195,7 @@ searchFileOptsParser = SearchFile
         <> metavar "FORMAT_NAME"
         <> help strSearchFormatDesc
         <> showDefault
-        <> value "fcs"
+        <> value "default"
         )
   <*> strOption
         (  long "prop-format"

--- a/ogma-cli/src/CLI/CommandStandalone.hs
+++ b/ogma-cli/src/CLI/CommandStandalone.hs
@@ -196,7 +196,7 @@ commandOptsParser = CommandOpts
         <> metavar "FORMAT_NAME"
         <> help strStandaloneFormatDesc
         <> showDefault
-        <> value "fcs"
+        <> value "default"
         )
   <*> strOption
         (  long "prop-format"

--- a/ogma-cli/tests/Main.hs
+++ b/ogma-cli/tests/Main.hs
@@ -114,7 +114,7 @@ parseStandaloneFCS :: FilePath  -- ^ Path to an input file
 parseStandaloneFCS file success = do
     assertExecution "ogma" args success errorMsg
   where
-    args     = ["standalone", "--input-file", file]
+    args     = ["standalone", "--input-file", file, "--input-format", "fcs"]
     errorMsg = "Parsing file " ++ file ++ " result unexpected."
 
 -- | Test standalone backend for FDB format and Lustre.

--- a/ogma-core/CHANGELOG.md
+++ b/ogma-core/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Revision history for ogma-core
 
-## [1.X.Y] - 2026-08-28
+## [1.X.Y] - 2026-09-02
 
 * Replace adhoc function `mergeMaybe` with function from `base` (#516).
 * Fix malformed comments (#518).
@@ -17,6 +17,7 @@
 * Increase detail in template expansion error messages (#390).
 * Use path prefixes to specify path resolution context in project files (#567).
 * Update `Dockerfile` in ROS 2 template for Space ROS `jazzy-2026.07.0` (#569).
+* Introduce default input format configuration files (#575).
 
 ## [1.15.0] - 2026-07-21
 

--- a/ogma-core/data/formats/default_literal
+++ b/ogma-core/data/formats/default_literal
@@ -1,0 +1,15 @@
+JSONFormat
+   { specInternalVars          = Just "..auxiliary_defs[*]"
+   , specInternalVarId         = ".name"
+   , specInternalVarExpr       = ".meaning"
+   , specInternalVarType       = Just ".type"
+   , specExternalVars          = Just "..inputs[*]"
+   , specExternalVarId         = ".name"
+   , specExternalVarType       = Just ".type"
+   , specRequirements          = "..properties[*]"
+   , specRequirementId         = ".id"
+   , specRequirementDesc       = Just ".description"
+   , specRequirementExpr       = ".formula"
+   , specRequirementResultType = Nothing
+   , specRequirementResultExpr = Nothing
+   }

--- a/ogma-core/data/formats/default_lustre
+++ b/ogma-core/data/formats/default_lustre
@@ -1,0 +1,15 @@
+JSONFormat
+   { specInternalVars          = Just "..auxiliary_defs[*]"
+   , specInternalVarId         = ".name"
+   , specInternalVarExpr       = ".meaning"
+   , specInternalVarType       = Just ".type"
+   , specExternalVars          = Just "..inputs[*]"
+   , specExternalVarId         = ".name"
+   , specExternalVarType       = Just ".type"
+   , specRequirements          = "..properties[*]"
+   , specRequirementId         = ".id"
+   , specRequirementDesc       = Just ".description"
+   , specRequirementExpr       = ".formula"
+   , specRequirementResultType = Nothing
+   , specRequirementResultExpr = Nothing
+   }

--- a/ogma-core/data/formats/default_smv
+++ b/ogma-core/data/formats/default_smv
@@ -1,0 +1,15 @@
+JSONFormat
+   { specInternalVars          = Just "..auxiliary_defs[*]"
+   , specInternalVarId         = ".name"
+   , specInternalVarExpr       = ".meaning"
+   , specInternalVarType       = Just ".type"
+   , specExternalVars          = Just "..inputs[*]"
+   , specExternalVarId         = ".name"
+   , specExternalVarType       = Just ".type"
+   , specRequirements          = "..properties[*]"
+   , specRequirementId         = ".id"
+   , specRequirementDesc       = Just ".description"
+   , specRequirementExpr       = ".formula"
+   , specRequirementResultType = Nothing
+   , specRequirementResultExpr = Nothing
+   }

--- a/ogma-core/ogma-core.cabal
+++ b/ogma-core/ogma-core.cabal
@@ -76,6 +76,9 @@ data-files:          templates/cfs/Dockerfile
                      templates/fprime/instance-copilot
                      templates/report/Report.md
                      templates/standalone/Copilot.hs
+                     data/formats/default_smv
+                     data/formats/default_literal
+                     data/formats/default_lustre
                      data/formats/fcs_smv
                      data/formats/fcs_lustre
                      data/formats/fdb_smv


### PR DESCRIPTION
Introduce three variants of a new default file format for input specification that can be used by new projects, one for each property format supported, as prescribed in the solution proposed for #575.
