### PR TITLE
`ogma-cli`: Update package index before installing dependencies in CI jobs. Refs #577.

### DIFF
--- a/.github/workflows/repo-ghc-8.6-cabal-2.4-cfs.yml
+++ b/.github/workflows/repo-ghc-8.6-cabal-2.4-cfs.yml
@@ -46,6 +46,7 @@ jobs:
 
     - name: Install dependencies
       run: |
+        sudo apt-get update
         sudo apt-get install -y libbz2-dev libexpat-dev cmake make psmisc
         cabal v1-install alex happy --constraint="alex <3.5.4.1 || >3.5.4.1"
         cabal v1-install BNFC

--- a/.github/workflows/repo-ghc-8.6-cabal-2.4-csv.yml
+++ b/.github/workflows/repo-ghc-8.6-cabal-2.4-csv.yml
@@ -46,6 +46,7 @@ jobs:
 
     - name: Install dependencies
       run: |
+        sudo apt-get update
         sudo apt-get install -y libbz2-dev libexpat-dev cmake make psmisc
         cabal v1-install alex happy --constraint="alex <3.5.4.1 || >3.5.4.1"
         cabal v1-install BNFC

--- a/.github/workflows/repo-ghc-8.6-cabal-2.4-diagram.yml
+++ b/.github/workflows/repo-ghc-8.6-cabal-2.4-diagram.yml
@@ -46,6 +46,7 @@ jobs:
 
     - name: Install dependencies
       run: |
+        sudo apt-get update
         sudo apt-get install -y libz-dev libbz2-dev libexpat-dev
         cabal v1-install alex happy --constraint="alex <3.5.4.1 || >3.5.4.1"
         cabal v1-install BNFC

--- a/.github/workflows/repo-ghc-8.6-cabal-2.4-ros.yml
+++ b/.github/workflows/repo-ghc-8.6-cabal-2.4-ros.yml
@@ -43,6 +43,7 @@ jobs:
 
     - name: Install dependencies
       run: |
+        sudo apt-get update
         sudo apt-get install -y libbz2-dev libexpat-dev
         cabal install --lib copilot copilot-c99 copilot-language copilot-theorem \
           copilot-libraries copilot-interpreter

--- a/.github/workflows/repo-ghc-8.6-cabal-2.4-xlsx.yml
+++ b/.github/workflows/repo-ghc-8.6-cabal-2.4-xlsx.yml
@@ -46,6 +46,7 @@ jobs:
 
     - name: Install dependencies
       run: |
+        sudo apt-get update
         sudo apt-get install -y libbz2-dev libexpat-dev cmake make psmisc
         cabal v1-install alex happy --constraint="alex <3.5.4.1 || >3.5.4.1"
         cabal v1-install BNFC

--- a/.github/workflows/repo-ghc-8.6-cabal-2.4.yml
+++ b/.github/workflows/repo-ghc-8.6-cabal-2.4.yml
@@ -47,6 +47,7 @@ jobs:
 
     - name: Install dependencies
       run: |
+        sudo apt-get update
         sudo apt-get install -y libbz2-dev libexpat-dev
         cabal v1-install alex happy --constraint="alex <3.5.4.1 || >3.5.4.1"
         cabal v1-install BNFC

--- a/.github/workflows/repo-ghc-9.10-cabal-3.12-ros-turtlesim.yml
+++ b/.github/workflows/repo-ghc-9.10-cabal-3.12-ros-turtlesim.yml
@@ -43,6 +43,7 @@ jobs:
 
     - name: Install dependencies
       run: |
+        sudo apt-get update
         sudo apt-get install -y libbz2-dev libexpat-dev
         cabal install --lib copilot copilot-c99 copilot-language copilot-theorem \
           copilot-libraries copilot-interpreter

--- a/ogma-cli/CHANGELOG.md
+++ b/ogma-cli/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Revision history for ogma-cli
 
-## [1.X.Y] - 2026-08-28
+## [1.X.Y] - 2026-09-02
 
 * Remove unnecessary line breaks (#520).
 * Update cFS examples to avoid MID collisions (#522).
@@ -14,6 +14,7 @@
 * Make file paths in example project files relative to project path (#567).
 * Add missing argument to `docker run` in Turtlesim tutorial (#571).
 * Fix container name in call to `docker exec` in Turtlesim example (#573).
+* Update package index before installing dependencies in CI jobs (#577).
 
 ## [1.15.0] - 2026-07-21
 


### PR DESCRIPTION
Modify all CI jobs to run `sudo apt-get update` prior to attempting to install any packages with `apt-get`, as prescribed in the solution proposed for #577.