### PR TITLE
`ogma-core`: Remove unused imports. Refs #590.

### DIFF
--- a/ogma-core/CHANGELOG.md
+++ b/ogma-core/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Revision history for ogma-core
 
-## [1.X.Y] - 2026-09-10
+## [1.X.Y] - 2026-09-12
 
 * Replace adhoc function `mergeMaybe` with function from `base` (#516).
 * Fix malformed comments (#518).
@@ -19,6 +19,7 @@
 * Update `Dockerfile` in ROS 2 template for Space ROS `jazzy-2026.07.0` (#569).
 * Introduce default input format configuration files (#575).
 * Address HLint suggestions (#586).
+* Remove unused imports (#590).
 
 ## [1.15.0] - 2026-07-21
 

--- a/ogma-core/src/Command/CFSApp.hs
+++ b/ogma-core/src/Command/CFSApp.hs
@@ -36,7 +36,7 @@ module Command.CFSApp
   where
 
 -- External imports
-import           Control.Applicative    ( liftA2, (<|>) )
+import           Control.Applicative    ( (<|>) )
 import qualified Control.Exception      as E
 import           Control.Monad.Except   ( ExceptT (..), liftEither,
                                           throwError )

--- a/ogma-core/src/Command/FPrimeApp.hs
+++ b/ogma-core/src/Command/FPrimeApp.hs
@@ -31,7 +31,7 @@ module Command.FPrimeApp
   where
 
 -- External imports
-import           Control.Applicative    ( liftA2, (<|>) )
+import           Control.Applicative    ( (<|>) )
 import qualified Control.Exception      as E
 import           Control.Monad.Except   ( ExceptT(..), liftEither )
 import           Data.Aeson             ( ToJSON, toJSON )

--- a/ogma-core/src/Command/ROSApp.hs
+++ b/ogma-core/src/Command/ROSApp.hs
@@ -36,7 +36,7 @@ module Command.ROSApp
   where
 
 -- External imports
-import           Control.Applicative  (liftA2, (<|>))
+import           Control.Applicative  ((<|>))
 import qualified Control.Exception    as E
 import           Control.Monad.Except (ExceptT (..), liftEither)
 import           Data.Aeson           (ToJSON (..))

--- a/ogma-core/src/Command/Report.hs
+++ b/ogma-core/src/Command/Report.hs
@@ -29,8 +29,7 @@ module Command.Report
 -- External imports
 import qualified Control.Exception      as E
 import           Control.Monad          (foldM)
-import           Control.Monad.Except   (ExceptT (..), liftEither, runExceptT,
-                                         withExceptT)
+import           Control.Monad.Except   (ExceptT (..), liftEither, withExceptT)
 import           Control.Monad.IO.Class (liftIO)
 import           Data.Aeson             (ToJSON (..))
 import           GHC.Generics           (Generic)

--- a/ogma-core/src/Data/Spec/Parser.hs
+++ b/ogma-core/src/Data/Spec/Parser.hs
@@ -29,19 +29,16 @@ import qualified Control.Exception    as E
 import           Control.Monad.Except (ExceptT (..))
 import           Data.Aeson           (eitherDecode)
 import qualified Data.ByteString.Lazy as L
-import           Data.List            (isInfixOf, isPrefixOf, nub, (\\))
+import           Data.List            (isInfixOf, isPrefixOf)
 import           System.Directory     (doesFileExist)
 import           System.FilePath      ((</>))
 import           System.Process       (readProcess)
 
 -- External imports: auxiliary
 import Data.ByteString.Extra as B (safeReadFile)
-import Data.String.Extra     (sanitizeLCIdentifier, sanitizeUCIdentifier)
 
 -- External imports: ogma
-import Data.OgmaSpec            (ExternalVariableDef (..),
-                                 InternalVariableDef (..), Requirement (..),
-                                 Spec (..))
+import Data.OgmaSpec            (Requirement (..), Spec (..))
 import Language.CSVSpec.Parser  (parseCSVSpec)
 import Language.JSONSpec.Parser (parseJSONSpec)
 import Language.XLSXSpec.Parser (parseXLSXSpec)
@@ -50,7 +47,6 @@ import Language.YAMLSpec.Parser (parseYAMLSpec)
 
 -- Internal imports: auxiliary
 import Command.Errors    (ErrorTriplet(..), ErrorCode)
-import Data.Diagram      (Diagram)
 import Data.Either.Extra (mapLeft)
 import Data.ExprPair     (ExprPairT(..))
 import Data.Location     (Location (..))

--- a/ogma-core/src/Language/Trans/CStructs2Copilot.hs
+++ b/ogma-core/src/Language/Trans/CStructs2Copilot.hs
@@ -28,7 +28,6 @@ module Language.Trans.CStructs2Copilot where
 
 -- External imports
 import Data.Char ( isUpper, toLower )
-import Data.List ( intercalate )
 
 -- External imports: auxiliary
 import Data.List.Extra ( toHead, toTail )

--- a/ogma-core/src/Language/YAMLSpec/Parser.hs
+++ b/ogma-core/src/Language/YAMLSpec/Parser.hs
@@ -20,20 +20,19 @@
 module Language.YAMLSpec.Parser where
 
 -- External imports
-import           Control.Monad.Except   (ExceptT (..), runExceptT)
-import           Control.Monad.IO.Class (liftIO)
-import           Data.Aeson             (Value (..))
-import           Data.Aeson.Key         (fromString)
-import qualified Data.Aeson.KeyMap      as M
-import           Data.Bifunctor         (first)
-import qualified Data.ByteString        as BS
-import           Data.Char              (isSpace)
-import           Data.List              (intercalate)
-import           Data.Maybe             (maybeToList)
-import           Data.Text              (unpack)
-import qualified Data.Vector            as V
-import qualified Data.Yaml              as Y
-import           System.FilePath        (takeBaseName, takeFileName)
+import           Control.Monad.Except (ExceptT (..), runExceptT)
+import           Data.Aeson           (Value (..))
+import           Data.Aeson.Key       (fromString)
+import qualified Data.Aeson.KeyMap    as M
+import           Data.Bifunctor       (first)
+import qualified Data.ByteString      as BS
+import           Data.Char            (isSpace)
+import           Data.List            (intercalate)
+import           Data.Maybe           (maybeToList)
+import           Data.Text            (unpack)
+import qualified Data.Vector          as V
+import qualified Data.Yaml            as Y
+import           System.FilePath      (takeBaseName, takeFileName)
 
 -- External imports: ogma-spec
 import Data.Either.Extra (mapLeft)


### PR DESCRIPTION
Remove unused imports from `ogma-core`, as prescribed in the solution proposed for #590.