### PR TITLE
`ogma-extra`: Remove unused import from `System.Directory.Extra` module. Refs #588.

### DIFF
--- a/ogma-extra/CHANGELOG.md
+++ b/ogma-extra/CHANGELOG.md
@@ -1,11 +1,12 @@
 # Revision history for ogma-extra
 
-## [1.X.Y] - 2026-09-05
+## [1.X.Y] - 2026-09-12
 
 * Remove unnecessary line breaks (#520).
 * Bump upper version constraint on `QuickCheck` (#545).
 * Handle template expansion errors using specialized exception type (#390).
 * Address HLint suggestions (#579).
+* Remove unused import from `System.Directory.Extra` module (#588).
 
 ## [1.15.0] - 2026-07-21
 

--- a/ogma-extra/src/System/Directory/Extra.hs
+++ b/ogma-extra/src/System/Directory/Extra.hs
@@ -36,7 +36,7 @@ import           Distribution.Simple.Utils ( getDirectoryContentsRecursive )
 import           System.Directory          ( createDirectoryIfMissing,
                                              doesFileExist )
 import           System.FilePath           ( makeRelative, splitFileName,
-                                             takeDirectory, (</>) )
+                                             (</>) )
 import           Text.Microstache          ( MustacheException (..), Template,
                                              compileMustacheFile,
                                              compileMustacheText,


### PR DESCRIPTION
Remove unused import from `ogma-extra:System.Directory.Extra`, as prescribed in the solution proposed for #588.