### PR TITLE
`ogma-language-csv`: Address HLint suggestions. Refs #581.

### DIFF
--- a/ogma-language-csv/CHANGELOG.md
+++ b/ogma-language-csv/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Revision history for ogma-language-csv
 
+## [1.X.Y] - 2026-09-05
+
+* Address HLint suggestions (#581).
+
 ## [1.15.0] - 2026-07-21
 
 * Version bump (1.15.0) (#508).

--- a/ogma-language-csv/src/Language/CSVSpec/Parser.hs
+++ b/ogma-language-csv/src/Language/CSVSpec/Parser.hs
@@ -70,7 +70,7 @@ parseCSVSpec parseExpr _defA csvFormat value = do
                   rowL !! specRequirementExpr csvFormat
         exprR <- maybe (return $ Right Nothing)
                        (\ix -> fmap Just <$>
-                                 (parseExpr $ bsToString $ rowL !! ix))
+                                 parseExpr (bsToString $ rowL !! ix))
                        (specRequirementResultExpr csvFormat)
         case (expr, exprR) of
           (Left e, _)

--- a/ogma-language-csv/src/Language/CSVSpec/Parser.hs
+++ b/ogma-language-csv/src/Language/CSVSpec/Parser.hs
@@ -88,7 +88,7 @@ parseCSVSpec parseExpr _defA csvFormat value = do
                     specRequirementDesc csvFormat
               , requirementExpr = e
               , requirementResultType =
-                  fmap (bsToString . (rowL !!)) $
+                  bsToString . (rowL !!) <$>
                     specRequirementResultType csvFormat
               , requirementResultExpr = rE
               }


### PR DESCRIPTION
Address all suggestions reported by HLint on `ogma-language-csv`, by re-writing the code or by making HLint ignore them, as prescribed in the solution proposed for #581.