### PR TITLE
`ogma-extra`: Address HLint suggestions. Refs #579.

### DIFF
--- a/ogma-extra/CHANGELOG.md
+++ b/ogma-extra/CHANGELOG.md
@@ -1,10 +1,11 @@
 # Revision history for ogma-extra
 
-## [1.X.Y] - 2026-08-27
+## [1.X.Y] - 2026-09-05
 
 * Remove unnecessary line breaks (#520).
 * Bump upper version constraint on `QuickCheck` (#545).
 * Handle template expansion errors using specialized exception type (#390).
+* Address HLint suggestions (#579).
 
 ## [1.15.0] - 2026-07-21
 

--- a/ogma-extra/src/Data/List/Extra.hs
+++ b/ogma-extra/src/Data/List/Extra.hs
@@ -39,5 +39,5 @@ toTail _ xs     = xs
 -- | Remove a suffix from a string, if present.
 stripSuffix :: String -> String -> String
 stripSuffix suffix string
-  | isSuffixOf suffix string = take (length string - length suffix) string
-  | otherwise                = string
+  | suffix `isSuffixOf` string = take (length string - length suffix) string
+  | otherwise                  = string

--- a/ogma-extra/src/System/Directory/Extra.hs
+++ b/ogma-extra/src/System/Directory/Extra.hs
@@ -45,6 +45,7 @@ import           Text.Parsec.Error         ( Message (..), errorMessages,
                                              errorPos )
 import           Text.Parsec.Pos           ( sourceColumn, sourceLine )
 
+{- HLINT ignore "Redundant <$>" -}
 -- | Copy a template directory into a target location, expanding variables
 -- provided in a map in a JSON value, both in the file contents and in the
 -- filepaths themselves.


### PR DESCRIPTION
Address all suggestions reported by HLint on `ogma-extra`, by re-writing the code or by making HLint ignore them, as prescribed in the solution proposed for #579.