### PR TITLE
`ogma-core`: Address HLint suggestions. Refs #586.

### DIFF
--- a/ogma-core/.hlint.yaml
+++ b/ogma-core/.hlint.yaml
@@ -3,3 +3,5 @@
 
 # Ignore in automatically generated files.
 - ignore: {within: [Paths_ogma_core]}
+
+- ignore: {name: Use tuple-section}

--- a/ogma-core/CHANGELOG.md
+++ b/ogma-core/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Revision history for ogma-core
 
-## [1.X.Y] - 2026-09-02
+## [1.X.Y] - 2026-09-10
 
 * Replace adhoc function `mergeMaybe` with function from `base` (#516).
 * Fix malformed comments (#518).
@@ -18,6 +18,7 @@
 * Use path prefixes to specify path resolution context in project files (#567).
 * Update `Dockerfile` in ROS 2 template for Space ROS `jazzy-2026.07.0` (#569).
 * Introduce default input format configuration files (#575).
+* Address HLint suggestions (#586).
 
 ## [1.15.0] - 2026-07-21
 

--- a/ogma-core/src/Command/CFSApp.hs
+++ b/ogma-core/src/Command/CFSApp.hs
@@ -183,8 +183,7 @@ commandLogic :: VariableDB
              -> [Trigger]
              -> Maybe Command.Standalone.AppData
              -> AppData
-commandLogic varDB varNames handlers copilotM =
-    AppData vars ids infos datas handlers copilotM
+commandLogic varDB varNames = AppData vars ids infos datas
   where
 
     -- This is a Data.List.unzip4

--- a/ogma-core/src/Command/CFSApp.hs
+++ b/ogma-core/src/Command/CFSApp.hs
@@ -113,7 +113,7 @@ command' options (ExprPair exprT) = do
 
     specT <- maybe
                (return Nothing)
-               (\e -> Just . InputFileSpec <$> readInputExpr' e)
+               (fmap (Just . InputFileSpec) . readInputExpr')
                cExpr
 
     specF <- if null fpA

--- a/ogma-core/src/Command/CFSApp.hs
+++ b/ogma-core/src/Command/CFSApp.hs
@@ -247,7 +247,7 @@ variableMap varDB varName = do
 
       active = inputActive inputDef
 
-  let typeVar' = fromMaybe (topicType topicDef) (typeToType <$> typeDef)
+  let typeVar' = maybe (topicType topicDef) typeToType typeDef
 
   -- Pick name for the function to process a message ID.
   let mn = pascalCase $ stripSuffix "_MID" mid

--- a/ogma-core/src/Command/CFSApp.hs
+++ b/ogma-core/src/Command/CFSApp.hs
@@ -131,8 +131,7 @@ command' options (ExprPair exprT) = do
 
     mode <- parseDiagramMode (commandDiagramMode options)
 
-    copilotM <- sequenceA $
-                  (\spec' -> processSpec spec' cExpr fpA mode) <$> spec
+    copilotM <- traverse (\spec' -> processSpec spec' cExpr fpA mode) spec
 
     let varNames = fromMaybe (defaultVarNames spec) vs
         monitors = maybe (defaultMonitors spec) (map (\x -> (x, Nothing))) rs

--- a/ogma-core/src/Command/CFSApp.hs
+++ b/ogma-core/src/Command/CFSApp.hs
@@ -159,8 +159,8 @@ command' options (ExprPair exprT) = do
     readInputFile' f =
       parseInputFile f formatName propFormatName propVia exprT
 
-    processSpec spec' expr' fp' mode =
-      Command.Standalone.commandLogic expr' fp' "copilot" [] exprT spec' mode
+    processSpec spec' expr' fp' =
+      Command.Standalone.commandLogic expr' fp' "copilot" [] exprT spec'
 
     defaultVarNames spec = case spec of
       Just (InputFileSpec spec') -> specExtractExternalVariables (Just spec')

--- a/ogma-core/src/Command/Common.hs
+++ b/ogma-core/src/Command/Common.hs
@@ -226,9 +226,8 @@ checkArguments _       _         _         = Right ()
 -- | Extract the variables from a specification, and sanitize them.
 specExtractExternalVariables :: Maybe (Spec a) -> [String]
 specExtractExternalVariables Nothing   = []
-specExtractExternalVariables (Just cs) = map sanitizeLCIdentifier
-                                       $ map externalVariableName
-                                       $ externalVariables cs
+specExtractExternalVariables (Just cs) =
+ map (sanitizeLCIdentifier . externalVariableName) $ externalVariables cs
 
 -- | Extract the requirements from a specification, and sanitize them to match
 -- the names of the handlers used by Copilot.

--- a/ogma-core/src/Command/Common.hs
+++ b/ogma-core/src/Command/Common.hs
@@ -157,7 +157,7 @@ parseRequirementsListFile :: Maybe FilePath
 parseRequirementsListFile Nothing   = return Nothing
 parseRequirementsListFile (Just fp) =
   ExceptT $ makeLeftE (cannotOpenHandlersFile fp) <$>
-    (E.try $ Just . lines <$> readFile fp)
+    E.try (Just . lines <$> readFile fp)
 
 -- | Read a list of variable DBs.
 openVarDBFiles :: VariableDB

--- a/ogma-core/src/Command/Diagram.hs
+++ b/ogma-core/src/Command/Diagram.hs
@@ -187,7 +187,7 @@ exprPair :: DiagramPropFormat -> ExprPair
 exprPair Inputs = ExprPair $
   ExprPairT
     ((Right . read) :: String -> Either String Int)
-    (\_ -> id)
+    (const id)
     (\x -> "input == " ++ show x)
     (const [])
     (-1)

--- a/ogma-core/src/Command/FPrimeApp.hs
+++ b/ogma-core/src/Command/FPrimeApp.hs
@@ -121,7 +121,7 @@ command' options (ExprPair exprT) = do
 
     liftEither $ checkArguments spec vs rs
 
-    copilotM <- sequenceA $ (\spec' -> processSpec spec' cExpr fpA) <$> spec
+    copilotM <- traverse (\spec' -> processSpec spec' cExpr fpA) spec
 
     let varNames = fromMaybe (defaultVarNames spec) vs
         monitors = maybe (defaultMonitors spec) (map (\x -> (x, Nothing))) rs

--- a/ogma-core/src/Command/FPrimeApp.hs
+++ b/ogma-core/src/Command/FPrimeApp.hs
@@ -105,7 +105,7 @@ command' options (ExprPair exprT) = do
 
     specT <- maybe
                (return Nothing)
-               (\e -> Just . InputFileSpec <$> readInputExpr' e)
+               (fmap (Just . InputFileSpec). readInputExpr')
                cExpr
 
     specF <- if null fpA

--- a/ogma-core/src/Command/Overview.hs
+++ b/ogma-core/src/Command/Overview.hs
@@ -202,7 +202,7 @@ data CommandSummaryDiagram = CommandSummaryDiagram
 instance ToJSON CommandSummaryDiagram
 
 -- | Options used to customize the interpretation of input specifications.
-data CommandOptions = CommandOptions
+newtype CommandOptions = CommandOptions
   { commandInputFiles :: [ OverviewFile ]
   }
 

--- a/ogma-core/src/Command/Overview.hs
+++ b/ogma-core/src/Command/Overview.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE DeriveGeneric             #-}
 {-# LANGUAGE ExistentialQuantification #-}
-{-# LANGUAGE OverloadedStrings         #-}
 {-# LANGUAGE ScopedTypeVariables       #-}
 -- Copyright 2024 United States Government as represented by the Administrator
 -- of the National Aeronautics and Space Administration. All Rights Reserved.

--- a/ogma-core/src/Command/ROSApp.hs
+++ b/ogma-core/src/Command/ROSApp.hs
@@ -127,7 +127,7 @@ command' options (ExprPair exprT) = do
 
     liftEither $ checkArguments spec vs rs
 
-    copilotM <- sequenceA $ (\spec' -> processSpec spec' cExpr fpA) <$> spec
+    copilotM <- traverse (\spec' -> processSpec spec' cExpr fpA) spec
 
     let varNames = fromMaybe (defaultVarNames spec) vs
         monitors = maybe (defaultMonitors spec) (map (\x -> (x, Nothing))) rs

--- a/ogma-core/src/Command/ROSApp.hs
+++ b/ogma-core/src/Command/ROSApp.hs
@@ -111,7 +111,7 @@ command' options (ExprPair exprT) = do
 
     specT <- maybe
                (return Nothing)
-               (\e -> Just . InputFileSpec <$> readInputExpr' e)
+               (fmap (Just . InputFileSpec) . readInputExpr')
                cExpr
 
     specF <- if null fpA

--- a/ogma-core/src/Command/ROSApp.hs
+++ b/ogma-core/src/Command/ROSApp.hs
@@ -235,9 +235,10 @@ variableMap varDB varName = do
                 (inputType inputDef)
                 (Just . typeToType)
                 (findType varDB varName "ros/variable" "C")
-  let typeMsg' = fromMaybe
+  let typeMsg' = maybe
                    (topicType topicDef)
-                   (typeFromType <$> findType varDB varName "ros/message" "C")
+                   typeFromType
+                   (findType varDB varName "ros/message" "C")
 
       fieldMsg = typeFromField =<< findType varDB varName "ros/message" "C"
 

--- a/ogma-core/src/Command/Report.hs
+++ b/ogma-core/src/Command/Report.hs
@@ -160,7 +160,7 @@ command' options (ExprPair exprT) file = do
                            }
 
         pure $ CommandSummary
-                 { commandRequirementsAny = length reqListDetails > 0
+                 { commandRequirementsAny = not (null reqListDetails)
                  , commandRequirementList = [fileReqs]
                  , commandDiagramsAny     = False
                  , commandDiagramsList    = []

--- a/ogma-core/src/Command/Search.hs
+++ b/ogma-core/src/Command/Search.hs
@@ -174,7 +174,7 @@ data RequirementInfo = RequirementInfo
 instance ToJSON RequirementInfo
 
 -- | Information about a diagram that matches the search query.
-data DiagramInfo = DiagramInfo
+newtype DiagramInfo = DiagramInfo
     { diagramInfoLocation :: FilePath
     }
   deriving (Generic, Show)

--- a/ogma-core/src/Command/Standalone.hs
+++ b/ogma-core/src/Command/Standalone.hs
@@ -106,7 +106,7 @@ command' options (ExprPair exprT) = do
     -- definitions.
     specT <- maybe
                (return Nothing)
-               (\e -> Just . InputFileSpec <$> readInputExpr' e)
+               (fmap (Just . InputFileSpec) . readInputExpr')
                triggerExprM
 
     specF <- if null fpA

--- a/ogma-core/src/Command/Standalone.hs
+++ b/ogma-core/src/Command/Standalone.hs
@@ -121,7 +121,7 @@ command' options (ExprPair exprT) = do
     let spec = specT <|> specF
 
     case spec of
-      Nothing    -> liftEither $ Left $ commandMissingSpec
+      Nothing    -> liftEither $ Left commandMissingSpec
       Just spec' ->
         commandLogic triggerExprM fpA name typeMaps exprT spec' ComputeState
 

--- a/ogma-core/src/Data/Aeson/Extra.hs
+++ b/ogma-core/src/Data/Aeson/Extra.hs
@@ -28,7 +28,7 @@ import Data.Aeson.KeyMap (union)
 --
 -- Fails if the values are not objects or null.
 mergeObjects :: Value -> Value -> Value
-mergeObjects (Object m1) (Object m2) = Object (union m1 m2)
+mergeObjects (Object m1) (Object m2) = Object (m1 `union` m2)
 mergeObjects obj         Null        = obj
 mergeObjects Null        obj         = obj
 mergeObjects _           _           = error "The values passed are not objects"

--- a/ogma-core/src/Data/Diagram/Parser/Mermaid.hs
+++ b/ogma-core/src/Data/Diagram/Parser/Mermaid.hs
@@ -79,6 +79,7 @@ pGraphDiagram exprP = do
 
   pure $ Diagram transitions
 
+{-# ANN pGraphTransition ("HLint: ignore Redundant bracket" :: String) #-}
 -- | Parser for an edge in a state diagram.
 --
 -- This parser depends on an auxiliary parser for the expressions associated to

--- a/ogma-core/src/Data/Diagram/Parser/Mermaid.hs
+++ b/ogma-core/src/Data/Diagram/Parser/Mermaid.hs
@@ -110,7 +110,8 @@ pStateDiagram exprPair = do
 
   pure $ Diagram transitions
 
-{-# ANN pStateTransition ("HLint: ignore Redundant bracket" :: String) #-}
+{-# ANN pStateTransition ("HLint: ignore Redundant bracket" :: String)  #-}
+{-# ANN pStateTransition ("HLint: ignore Reduce duplication" :: String) #-}
 -- | Parser for transition label in stateDiagram-v2 mermaid diagram.
 pStateTransition :: ExprPair -> MermaidParser (Int, String, Int)
 pStateTransition ep@(ExprPair (ExprPairT { exprTParse = parseProp })) = do

--- a/ogma-core/src/Data/Diagram/Parser/Mermaid.hs
+++ b/ogma-core/src/Data/Diagram/Parser/Mermaid.hs
@@ -110,6 +110,7 @@ pStateDiagram exprPair = do
 
   pure $ Diagram transitions
 
+{-# ANN pStateTransition ("HLint: ignore Redundant bracket" :: String) #-}
 -- | Parser for transition label in stateDiagram-v2 mermaid diagram.
 pStateTransition :: ExprPair -> MermaidParser (Int, String, Int)
 pStateTransition ep@(ExprPair (ExprPairT { exprTParse = parseProp })) = do

--- a/ogma-core/src/Data/Diagram/Parser/Mermaid.hs
+++ b/ogma-core/src/Data/Diagram/Parser/Mermaid.hs
@@ -144,6 +144,7 @@ pSequenceDiagram exprPair = do
 
   pure $ Diagram transitions
 
+{-# ANN pSequenceTransition ("HLint: ignore Redundant bracket" :: String) #-}
 -- | Parser for a connection, message or transition in a sequence diagram.
 --
 -- This parser depends on an auxiliary parser for the expressions associated to

--- a/ogma-core/src/Data/Diagram/Parser/Mermaid.hs
+++ b/ogma-core/src/Data/Diagram/Parser/Mermaid.hs
@@ -129,7 +129,7 @@ pStateTransition ep@(ExprPair (ExprPairT { exprTParse = parseProp })) = do
 
   _ <- newline
 
-  pure $ (from, exprPairShow ep edge, to)
+  pure (from, exprPairShow ep edge, to)
 
 -- | Parser for Mermaid diagrams of type sequenceDiagram.
 pSequenceDiagram :: ExprPair -> MermaidParser Diagram

--- a/ogma-core/src/Data/ExprPair.hs
+++ b/ogma-core/src/Data/ExprPair.hs
@@ -78,7 +78,7 @@ exprPair "lustre" = ExprPair $
 exprPair "literal" = ExprPair $
   ExprPairT
     Right
-    (\_ -> id)
+    (const id)
     id
     (const [])
     "undefined"

--- a/ogma-core/src/Data/ExprPair.hs
+++ b/ogma-core/src/Data/ExprPair.hs
@@ -71,7 +71,7 @@ exprPair :: String -> ExprPair
 exprPair "lustre" = ExprPair $
   ExprPairT
     (Lustre.pBoolSpec . Lustre.myLexer)
-    (\_ -> id)
+    (const id)
     Lustre.boolSpec2Copilot
     Lustre.boolSpecNames
     (Lustre.BoolSpecSignal (Lustre.Ident "undefined"))

--- a/ogma-core/src/Data/Spec/Analysis.hs
+++ b/ogma-core/src/Data/Spec/Analysis.hs
@@ -243,7 +243,7 @@ showSpec spec = template ++ "\n" ++ extra ++ "\n" ++ triggers
       map ("       " ++) [ n ++ " :: " ++ t, n ++ " = " ++ i ]
 
     formatTrigger (_, _, h, g, a) =
-      map ("   " ++) [ "trigger " ++ show h ++ " (" ++ g ++ ") " ++ a ]
+      [ "   trigger " ++ show h ++ " (" ++ g ++ ") " ++ a ]
 
 -- | Default imports for a 'Spec' that was converted into a 'Copilot.Spec'.
 defaultSpecImports :: [(String, Maybe String)]

--- a/ogma-core/src/Data/Spec/Extra.hs
+++ b/ogma-core/src/Data/Spec/Extra.hs
@@ -33,7 +33,7 @@ addMissingIdentifiers :: (a -> [String]) -> Spec a -> Spec a
 addMissingIdentifiers f s = s { externalVariables = vars' }
   where
     vars'   = externalVariables s ++ newVars
-    newVars = map (\n -> ExternalVariableDef n "") newVarNames
+    newVars = map (`ExternalVariableDef` "") newVarNames
 
     -- Names that are not defined anywhere
     newVarNames = identifiers \\ existingNames

--- a/ogma-core/src/Language/Trans/Spec2Copilot.hs
+++ b/ogma-core/src/Language/Trans/Spec2Copilot.hs
@@ -140,30 +140,9 @@ spec2Copilot specName typeMaps exprTransform showExpr spec =
                 (Just ty, Just ex) -> "[ arg (" ++ showExpr ex ++ " ) ]"
                 _                  -> "[]"
 
-    -- Map from a variable name to its desired identifier in the code
-    -- generated.
-    internalVariableMap =
-      map (\x -> (x, sanitizeLCIdentifier x)) internalVariableNames
-
-    externalVariableMap =
-      map (\x -> (x, sanitizeLCIdentifier x)) externalVariableNames
-
-    requirementNameMap =
-      map (\x -> (x, "prop" ++ sanitizeUCIdentifier x)) requirementNames
-
-    nameSubstitutions = internalVariableMap
-                     ++ externalVariableMap
-                     ++ requirementNameMap
-
-    -- Variable/requirement names used in the input spec.
-    internalVariableNames = map internalVariableName
-                          $ internalVariables spec
-
-    externalVariableNames = map externalVariableName
-                          $ externalVariables spec
-
-    requirementNames = map requirementName
-                     $ requirements spec
+    nameSubstitutions = internalVariableMap spec
+                     ++ externalVariableMap spec
+                     ++ requirementNameMap spec
 
 -- | Check that a specification does not contain any name clashes between
 -- variables and/or requirements.
@@ -195,30 +174,9 @@ specAnalyze spec
                                 `union` externalVariableNames')
 
     -- Names used.
-    internalVariableNames' = map snd internalVariableMap
-    externalVariableNames' = map snd externalVariableMap
-    requirementNames'      = map snd requirementNameMap
-
-    -- Map from a variable name to its desired identifier in the code
-    -- generated.
-    internalVariableMap =
-      map (\x -> (x, sanitizeLCIdentifier x)) internalVariableNames
-
-    externalVariableMap =
-      map (\x -> (x, sanitizeLCIdentifier x)) externalVariableNames
-
-    requirementNameMap =
-      map (\x -> (x, "prop" ++ sanitizeUCIdentifier x)) requirementNames
-
-    -- Variable/requirement names used in the input spec.
-    internalVariableNames = map internalVariableName
-                          $ internalVariables spec
-
-    externalVariableNames = map externalVariableName
-                          $ externalVariables spec
-
-    requirementNames = map requirementName
-                     $ requirements spec
+    internalVariableNames' = map snd (internalVariableMap spec)
+    externalVariableNames' = map snd (externalVariableMap spec)
+    requirementNames'      = map snd (requirementNameMap spec)
 
 -- * Auxiliary
 
@@ -234,3 +192,33 @@ safeMap ls k = fromMaybe k $ lookup k ls
 -- an end of line character at the end of the last string.
 unlines' :: [String] -> String
 unlines' = intercalate "\n"
+
+-- | Map from an internal variable name to its desired identifier in the code
+-- generated.
+internalVariableMap :: Spec a -> [(String, String)]
+internalVariableMap =
+  map (\x -> (x, sanitizeLCIdentifier x)) . internalVariableNames
+
+-- | Map from an external variable name to its desired identifier in the code
+-- generated.
+externalVariableMap :: Spec a -> [(String, String)]
+externalVariableMap =
+  map (\x -> (x, sanitizeLCIdentifier x)) . externalVariableNames
+
+-- | Map from a requirement name to its desired identifier in the code
+-- generated.
+requirementNameMap :: Spec a -> [(String, String)]
+requirementNameMap =
+  map (\x -> (x, "prop" ++ sanitizeUCIdentifier x)) . requirementNames
+
+-- | Names of all internal variables in a 'Spec'.
+internalVariableNames :: Spec a -> [String]
+internalVariableNames = map internalVariableName . internalVariables
+
+-- | Names of all external variables in a 'Spec'.
+externalVariableNames :: Spec a -> [String]
+externalVariableNames = map externalVariableName . externalVariables
+
+-- | Names of all requirements in a 'Spec'.
+requirementNames :: Spec a -> [String]
+requirementNames = map requirementName . requirements

--- a/ogma-core/src/Language/YAMLSpec/Parser.hs
+++ b/ogma-core/src/Language/YAMLSpec/Parser.hs
@@ -29,6 +29,7 @@ import           Data.Bifunctor         (first)
 import qualified Data.ByteString        as BS
 import           Data.Char              (isSpace)
 import           Data.List              (intercalate)
+import           Data.Maybe             (maybeToList)
 import           Data.Text              (unpack)
 import qualified Data.Vector            as V
 import qualified Data.Yaml              as Y
@@ -249,7 +250,7 @@ objectFieldValueList _ _ = []
 --
 -- If the values are an array, it returns the values in the array directly.
 objectFieldValues :: String -> Value -> [Value]
-objectFieldValues key (Object o) = maybe [] (:[]) $ M.lookup (fromString key) o
+objectFieldValues key (Object o) = maybeToList $ M.lookup (fromString key) o
 objectFieldValues _   _          = []
 
 -- ** Either-related auxiliary functions

--- a/ogma-core/tests/Main.hs
+++ b/ogma-core/tests/Main.hs
@@ -1,3 +1,4 @@
+{- HLint ignore "Reduce duplication" -}
 -- | Test ogma-core.
 module Main where
 


### PR DESCRIPTION
Address all suggestions reported by HLint on `ogma-core`, by re-writing the code or by making HLint ignore them, as prescribed in the solution proposed for #586.